### PR TITLE
save nextPage timestamp as smallmts

### DIFF
--- a/src/state/fundingCreditHistory/reducer.js
+++ b/src/state/fundingCreditHistory/reducer.js
@@ -53,7 +53,9 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
           updateCoins.push(currentSymbol)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mtsUpdate) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mtsUpdate)
+        ) {
           smallestMts = mtsUpdate
         }
         return {
@@ -82,7 +84,7 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/fundingLoanHistory/reducer.js
+++ b/src/state/fundingLoanHistory/reducer.js
@@ -52,7 +52,9 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
           updateCoins.push(currentSymbol)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mtsUpdate) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mtsUpdate)
+        ) {
           smallestMts = mtsUpdate
         }
         return {
@@ -80,7 +82,7 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/fundingOfferHistory/reducer.js
+++ b/src/state/fundingOfferHistory/reducer.js
@@ -51,7 +51,9 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
           updateCoins.push(currentSymbol)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mtsUpdate) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mtsUpdate)
+        ) {
           smallestMts = mtsUpdate
         }
         return {
@@ -78,7 +80,7 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/ledgers/reducer.js
+++ b/src/state/ledgers/reducer.js
@@ -42,7 +42,9 @@ export function ledgersReducer(state = initialState, action) {
           updateCoins.push(currency)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mts) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mts)
+        ) {
           smallestMts = mts
         }
         return {
@@ -60,7 +62,7 @@ export function ledgersReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/movements/reducer.js
+++ b/src/state/movements/reducer.js
@@ -45,7 +45,9 @@ export function movementsReducer(state = initialState, action) {
           updateCoins.push(currency)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mtsUpdated) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mtsUpdated)
+        ) {
           smallestMts = mtsUpdated
         }
         return {
@@ -66,7 +68,7 @@ export function movementsReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/orders/reducer.js
+++ b/src/state/orders/reducer.js
@@ -56,7 +56,9 @@ export function ordersReducer(state = initialState, action) {
           updatePairs.push(internalPair)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mtsUpdate) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mtsUpdate)
+        ) {
           smallestMts = mtsUpdate
         }
         return {
@@ -86,7 +88,7 @@ export function ordersReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingPairs: updatePairs.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/publicTrades/reducer.js
+++ b/src/state/publicTrades/reducer.js
@@ -31,7 +31,9 @@ export function publicTradesReducer(state = initialState, action) {
           mts,
         } = entry
         // log smallest mts
-        if (!smallestMts || smallestMts > mts) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mts)
+        ) {
           smallestMts = mts
         }
         return {
@@ -46,7 +48,7 @@ export function publicTradesReducer(state = initialState, action) {
         ...state,
         entries: [...state.entries, ...entries],
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,

--- a/src/state/trades/reducer.js
+++ b/src/state/trades/reducer.js
@@ -48,7 +48,9 @@ export function tradesReducer(state = initialState, action) {
           updatePairs.push(internalPair)
         }
         // log smallest mts
-        if (!smallestMts || smallestMts > mtsCreate) {
+        if (nextPage === false
+          && (!smallestMts || smallestMts > mtsCreate)
+        ) {
           smallestMts = mtsCreate
         }
         return {
@@ -70,7 +72,7 @@ export function tradesReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingPairs: updatePairs.sort(),
         dataReceived: true,
-        smallestMts,
+        smallestMts: nextPage !== false ? nextPage : smallestMts,
         offset: state.offset + entries.length,
         pageOffset: 0,
         pageLoading: false,


### PR DESCRIPTION
UI was saved the `smallmts` value based on iterating current entries' timestamps. The value will be passed as the time param (for a certain time range) to query the next dataset.

Newly introduced `nextPage` param will return the next entry's timestamp when next page of dataset is available. 
UI should save it as `smallmts` (when avaialble) instead of iterating entries timestamp

context: https://trello.com/c/H589m6e4/181-movement-nextpage-returns-number-instead-of-boolean