### PR TITLE
save right symbol format in existingCoins

### DIFF
--- a/src/state/fundingCreditHistory/reducer.js
+++ b/src/state/fundingCreditHistory/reducer.js
@@ -45,9 +45,10 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
           status,
           symbol,
         } = entry
+        const currentSymbol = symbol.slice(1)
         // save new symbol to updateCoins list
-        if (updateCoins.indexOf(symbol) === -1) {
-          updateCoins.push(symbol)
+        if (updateCoins.indexOf(currentSymbol) === -1) {
+          updateCoins.push(currentSymbol)
         }
         // log smallest mts
         if (!smallestMts || smallestMts > mtsUpdate) {
@@ -55,7 +56,7 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
         }
         return {
           id,
-          symbol: symbol.slice(1),
+          symbol: currentSymbol,
           side,
           mtsCreate,
           mtsUpdate,

--- a/src/state/fundingLoanHistory/reducer.js
+++ b/src/state/fundingLoanHistory/reducer.js
@@ -44,9 +44,10 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
           status,
           symbol,
         } = entry
+        const currentSymbol = symbol.slice(1)
         // save new symbol to updateCoins list
-        if (updateCoins.indexOf(symbol) === -1) {
-          updateCoins.push(symbol)
+        if (updateCoins.indexOf(currentSymbol) === -1) {
+          updateCoins.push(currentSymbol)
         }
         // log smallest mts
         if (!smallestMts || smallestMts > mtsUpdate) {
@@ -54,7 +55,7 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
         }
         return {
           id,
-          symbol: symbol.slice(1),
+          symbol: currentSymbol,
           side,
           mtsCreate,
           mtsUpdate,

--- a/src/state/fundingOfferHistory/reducer.js
+++ b/src/state/fundingOfferHistory/reducer.js
@@ -42,9 +42,10 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
           symbol,
           type,
         } = entry
+        const currentSymbol = symbol.slice(1)
         // save new symbol to updateCoins list
-        if (updateCoins.indexOf(symbol) === -1) {
-          updateCoins.push(symbol)
+        if (updateCoins.indexOf(currentSymbol) === -1) {
+          updateCoins.push(currentSymbol)
         }
         // log smallest mts
         if (!smallestMts || smallestMts > mtsUpdate) {
@@ -52,7 +53,7 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
         }
         return {
           id,
-          symbol: symbol.slice(1),
+          symbol: currentSymbol,
           mtsCreate,
           mtsUpdate,
           amount,


### PR DESCRIPTION
saving the right symbol format (without `f` prefix) so the drop-down symbol selector in funding credit/loan/offer page could render different color for exist symbols