### PR TITLE
pass param to show the right withdrawals/deposits title

### DIFF
--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -65,8 +65,12 @@ function getCSV(auth, query, target, options) {
       method = 'getTradesCsv'
       break
     case MENU_WITHDRAWALS:
+      method = 'getMovementsCsv'
+      params.isWithdrawals = true
+      break
     case MENU_DEPOSITS:
       method = 'getMovementsCsv'
+      params.isDeposits = true
       break
     case MENU_PUBLIC_TRADES:
       method = 'getPublicTradesCsv'


### PR DESCRIPTION
reflect backend's request https://github.com/bitfinexcom/bfx-report/pull/50
frontend could pass right param to export the movements csv file with the right title

context: https://trello.com/c/3CsYO2cL/159-change-movements-csv-export-title-to-withdrawals-deposits