### PR TITLE
fetch data when component did mount

### DIFF
--- a/src/components/Auth/__tests__/__snapshots__/Auth.unit.test.js.snap
+++ b/src/components/Auth/__tests__/__snapshots__/Auth.unit.test.js.snap
@@ -5,30 +5,30 @@ exports[`render correctly 1`] = `
   className="row"
 >
   <div
-    className="pt-card pt-interactive pt-elevation-0 bitfinex-auth col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6"
+    className="bp3-card bp3-interactive bp3-elevation-0 bitfinex-auth col-xs-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6"
   >
-    <h5>
+    <h4>
       Auth
        
       <svg
-        className="pt-icon pt-intent-success"
+        className="bp3-icon bp3-intent-success"
         data-icon="tick"
         height={21}
         style={Object {}}
         viewBox="0 0 20 20"
         width={21}
       >
-        <title>
+        <desc>
           tick
-        </title>
+        </desc>
         <path
           d="M17 4c-.28 0-.53.11-.71.29L7 13.59 3.71 10.3A.965.965 0 0 0 3 10a1.003 1.003 0 0 0-.71 1.71l4 4c.18.18.43.29.71.29s.53-.11.71-.29l10-10A1.003 1.003 0 0 0 17 4z"
           fillRule="evenodd"
         />
       </svg>
-    </h5>
+    </h4>
     <div
-      className="pt-callout"
+      className="bp3-callout"
     >
       Visit 
       <a
@@ -41,54 +41,95 @@ exports[`render correctly 1`] = `
        to get the readonly API key and secret pair.
     </div>
     <br />
-    <p>
+    <div
+      className="bp3-form-group"
+    >
       <label
-        className="pt-label"
+        className="bp3-label"
+        htmlFor="key"
       >
         Enter API Key:
+         
+        <span
+          className="bp3-text-muted"
+        >
+          (required)
+        </span>
       </label>
+      <div
+        className="bp3-form-content"
+      />
+    </div>
+    <div
+      className="bp3-input-group"
+    >
       <input
-        className="pt-input"
-        dir="auto"
-        minLength="10"
+        className="bp3-input"
+        id="key"
         name="key"
         onChange={[Function]}
         placeholder="Enter API Key:"
-        required={true}
+        style={
+          Object {
+            "paddingRight": 10,
+          }
+        }
         type="text"
         value=""
       />
-    </p>
-    <p>
+    </div>
+    <br />
+    <div
+      className="bp3-form-group"
+    >
       <label
-        className="pt-label"
+        className="bp3-label"
+        htmlFor="secret"
       >
         Enter API Secret:
+         
+        <span
+          className="bp3-text-muted"
+        >
+          (required)
+        </span>
       </label>
+      <div
+        className="bp3-form-content"
+      />
+    </div>
+    <div
+      className="bp3-input-group"
+    >
       <input
-        className="pt-input"
-        dir="auto"
-        minLength="10"
+        className="bp3-input"
+        id="secret"
         name="secret"
         onChange={[Function]}
         placeholder="Enter API Secret:"
-        required={true}
+        style={
+          Object {
+            "paddingRight": 10,
+          }
+        }
         type="text"
         value=""
       />
-    </p>
+    </div>
+    <br />
     <p>
       <button
-        className="pt-button pt-intent-primary"
+        className="bp3-button bp3-intent-primary"
         disabled={undefined}
         name="check"
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        tabIndex={undefined}
         type="button"
       >
         <span
-          className="pt-button-text"
+          className="bp3-button-text"
         >
           Check Auth
         </span>

--- a/src/components/Ledgers/Ledgers.container.js
+++ b/src/components/Ledgers/Ledgers.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import actions from 'state/ledgers/actions'
 import Ledgers from './Ledgers'
 
 function mapStateToProps(state = {}) {
@@ -9,6 +10,10 @@ function mapStateToProps(state = {}) {
   }
 }
 
