### PR TITLE
add type check of progress param

### DIFF
--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -103,7 +103,7 @@ function* syncWatcher() {
           if (progress) {
             // go offline when progress return result
             // "Error: The server https://{url} is not available", which means no internet connection
-            if (progress.startsWith('Error: The server')) {
+            if (typeof progress === 'string' && progress.startsWith('Error: The server')) {
               yield put(actions.setSyncMode(types.MODE_OFFLINE))
             // go offline with notification when progress 100
             } else if ((progress === 100 && syncMode !== types.MODE_OFFLINE)) {


### PR DESCRIPTION
`progress` type could be number, boolean, or string. prevent fail by adding type check before calling `startsWith`