### PR TITLE
fix: use right update action for fetchNextPublicTrades

### DIFF
--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -71,7 +71,7 @@ function* fetchNextPublicTrades() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPublicTrades, auth, query, targetPair, smallestMts)
-    yield put(actions.updateTrades(result))
+    yield put(actions.updatePublicTrades(result))
 
     if (error) {
       yield put(actions.fetchFail({


### PR DESCRIPTION
fix fetchNextPublicTrades fail which due to call the non-exist update action