-const LedgersContainer = connect(mapStateToProps)(Ledgers)
+const mapDispatchToProps = dispatch => ({
+  fetchLedgers: () => dispatch(actions.fetchLedgers()),
+})
+
+const LedgersContainer = connect(mapStateToProps, mapDispatchToProps)(Ledgers)
 
 export default LedgersContainer

--- a/src/components/Ledgers/Ledgers.js
+++ b/src/components/Ledgers/Ledgers.js
@@ -30,6 +30,11 @@ class Ledgers extends PureComponent {
     symbol: '',
   }
 
+  componentDidMount() {
+    // eslint-disable-next-line react/destructuring-assignment
+    this.props.fetchLedgers()
+  }
+
   handleClick(symbol) {
     if (!this.handlers[symbol]) {
       this.handlers[symbol] = () => {

--- a/src/components/Ledgers/Ledgers.props.js
+++ b/src/components/Ledgers/Ledgers.props.js
@@ -12,6 +12,7 @@ const LEDGERS_ENTRIES_PROPS = PropTypes.shape({
 export const propTypes = {
   currencies: PropTypes.arrayOf(PropTypes.string),
   entries: PropTypes.arrayOf(LEDGERS_ENTRIES_PROPS).isRequired,
+  fetchLedgers: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   loading: PropTypes.bool.isRequired,
 }
@@ -19,6 +20,7 @@ export const propTypes = {
 export const defaultProps = {
   currencies: [],
   entries: [],
+  fetchLedgers: () => {},
   intl: {},
   loading: true,
 }

--- a/src/components/Movements/Movements.container.js
+++ b/src/components/Movements/Movements.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import actions from 'state/movements/actions'
 import Movements from './Movements'
 
 function mapStateToProps(state = {}) {
@@ -8,6 +9,10 @@ function mapStateToProps(state = {}) {
   }
 }
 
-const MovementsContainer = connect(mapStateToProps)(Movements)
+const mapDispatchToProps = dispatch => ({
+  fetchMovements: () => dispatch(actions.fetchMovements()),
+})
+
+const MovementsContainer = connect(mapStateToProps, mapDispatchToProps)(Movements)
 
 export default MovementsContainer

--- a/src/components/Movements/Movements.js
+++ b/src/components/Movements/Movements.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, PureComponent } from 'react'
 import { injectIntl } from 'react-intl'
 import {
   Button,
@@ -21,114 +21,122 @@ import Inspector from './Inspector'
 const TYPE_WITHDRAWALS = 'withdrawals'
 const COLUMN_WIDTHS = [80, 150, 125, 120, 400]
 
-export const Movements = ({
-  entries,
-  intl,
-  type,
-  loading,
-}) => {
-  const filteredData = entries.filter(entry => (type === TYPE_WITHDRAWALS
-    ? parseFloat(entry.amount) < 0 : parseFloat(entry.amount) > 0))
-  const numRows = filteredData.length
+class Movements extends PureComponent {
+  componentDidMount() {
+    // eslint-disable-next-line react/destructuring-assignment
+    this.props.fetchMovements()
+  }
 
-  const idCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].id}
-    </Cell>
-  )
+  render() {
+    const {
+      entries,
+      intl,
+      type,
+      loading,
+    } = this.props
+    const filteredData = entries.filter(entry => (type === TYPE_WITHDRAWALS
+      ? parseFloat(entry.amount) < 0 : parseFloat(entry.amount) > 0))
+    const numRows = filteredData.length
 
-  const mtsUpdatedCellRenderer = rowIndex => (
-    <Cell>
-      <TruncatedFormat>
-        {formatTime(entries[rowIndex].mtsUpdated)}
-      </TruncatedFormat>
-    </Cell>
-  )
-
-  const amountCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].amount}
-    </Cell>
-  )
-
-  const statusCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].status}
-    </Cell>
-  )
-
-  const destinationCellRenderer = (rowIndex) => {
-    const entry = filteredData[rowIndex]
-    return (
+    const idCellRenderer = rowIndex => (
       <Cell>
-        {entry.destinationAddress}
-        &nbsp;
-        <Inspector currency={entry.currency} destinationAddress={entry.destinationAddress} />
+        {entries[rowIndex].id}
       </Cell>
     )
-  }
 
-  const titleMsgId = type === TYPE_WITHDRAWALS
-    ? 'movements.withdrawals.title' : 'movements.deposits.title'
-  let showContent
-  if (loading) {
-    showContent = (
-      <Loading title={titleMsgId} />
+    const mtsUpdatedCellRenderer = rowIndex => (
+      <Cell>
+        <TruncatedFormat>
+          {formatTime(entries[rowIndex].mtsUpdated)}
+        </TruncatedFormat>
+      </Cell>
     )
-  } else if (numRows === 0) {
-    showContent = (
-      <NoData title={titleMsgId} />
+
+    const amountCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].amount}
+      </Cell>
     )
-  } else {
-    showContent = (
-      <Fragment>
-        <h4>
-          {intl.formatMessage({ id: titleMsgId })}
+
+    const statusCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].status}
+      </Cell>
+    )
+
+    const destinationCellRenderer = (rowIndex) => {
+      const entry = filteredData[rowIndex]
+      return (
+        <Cell>
+          {entry.destinationAddress}
           &nbsp;
-          <Button icon='cloud-download' disabled>
-            {intl.formatMessage({ id: 'timeframe.download' })}
-          </Button>
-        </h4>
-        <Table
-          className='bitfinex-table'
-          numRows={numRows}
-          enableRowHeader={false}
-          columnWidths={COLUMN_WIDTHS}
-        >
-          <Column
-            id='id'
-            name='#'
-            cellRenderer={idCellRenderer}
-          />
-          <Column
-            id='mtsupdated'
-            name={intl.formatMessage({ id: 'movements.column.updated' })}
-            cellRenderer={mtsUpdatedCellRenderer}
-          />
-          <Column
-            id='status'
-            name={intl.formatMessage({ id: 'movements.column.status' })}
-            cellRenderer={statusCellRenderer}
-          />
-          <Column
-            id='amount'
-            name={intl.formatMessage({ id: 'movements.column.amount' })}
-            cellRenderer={amountCellRenderer}
-          />
-          <Column
-            id='destination'
-            name={intl.formatMessage({ id: 'movements.column.destination' })}
-            cellRenderer={destinationCellRenderer}
-          />
-        </Table>
-      </Fragment>
+          <Inspector currency={entry.currency} destinationAddress={entry.destinationAddress} />
+        </Cell>
+      )
+    }
+
+    const titleMsgId = type === TYPE_WITHDRAWALS
+      ? 'movements.withdrawals.title' : 'movements.deposits.title'
+    let showContent
+    if (loading) {
+      showContent = (
+        <Loading title={titleMsgId} />
+      )
+    } else if (numRows === 0) {
+      showContent = (
+        <NoData title={titleMsgId} />
+      )
+    } else {
+      showContent = (
+        <Fragment>
+          <h4>
+            {intl.formatMessage({ id: titleMsgId })}
+            &nbsp;
+            <Button icon='cloud-download' disabled>
+              {intl.formatMessage({ id: 'timeframe.download' })}
+            </Button>
+          </h4>
+          <Table
+            className='bitfinex-table'
+            numRows={numRows}
+            enableRowHeader={false}
+            columnWidths={COLUMN_WIDTHS}
+          >
+            <Column
+              id='id'
+              name='#'
+              cellRenderer={idCellRenderer}
+            />
+            <Column
+              id='mtsupdated'
+              name={intl.formatMessage({ id: 'movements.column.updated' })}
+              cellRenderer={mtsUpdatedCellRenderer}
+            />
+            <Column
+              id='status'
+              name={intl.formatMessage({ id: 'movements.column.status' })}
+              cellRenderer={statusCellRenderer}
+            />
+            <Column
+              id='amount'
+              name={intl.formatMessage({ id: 'movements.column.amount' })}
+              cellRenderer={amountCellRenderer}
+            />
+            <Column
+              id='destination'
+              name={intl.formatMessage({ id: 'movements.column.destination' })}
+              cellRenderer={destinationCellRenderer}
+            />
+          </Table>
+        </Fragment>
+      )
+    }
+    return (
+      <Card interactive elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
+        {showContent}
+      </Card>
     )
   }
