### PR TITLE
do not leave extra ? when no query param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,12 @@ window.addEventListener('load', function handler() {
     window.removeEventListener('load', handler)
     // remove authToken param from url but keep others
     const params = _omit(parsed, 'authToken')
+    const queries = queryString.stringify(params, { encode: false })
+    const queryParams = queries ? `?${queries}` : ''
     window.history.pushState(null, null,
       window.location.href.replace(
         window.location.search,
-        `?${queryString.stringify(params, { encode: false })}`,
+        queryParams,
       ))
     store.dispatch(checkAuthWithToken(authToken))
   }


### PR DESCRIPTION
when login with `?authToken=xxx` the url will be `http://localhost:3000/?`, should be `http://localhost:3000/`