### PR TITLE
pass default timezone to csv export

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "history": "^4.7.2",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
+    "moment-timezone": "^0.5.21",
     "node-sass-chokidar": "^1.3.3",
     "normalize.css": "^8.0.0",
     "prop-types": "^15.6.1",

--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -10,6 +10,7 @@ import _omit from 'lodash/omit'
 import {
   formatRawPairToTPair,
   formatRawSymbolToFSymbol,
+  getDefaultTimezone,
   makeFetchCall,
   postJsonfetch,
 } from 'state/utils'
@@ -49,9 +50,7 @@ function getCSV(auth, query, target, symbol, timezone) {
   if (symbol) {
     params.symbol = symbol
   }
-  if (timezone) {
-    params.timezone = timezone
-  }
+  params.timezone = timezone || getDefaultTimezone()
   let method = ''
   switch (target) {
     case MENU_FCREDIT:

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import moment from 'moment-timezone'
 
 import { platform } from 'var/config'
 
@@ -115,6 +115,10 @@ export function momentFormatter(format) {
   }
 }
 
+export function getDefaultTimezone() {
+  return moment.tz.guess()
+}
+
 export function getSideMsg(side) {
   let msg
   if (side === 1) {
@@ -141,6 +145,7 @@ export default {
   formatTime,
   getAuth,
   getCurrentEntries,
+  getDefaultTimezone,
   getSideMsg,
   isValidateType,
   momentFormatter,


### PR DESCRIPTION
the backend need some hint for the user default timezone (if running on server)

Please wait until backend PR is ready to process the timezone string, or the export CSV function will be broken with `ERR_API_BASE: ERR_ARGS_NO_PARAMS` server message.

@ezeswci  @ZIMkaRU please comment when backend PR is ready