-  return (
-    <Card interactive elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
-      {showContent}
-    </Card>
-  )
 }
 
 Movements.propTypes = propTypes

--- a/src/components/Movements/Movements.props.js
+++ b/src/components/Movements/Movements.props.js
@@ -13,12 +13,14 @@ const MOVEMENTS_ENTRIES_PROPS = PropTypes.shape({
 
 export const propTypes = {
   entries: PropTypes.arrayOf(MOVEMENTS_ENTRIES_PROPS).isRequired,
+  fetchMovements: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   loading: PropTypes.bool.isRequired,
 }
 
 export const defaultProps = {
   entries: [],
+  fetchMovements: () => {},
   intl: {},
   loading: true,
 }

--- a/src/components/Orders/Orders.container.js
+++ b/src/components/Orders/Orders.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import actions from 'state/orders/actions'
 import Orders from './Orders'
 
 function mapStateToProps(state = {}) {
@@ -8,6 +9,10 @@ function mapStateToProps(state = {}) {
   }
 }
 
-const OrdersContainer = connect(mapStateToProps)(Orders)
+const mapDispatchToProps = dispatch => ({
+  fetchOrders: () => dispatch(actions.fetchOrders()),
+})
+
+const OrdersContainer = connect(mapStateToProps, mapDispatchToProps)(Orders)
 
 export default OrdersContainer

--- a/src/components/Orders/Orders.js
+++ b/src/components/Orders/Orders.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, PureComponent } from 'react'
 import { injectIntl } from 'react-intl'
 import {
   Button,
@@ -18,145 +18,157 @@ import { propTypes, defaultProps } from './Orders.props'
 
 const COLUMN_WIDTHS = [80, 70, 150, 100, 100, 100, 100, 150, 200]
 
-export const Orders = ({ entries, intl, loading }) => {
-  const numRows = entries.length
-
-  const idCellRenderer = rowIndex => (
-    <Cell wrapText={false}>
-      {entries[rowIndex].id}
-    </Cell>
-  )
-
-  const pairCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].pair}
-    </Cell>
-  )
-
-  const typeCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].type}
-    </Cell>
-  )
-
-  const amountOrigCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].amountOrig}
-    </Cell>
-  )
-
-  const amountCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].amount}
-    </Cell>
-  )
-
-  const priceCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].price}
-    </Cell>
-  )
-
-  const priceAvgCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].priceAvg}
-    </Cell>
-  )
-
-  const mtsUpdateCellRenderer = rowIndex => (
-    <Cell>
-      <TruncatedFormat>
-        {formatTime(entries[rowIndex].mtsUpdate)}
-      </TruncatedFormat>
-    </Cell>
-  )
-
-  const statusCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].status}
-    </Cell>
-  )
-
-  let showContent
-  if (loading) {
-    showContent = (
-      <Loading title='orders.title' />
-    )
-  } else if (numRows === 0) {
-    showContent = (
-      <NoData title='orders.title' />
-    )
-  } else {
-    showContent = (
-      <Fragment>
-        <h4>
-          {intl.formatMessage({ id: 'orders.title' })}
-          &nbsp;
-          <Button icon='cloud-download' disabled>
-            {intl.formatMessage({ id: 'timeframe.download' })}
-          </Button>
-        </h4>
-        <Table
-          className='bitfinex-table'
-          numRows={numRows}
-          enableRowHeader={false}
-          columnWidths={COLUMN_WIDTHS}
-        >
-          <Column
-            id='id'
-            name='#'
-            cellRenderer={idCellRenderer}
-          />
-          <Column
-            id='symbol'
-            name={intl.formatMessage({ id: 'orders.column.pair' })}
-            cellRenderer={pairCellRenderer}
-          />
-          <Column
-            id='type'
-            name={intl.formatMessage({ id: 'orders.column.type' })}
-            cellRenderer={typeCellRenderer}
-          />
-          <Column
-            id='amount'
-            name={intl.formatMessage({ id: 'orders.column.amount' })}
-            cellRenderer={amountCellRenderer}
-          />
-          <Column
-            id='amountOrig'
-            name={intl.formatMessage({ id: 'orders.column.amount-orig' })}
-            cellRenderer={amountOrigCellRenderer}
-          />
-          <Column
-            id='price'
-            name={intl.formatMessage({ id: 'orders.column.price' })}
-            cellRenderer={priceCellRenderer}
-          />
-          <Column
-            id='priceAvg'
-            name={intl.formatMessage({ id: 'orders.column.avgprice' })}
-            cellRenderer={priceAvgCellRenderer}
-          />
-          <Column
-            id='mtsUpdate'
-            name={intl.formatMessage({ id: 'orders.column.update' })}
-            cellRenderer={mtsUpdateCellRenderer}
-          />
-          <Column
-            id='status'
-            name={intl.formatMessage({ id: 'orders.column.status' })}
-            cellRenderer={statusCellRenderer}
-          />
-        </Table>
-      </Fragment>
-    )
+class Orders extends PureComponent {
+  componentDidMount() {
+    // eslint-disable-next-line react/destructuring-assignment
+    this.props.fetchOrders()
   }
 
-  return (
-    <Card interactive elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
-      {showContent}
-    </Card>
-  )
+  render() {
+    const {
+      entries,
+      intl,
+      loading,
+    } = this.props
+    const numRows = entries.length
+
+    const idCellRenderer = rowIndex => (
+      <Cell wrapText={false}>
+        {entries[rowIndex].id}
+      </Cell>
+    )
+
+    const pairCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].pair}
+      </Cell>
+    )
+
+    const typeCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].type}
+      </Cell>
+    )
+
+    const amountOrigCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].amountOrig}
+      </Cell>
+    )
+
+    const amountCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].amount}
+      </Cell>
+    )
+
+    const priceCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].price}
+      </Cell>
+    )
+
+    const priceAvgCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].priceAvg}
+      </Cell>
+    )
+
+    const mtsUpdateCellRenderer = rowIndex => (
+      <Cell>
+        <TruncatedFormat>
+          {formatTime(entries[rowIndex].mtsUpdate)}
+        </TruncatedFormat>
+      </Cell>
+    )
+
+    const statusCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].status}
+      </Cell>
+    )
+
+    let showContent
+    if (loading) {
+      showContent = (
+        <Loading title='orders.title' />
+      )
+    } else if (numRows === 0) {
+      showContent = (
+        <NoData title='orders.title' />
+      )
+    } else {
+      showContent = (
+        <Fragment>
+          <h4>
+            {intl.formatMessage({ id: 'orders.title' })}
+            &nbsp;
+            <Button icon='cloud-download' disabled>
+              {intl.formatMessage({ id: 'timeframe.download' })}
+            </Button>
+          </h4>
+          <Table
+            className='bitfinex-table'
+            numRows={numRows}
+            enableRowHeader={false}
+            columnWidths={COLUMN_WIDTHS}
+          >
+            <Column
+              id='id'
+              name='#'
+              cellRenderer={idCellRenderer}
+            />
+            <Column
+              id='symbol'
+              name={intl.formatMessage({ id: 'orders.column.pair' })}
+              cellRenderer={pairCellRenderer}
+            />
+            <Column
+              id='type'
+              name={intl.formatMessage({ id: 'orders.column.type' })}
+              cellRenderer={typeCellRenderer}
+            />
+            <Column
+              id='amount'
+              name={intl.formatMessage({ id: 'orders.column.amount' })}
+              cellRenderer={amountCellRenderer}
+            />
+            <Column
+              id='amountOrig'
+              name={intl.formatMessage({ id: 'orders.column.amount-orig' })}
+              cellRenderer={amountOrigCellRenderer}
+            />
+            <Column
+              id='price'
+              name={intl.formatMessage({ id: 'orders.column.price' })}
+              cellRenderer={priceCellRenderer}
+            />
+            <Column
+              id='priceAvg'
+              name={intl.formatMessage({ id: 'orders.column.avgprice' })}
+              cellRenderer={priceAvgCellRenderer}
+            />
+            <Column
+              id='mtsUpdate'
+              name={intl.formatMessage({ id: 'orders.column.update' })}
+              cellRenderer={mtsUpdateCellRenderer}
+            />
+            <Column
+              id='status'
+              name={intl.formatMessage({ id: 'orders.column.status' })}
+              cellRenderer={statusCellRenderer}
+            />
+          </Table>
+        </Fragment>
+      )
+    }
+
+    return (
+      <Card interactive elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
+        {showContent}
+      </Card>
+    )
+  }
 }
 
 Orders.propTypes = propTypes

