### PR TITLE
always call syncnow before any sync/fetch requests

### DIFF
--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -100,9 +100,13 @@ function* syncWatcher() {
         const { result: progress } = yield call(getSyncProgress)
         // console.warn('queryWithDb, %', isQueryWithDb, progress)
         if (isQueryWithDb) {
-          // when progress 100 => offline mode
-          if (progress && progress === 100) {
-            if (syncMode !== types.MODE_OFFLINE) {
+          if (progress) {
+            // go offline when progress return result
+            // "Error: The server https://{url} is not available", which means no internet connection
+            if (progress.startsWith('Error: The server')) {
+              yield put(actions.setSyncMode(types.MODE_OFFLINE))
+            // go offline with notification when progress 100
+            } else if ((progress === 100 && syncMode !== types.MODE_OFFLINE)) {
               yield put(actions.forceQueryFromDb())
             }
           } else if (syncMode !== types.MODE_SYNCING) {


### PR DESCRIPTION
The backend suggest that always call `syncnow` before any sync/fetch requests, so we can simplify to only call `syncnow` when check-auth success(authState=true) but haven't hide the auth dialog (isShown=false)

```
1---logout---
2---/check-auth---
3---syncNow---
4---isSyncModeWithDbData---
5---getSyncProgress---
```

Therefore we also don't need to hide dialog after each async call.

From Vladimir: To see what requests the frontend, makes on the backend add `console.log` to this place https://github.com/bitfinexcom/bfx-report/blob/master/src/services/helpers/async-error-catcher.js#L9

```
return (...args) => {
   console.log(`---${args[0].url}${args[0].body.method ? ' -> ' + args[0].body.method : ''}---`)
   const fnReturn = fn(...args)
   const next = args[args.length - 1]
```