### PR TITLE
fix checkEmail handle

### DIFF
--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -30,7 +30,7 @@ function* checkAuth({ payload: flag }) {
       }))
 
       // get owner email
-      const { ownerEmail, emailError } = yield call(checkEmail, auth)
+      const { result: ownerEmail, error: emailError } = yield call(checkEmail, auth)
       if (ownerEmail) {
         yield put(setOwnerEmail(ownerEmail))
       }


### PR DESCRIPTION
the backend always returns data as `{result, error} dict` and to avoid name conflict, frontend could deal the return data with alias

after fix the `ownerEmail` param will get returned `email` or `undefined` result and make the right call for the followup process