### PR TITLE
[refactor] use constants in time frame query type

### DIFF
--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -17,7 +17,7 @@ import actions from './actions'
 import { getTargetSymbol, getFundingCreditHistory } from './selectors'
 
 function getReqFCredit(auth, query, targetSymbol, smallestMts) {
-  const params = getTimeFrame(query, 'fundingCreditHistory', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_FCREDIT, smallestMts)
   if (targetSymbol) {
     params.symbol = formatRawSymbolToFSymbol(targetSymbol)
   }

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -17,7 +17,7 @@ import actions from './actions'
 import { getTargetSymbol, getFundingLoanHistory } from './selectors'
 
 function getReqFLoan(auth, query, targetSymbol, smallestMts) {
-  const params = getTimeFrame(query, 'floan', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_FLOAN, smallestMts)
   if (targetSymbol) {
     params.symbol = formatRawSymbolToFSymbol(targetSymbol)
   }

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -17,7 +17,7 @@ import actions from './actions'
 import { getTargetSymbol, getFundingOfferHistory } from './selectors'
 
 function getReqFOffer(auth, query, targetSymbol, smallestMts) {
-  const params = getTimeFrame(query, 'foffer', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_FOFFER, smallestMts)
   if (targetSymbol) {
     params.symbol = formatRawSymbolToFSymbol(targetSymbol)
   }

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -16,7 +16,7 @@ import actions from './actions'
 import { getTargetSymbol, getLedgers } from './selectors'
 
 function getReqLedgers(auth, query, targetSymbol, smallestMts) {
-  const params = getTimeFrame(query, 'ledgers', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_LEDGERS, smallestMts)
   if (targetSymbol) {
     params.symbol = targetSymbol
   }

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -16,7 +16,7 @@ import actions from './actions'
 import { getTargetSymbol, getMovements } from './selectors'
 
 function getReqMovements(auth, query, targetSymbol, smallestMts) {
-  const params = getTimeFrame(query, 'movements', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_MOVEMENTS, smallestMts)
   if (targetSymbol) {
     params.symbol = targetSymbol
   }

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -17,7 +17,7 @@ import actions from './actions'
 import { getOrders, getTargetPair } from './selectors'
 
 function getReqOrders(auth, query, targetPair, smallestMts) {
-  const params = getTimeFrame(query, 'orders', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_ORDERS, smallestMts)
   if (targetPair) {
     params.symbol = formatRawPairToTPair(targetPair)
   }

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -17,7 +17,7 @@ import actions from './actions'
 import { getPublicTrades, getTargetPair } from './selectors'
 
 function getReqPublicTrades(auth, query, targetPair, smallestMts) {
-  const params = getTimeFrame(query, 'publictrades', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_PUBLIC_TRADES, smallestMts)
   if (targetPair) {
     params.symbol = formatRawPairToTPair(targetPair)
   }

--- a/src/state/query/constants.js
+++ b/src/state/query/constants.js
@@ -6,6 +6,7 @@ export default {
   MENU_ORDERS: 'orders',
   MENU_TRADES: 'trades',
   MENU_DEPOSITS: 'deposits',
+  MENU_MOVEMENTS: 'movements',
   MENU_WITHDRAWALS: 'withdrawals',
   MENU_PUBLIC_TRADES: 'publictrades',
   TIME_TYPE_UTC: 'utc',

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -17,7 +17,7 @@ import actions from './actions'
 import { getTrades, getTargetPair } from './selectors'
 
 function getReqTrades(auth, query, targetPair, smallestMts) {
-  const params = getTimeFrame(query, 'trades', smallestMts)
+  const params = getTimeFrame(query, queryTypes.MENU_TRADES, smallestMts)
   if (targetPair) {
     params.symbol = formatRawPairToTPair(targetPair)
   }


### PR DESCRIPTION
use constants in time frame query type to prevent miss-typing types.

fix: pass the right param for funding credit history