### PR TITLE
fix: not format symbol if no sign

### DIFF
--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -106,6 +106,10 @@ function getSelector(target) {
 }
 
 function formatSymbol(target, sign) {
+  // return directly if no sign
+  if (!sign) {
+    return ''
+  }
   switch (target) {
     case MENU_LEDGERS:
     case MENU_WITHDRAWALS:


### PR DESCRIPTION
from ezeswici: when export a csv for all the possible pairs, front send a `t`.

Examples:

```
// Empty
getTradesCsv {"auth":{"apiKey":"CcrkhxUoe373pcnAKJMv9BUSLnaJvQlCIzobH7EDgxl","apiSecret":"k9levMupv9tV2sml2pDbaGTvqhDvxveouxln25qvR6O"},"params":{"start":1537632382098,"end":1538841982098,"symbol":"t"}}
// BTC
getTradesCsv {"auth":{"apiKey":"CcrkhxUoe373pcnAKJMv9BUSLnaJvQlCIzobH7EDgxl","apiSecret":"k9levMupv9tV2sml2pDbaGTvqhDvxveouxln25qvR6O"},"params":{"start":1537632494428,"end":1538842094428,"symbol":"tBTCUSD"}}```
```

Expect:
if there is no filter should be empty, without the `t`