--- a/src/components/Orders/Orders.props.js
+++ b/src/components/Orders/Orders.props.js
@@ -12,12 +12,14 @@ const ORDERS_ENTRIES_PROPS = PropTypes.shape({
 
 export const propTypes = {
   entries: PropTypes.arrayOf(ORDERS_ENTRIES_PROPS).isRequired,
+  fetchOrders: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   loading: PropTypes.bool.isRequired,
 }
 
 export const defaultProps = {
   entries: [],
+  fetchOrders: () => {},
   intl: {},
   loading: true,
 }

--- a/src/components/Trades/Trades.container.js
+++ b/src/components/Trades/Trades.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import actions from 'state/trades/actions'
 import Trades from './Trades'
 
 function mapStateToProps(state = {}) {
@@ -8,6 +9,10 @@ function mapStateToProps(state = {}) {
   }
 }
 
-const TradesContainer = connect(mapStateToProps)(Trades)
+const mapDispatchToProps = dispatch => ({
+  fetchTrades: () => dispatch(actions.fetchTrades()),
+})
+
+const TradesContainer = connect(mapStateToProps, mapDispatchToProps)(Trades)
 
 export default TradesContainer

--- a/src/components/Trades/Trades.js
+++ b/src/components/Trades/Trades.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, PureComponent } from 'react'
 import { injectIntl } from 'react-intl'
 import {
   Button,
@@ -18,116 +18,124 @@ import { propTypes, defaultProps } from './Trades.props'
 
 const COLUMN_WIDTHS = [80, 70, 125, 125, 125, 150]
 
-export const Trades = ({ entries, intl, loading }) => {
-  const numRows = entries.length
-
-  const idCellRenderer = rowIndex => (
-    <Cell wrapText={false}>
-      {entries[rowIndex].id}
-    </Cell>
-  )
-
-  const pairCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].pair}
-    </Cell>
-  )
-
-  const amountCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].execAmount}
-    </Cell>
-  )
-
-  const priceCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].execPrice}
-    </Cell>
-  )
-
-  const feeCellRenderer = rowIndex => (
-    <Cell>
-      {entries[rowIndex].fee}
-      &nbsp;
-      <span className='bitfinex-show-soft'>
-        {entries[rowIndex].feeCurrency}
-      </span>
-    </Cell>
-  )
-
-  const mtsCellRenderer = rowIndex => (
-    <Cell>
-      <TruncatedFormat>
-        {formatTime(entries[rowIndex].mtsCreate)}
-      </TruncatedFormat>
-    </Cell>
-  )
-
-  let showContent
-  if (loading) {
-    showContent = (
-      <Loading title='trades.title' />
-    )
-  } else if (numRows === 0) {
-    showContent = (
-      <NoData title='trades.title' />
-    )
-  } else {
-    showContent = (
-      <Fragment>
-        <h4>
-          {intl.formatMessage({ id: 'trades.title' })}
-          &nbsp;
-          <Button icon='cloud-download' disabled>
-            {intl.formatMessage({ id: 'timeframe.download' })}
-          </Button>
-        </h4>
-        <Table
-          className='bitfinex-table'
-          numRows={numRows}
-          enableRowHeader={false}
-          columnWidths={COLUMN_WIDTHS}
-        >
-          <Column
-            id='id'
-            name='#'
-            cellRenderer={idCellRenderer}
-          />
-          <Column
-            id='pair'
-            name={intl.formatMessage({ id: 'trades.column.pair' })}
-            cellRenderer={pairCellRenderer}
-          />
-          <Column
-            id='amount'
-            name={intl.formatMessage({ id: 'trades.column.amount' })}
-            cellRenderer={amountCellRenderer}
-          />
-          <Column
-            id='price'
-            name={intl.formatMessage({ id: 'trades.column.price' })}
-            cellRenderer={priceCellRenderer}
-          />
-          <Column
-            id='fee'
-            name={intl.formatMessage({ id: 'trades.column.fee' })}
-            cellRenderer={feeCellRenderer}
-          />
-          <Column
-            id='mts'
-            name={intl.formatMessage({ id: 'trades.column.time' })}
-            cellRenderer={mtsCellRenderer}
-          />
-        </Table>
-      </Fragment>
-    )
+class Trades extends PureComponent {
+  componentDidMount() {
+    // eslint-disable-next-line react/destructuring-assignment
+    this.props.fetchTrades()
   }
 
-  return (
-    <Card interactive elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
-      {showContent}
-    </Card>
-  )
+  render() {
+    const { entries, intl, loading } = this.props
+    const numRows = entries.length
+
+    const idCellRenderer = rowIndex => (
+      <Cell wrapText={false}>
+        {entries[rowIndex].id}
+      </Cell>
+    )
+
+    const pairCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].pair}
+      </Cell>
+    )
+
+    const amountCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].execAmount}
+      </Cell>
+    )
+
+    const priceCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].execPrice}
+      </Cell>
+    )
+
+    const feeCellRenderer = rowIndex => (
+      <Cell>
+        {entries[rowIndex].fee}
+        &nbsp;
+        <span className='bitfinex-show-soft'>
+          {entries[rowIndex].feeCurrency}
+        </span>
+      </Cell>
+    )
+
+    const mtsCellRenderer = rowIndex => (
+      <Cell>
+        <TruncatedFormat>
+          {formatTime(entries[rowIndex].mtsCreate)}
+        </TruncatedFormat>
+      </Cell>
+    )
+
+    let showContent
+    if (loading) {
+      showContent = (
+        <Loading title='trades.title' />
+      )
+    } else if (numRows === 0) {
+      showContent = (
+        <NoData title='trades.title' />
+      )
+    } else {
+      showContent = (
+        <Fragment>
+          <h4>
+            {intl.formatMessage({ id: 'trades.title' })}
+            &nbsp;
+            <Button icon='cloud-download' disabled>
+              {intl.formatMessage({ id: 'timeframe.download' })}
+            </Button>
+          </h4>
+          <Table
+            className='bitfinex-table'
+            numRows={numRows}
+            enableRowHeader={false}
+            columnWidths={COLUMN_WIDTHS}
+          >
+            <Column
+              id='id'
+              name='#'
+              cellRenderer={idCellRenderer}
+            />
+            <Column
+              id='pair'
+              name={intl.formatMessage({ id: 'trades.column.pair' })}
+              cellRenderer={pairCellRenderer}
+            />
+            <Column
+              id='amount'
+              name={intl.formatMessage({ id: 'trades.column.amount' })}
+              cellRenderer={amountCellRenderer}
+            />
+            <Column
+              id='price'
+              name={intl.formatMessage({ id: 'trades.column.price' })}
+              cellRenderer={priceCellRenderer}
+            />
+            <Column
+              id='fee'
+              name={intl.formatMessage({ id: 'trades.column.fee' })}
+              cellRenderer={feeCellRenderer}
+            />
+            <Column
+              id='mts'
+              name={intl.formatMessage({ id: 'trades.column.time' })}
+              cellRenderer={mtsCellRenderer}
+            />
+          </Table>
+        </Fragment>
+      )
+    }
+
+    return (
+      <Card interactive elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
+        {showContent}
+      </Card>
+    )
+  }
 }
 
 Trades.propTypes = propTypes

