### PR TITLE
avoid parentCellWidth warning

### DIFF
--- a/src/components/Movements/Movements.js
+++ b/src/components/Movements/Movements.js
@@ -151,9 +151,11 @@ class Movements extends PureComponent {
       const { currency, destinationAddress } = filteredData[rowIndex]
       return (
         <Cell tooltip={destinationAddress}>
-          {destinationAddress}
-          &nbsp;
-          <Explorer currency={currency} destinationAddress={destinationAddress} />
+          <Fragment>
+            {destinationAddress}
+            &nbsp;
+            <Explorer currency={currency} destinationAddress={destinationAddress} />
+          </Fragment>
         </Cell>
       )
     }

--- a/src/components/Trades/Trades.js
+++ b/src/components/Trades/Trades.js
@@ -146,11 +146,13 @@ class Trades extends PureComponent {
           className='bitfinex-text-align-right'
           tooltip={tooltip}
         >
-          {fee}
-          &nbsp;
-          <span className='bitfinex-show-soft'>
-            {feeCurrency}
-          </span>
+          <Fragment>
+            {fee}
+            &nbsp;
+            <span className='bitfinex-show-soft'>
+              {feeCurrency}
+            </span>
+          </Fragment>
         </Cell>
       )
     }


### PR DESCRIPTION
according to https://github.com/palantir/blueprint/issues/2446
to avoid React warning with parentCellWidth / parentCellHeight property, we can wrap cell with multi components in a `<Fragment>`

another way is fix that limitation in the framework (as I mentioned in their github https://github.com/palantir/blueprint/issues/2446#issuecomment-406954036
), but not see any plan of the adoption  yet

(These warning doesn't break anything and won't show on production)
