### PR TITLE
do destructure after make sure we have the right explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-intl": "^2.7.2",
     "react-redux": "^5.1.1",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "1.1.4",
+    "react-scripts": "1.1.5",
     "react-transition-group": "^2.5.0",
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",

--- a/src/components/Explorer/Explorer.js
+++ b/src/components/Explorer/Explorer.js
@@ -2,7 +2,10 @@ import React from 'react'
 
 import { propTypes, defaultProps } from './Explorer.props'
 
-export const Explorer = ({ currency, destinationAddress, explorers }) => {
+export const Explorer = ({ currency, destinationAddress, explorers = {} }) => {
+  if (!explorers[currency]) {
+    return null
+  }
   const [name, link] = explorers[currency]
   return name && link ? (
     <span className='bitfinex-show-soft'>


### PR DESCRIPTION
if the user visits http://localhost:3000/deposits directly, sometimes the explorers are not fetched from API yet and `explorers[currency]` will be null. 

We can avoid this case by add extra check.