### PR TITLE
add warning in public trades pref dialog during syncing

### DIFF
--- a/src/components/SyncPrefButton/SyncPrefButton.container.js
+++ b/src/components/SyncPrefButton/SyncPrefButton.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 
 import actions from 'state/sync/actions'
 import authActions from 'state/auth/actions'
-import { getStartTime, getSyncPairs } from 'state/sync/selectors'
+import { getStartTime, getSyncMode, getSyncPairs } from 'state/sync/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 
 import SyncPrefButton from './SyncPrefButton'
@@ -14,6 +14,7 @@ const mapStateToProps = (state = {}) => {
     pairs = ['btcusd']
   }
   return {
+    syncMode: getSyncMode(state),
     syncPairs: pairs,
     startTime: getStartTime(state) || new Date(start).getTime(),
   }

--- a/src/components/SyncPrefButton/SyncPrefButton.js
+++ b/src/components/SyncPrefButton/SyncPrefButton.js
@@ -2,6 +2,7 @@ import React, { PureComponent, Fragment } from 'react'
 import { injectIntl } from 'react-intl'
 import {
   Button,
+  Callout,
   Classes,
   Dialog,
   Intent,
@@ -9,9 +10,9 @@ import {
   Tooltip,
 } from '@blueprintjs/core'
 import { DateInput } from '@blueprintjs/datetime'
-
 import MultiPairSelector from 'ui/MultiPairSelector'
 import { parsePairTag } from 'state/symbols/utils'
+import mode from 'state/sync/constants'
 import { dialogDescStyle, dialogFieldStyle, dialogSmallDescStyle } from 'ui/utils'
 import { DATE_FORMAT } from 'state/utils'
 import { platform } from 'var/config'
@@ -51,7 +52,7 @@ class SyncPrefButton extends PureComponent {
         tempTime: new Date(nextProps.startTime),
       }
     }
-    return {}
+    return null
   }
 
   handleOpen(e) {
@@ -98,6 +99,7 @@ class SyncPrefButton extends PureComponent {
     const {
       intl,
       textOnly,
+      syncMode,
       syncPairs,
     } = this.props
     const {
@@ -105,6 +107,16 @@ class SyncPrefButton extends PureComponent {
       tempPairs,
       tempTime,
     } = this.state
+    const renderInSyncWarning = syncMode === mode.MODE_SYNCING
+      ? (
+        <Fragment>
+          <Callout intent={Intent.WARNING}>
+            {intl.formatMessage({ id: 'preferences.sync.insync-warning' })}
+          </Callout>
+          <br />
+        </Fragment>
+      )
+      : null
     return platform.showSyncMode
       ? (
         <Fragment>
@@ -138,6 +150,7 @@ class SyncPrefButton extends PureComponent {
             isOpen={isOpen}
           >
             <div className={Classes.DIALOG_BODY}>
+              {renderInSyncWarning}
               <div className='row'>
                 <div className={dialogDescStyle}>
                   {intl.formatMessage({ id: 'preferences.sync.pairs' })}
@@ -185,7 +198,11 @@ class SyncPrefButton extends PureComponent {
                   <Button
                     onClick={this.handleApply}
                     intent={Intent.PRIMARY}
-                    disabled={(tempPairs.length === 0 || tempTime === undefined)}
+                    disabled={(
+                      syncMode === mode.MODE_SYNCING
+                      || tempPairs.length === 0
+                      || tempTime === undefined
+                    )}
                   >
                     {intl.formatMessage({ id: 'preferences.sync.apply' })}
                   </Button>

--- a/src/locales/en-US.messages.json
+++ b/src/locales/en-US.messages.json
@@ -19,6 +19,7 @@
   "preferences.sync.starttime": "Start Time",
   "preferences.sync.apply": "Apply",
   "preferences.sync.apply.tooltip": "After apply, you needs to login again to take effect.",
+  "preferences.sync.insync-warning": "Can't apply during syncing. Please wait until syncing is done.",
   "theme.light": "Light",
   "theme.dark": "Dark",
   "auth.auth": "Auth",

--- a/src/locales/zh-Hant.messages.json
+++ b/src/locales/zh-Hant.messages.json
@@ -18,6 +18,7 @@
   "preferences.sync.starttime": "起始時間",
   "preferences.sync.apply": "確認",
   "preferences.sync.apply.tooltip": "確認後需要重新登入才會生效。",
+  "preferences.sync.insync-warning": "同步時無法確認設定。請等到同步完成後再按確認。",
   "theme.light": "白",
   "theme.dark": "黑",
   "auth.auth": "驗證",


### PR DESCRIPTION
This PR
- return null when no need update in getDerivedStateFromProps 
- add a warning message in pref dialog during syncing (because the `editPublicTrades` API is not functional during syncing) 
-  disable `apply` button during syncing