--- a/src/components/Trades/Trades.props.js
+++ b/src/components/Trades/Trades.props.js
@@ -12,12 +12,14 @@ const TRADES_ENTRIES_PROPS = PropTypes.shape({
 
 export const propTypes = {
   entries: PropTypes.arrayOf(TRADES_ENTRIES_PROPS).isRequired,
+  fetchTrades: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   loading: PropTypes.bool.isRequired,
 }
 
 export const defaultProps = {
   entries: [],
+  fetchTrades: () => {},
   intl: {},
   loading: true,
 }

--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -86,6 +86,5 @@ function* checkUpdate() {
 
 export default function* authSaga() {
   yield takeLatest(types.CHECK_AUTH, checkAuth)
-  yield takeLatest(types.UPDATE_AUTH_STATUS, checkUpdate)
   yield takeLatest(queryTypes.SET_TIME_RANGE, checkUpdate)
 }

--- a/src/state/ledgers/actions.js
+++ b/src/state/ledgers/actions.js
@@ -1,0 +1,14 @@
+import types from './constants'
+
+/**
+ * Create an action to fetch Ledgers data.
+ */
+export function fetchLedgers() {
+  return {
+    type: types.FETCH_LEDGERS,
+  }
+}
+
+export default {
+  fetchLedgers,
+}

--- a/src/state/movements/actions.js
+++ b/src/state/movements/actions.js
@@ -1,0 +1,14 @@
+import types from './constants'
+
+/**
+ * Create an action to fetch Movements data.
+ */
+export function fetchMovements() {
+  return {
+    type: types.FETCH_MOVEMENTS,
+  }
+}
+
+export default {
+  fetchMovements,
+}

--- a/src/state/orders/actions.js
+++ b/src/state/orders/actions.js
@@ -1,0 +1,14 @@
+import types from './constants'
+
+/**
+ * Create an action to fetch Orders data.
+ */
+export function fetchOrders() {
+  return {
+    type: types.FETCH_ORDERS,
+  }
+}
+
+export default {
+  fetchOrders,
+}

--- a/src/state/trades/actions.js
+++ b/src/state/trades/actions.js
@@ -1,0 +1,14 @@
+import types from './constants'
+
+/**
+ * Create an action to fetch Trades data.
+ */
+export function fetchTrades() {
+  return {
+    type: types.FETCH_TRADES,
+  }
+}
+
+export default {
+  fetchTrades,
+}


### PR DESCRIPTION
This PR
- update blueprint 3 auth snapshot
- turn Movements, Trades, Orders to `PureComponent` to support `componentDidMount` lifecycle method
- instead of fetch all data after auth, fetch data when component did mount
- lint/tests pass

Known issue:

* will still fetch all data after set time range

context: https://trello.com/c/tAVCG0pF/77-ask-only-the-actual-table
