### PR TITLE
fix funding query with correct symbol syntax

### DIFF
--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -19,7 +19,7 @@ import { getTargetSymbol, getFundingCreditHistory } from './selectors'
 function getReqFCredit(auth, query, targetSymbol, smallestMts) {
   const params = getTimeFrame(query, 'fundingCreditHistory', smallestMts)
   if (targetSymbol) {
-    params.symbol = targetSymbol
+    params.symbol = `f${targetSymbol}`
   }
   return postJsonfetch(`${platform.API_URL}/get-data`, {
     auth,

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -19,7 +19,7 @@ import { getTargetSymbol, getFundingLoanHistory } from './selectors'
 function getReqFLoan(auth, query, targetSymbol, smallestMts) {
   const params = getTimeFrame(query, 'floan', smallestMts)
   if (targetSymbol) {
-    params.symbol = targetSymbol
+    params.symbol = `f${targetSymbol}`
   }
   return postJsonfetch(`${platform.API_URL}/get-data`, {
     auth,

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -19,7 +19,7 @@ import { getTargetSymbol, getFundingOfferHistory } from './selectors'
 function getReqFOffer(auth, query, targetSymbol, smallestMts) {
   const params = getTimeFrame(query, 'foffer', smallestMts)
   if (targetSymbol) {
-    params.symbol = targetSymbol
+    params.symbol = `f${targetSymbol}`
   }
   return postJsonfetch(`${platform.API_URL}/get-data`, {
     auth,


### PR DESCRIPTION
according to https://github.com/bitfinexcom/bfx-report/blob/master/test/1-api.spec.js#L201 the funding symbol syntax is `f{SYMBOL}` but not `{SYMBOL}`