### PR TITLE
fix api url

### DIFF
--- a/src/var/config.js
+++ b/src/var/config.js
@@ -3,19 +3,19 @@ const platforms = {
   bitfinex: {
     id: 'bfx',
     Name: 'Bitfinex',
-    API_URL: 'https://api.bitfinex.com/api/`',
+    API_URL: 'https://api.bitfinex.com/api`',
     KEY_URL: 'https://www.bitfinex.com/api',
   },
   ethfinex: {
     id: 'efx',
     Name: 'Ethfinex',
-    API_URL: 'https://api.ethfinex.com/api/',
+    API_URL: 'https://api.ethfinex.com/api',
     KEY_URL: 'https://dev-prdn.bitfinex.com:2998/api',
   },
   localhost: {
     id: 'local',
     Name: 'Bfx',
-    API_URL: 'http://localhost:31339/api/',
+    API_URL: 'http://localhost:31339/api',
     KEY_URL: 'https://dev-prdn.bitfinex.com:2998/api',
   },
 }


### PR DESCRIPTION
avoid the double slash when composed the url