### PR TITLE
click to open the submenu instead of hover

### DIFF
--- a/src/components/Timeframe/Timeframe.js
+++ b/src/components/Timeframe/Timeframe.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import { injectIntl } from 'react-intl'
-import { MenuItem } from '@blueprintjs/core'
+import { MenuItem, PopoverInteractionKind } from '@blueprintjs/core'
 import queryString from 'query-string'
 
 import constants from 'state/query/constants'
@@ -10,10 +10,7 @@ import { formatDate } from 'state/utils'
 import { propTypes, defaultProps } from './Timeframe.props'
 
 const TIME_FRAMES_POPOVER_PROPS = {
-  hoverCloseDelay: 400,
-  // otherwise there's a "submenu item click" weird problem see
-  // https://github.com/palantir/blueprint/issues/3010
-  captureDismiss: true,
+  interactionKind: PopoverInteractionKind.CLICK,
 }
 
 class Timeframe extends PureComponent {


### PR DESCRIPTION
The blueprintjs's hover behavior (with popover) is buggy with more advanced usage 

To prevent showing both popover and submenu in the mobile layout, it's better to switch to `click` instead of `hover`.

context: https://trello.com/c/LjDbJUdG/135-pending