### PR TITLE
remove table max height

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -13,10 +13,6 @@ div.bitfinex-auth {
   margin-top: 10px;
 }
 
-.bitfinex-table {
-  max-height: 400px;
-}
-
 .bitfinex-show-soft {
   opacity: 0.5;
 }


### PR DESCRIPTION
context: https://trello.com/c/NmkFO8tI/68-resize-window

since we don't show all tables in a single page, its fine to not set max height of the table