### PR TITLE
fix: remove intl prop in timerange

### DIFF
--- a/src/components/TimeRange/TimeRange.props.js
+++ b/src/components/TimeRange/TimeRange.props.js
@@ -1,14 +1,11 @@
 import PropTypes from 'prop-types'
-import { intlShape } from 'react-intl'
 
 export const propTypes = {
-  intl: intlShape.isRequired,
   start: PropTypes.number,
   end: PropTypes.number,
 }
 
 export const defaultProps = {
-  intl: {},
   start: 0,
   end: 0,
 }


### PR DESCRIPTION
fix console warning by remove intl prop requirement for TimeRange component