### PR TITLE
change default trades and orders id column size

### DIFF
--- a/src/components/Orders/Orders.js
+++ b/src/components/Orders/Orders.js
@@ -20,7 +20,7 @@ import { checkFetch, formatTime, getCurrentEntries } from 'state/utils'
 
 import { propTypes, defaultProps } from './Orders.props'
 
-const COLUMN_WIDTHS = [80, 70, 150, 100, 100, 100, 100, 150, 200]
+const COLUMN_WIDTHS = [100, 70, 150, 100, 100, 100, 100, 150, 200]
 const LIMIT = queryConstants.DEFAULT_ORDERS_QUERY_LIMIT
 const PAGE_SIZE = queryConstants.DEFAULT_ORDERS_PAGE_SIZE
 

--- a/src/components/Trades/Trades.js
+++ b/src/components/Trades/Trades.js
@@ -20,7 +20,7 @@ import { checkFetch, formatTime, getCurrentEntries } from 'state/utils'
 
 import { propTypes, defaultProps } from './Trades.props'
 
-const COLUMN_WIDTHS = [80, 70, 125, 125, 125, 150]
+const COLUMN_WIDTHS = [85, 70, 125, 125, 125, 150]
 const LIMIT = queryConstants.DEFAULT_TRADES_QUERY_LIMIT
 const PAGE_SIZE = queryConstants.DEFAULT_TRADES_PAGE_SIZE
 


### PR DESCRIPTION
different dataset has different id length, adjust the default trades and orders id column size to make it not wrapped