### PR TITLE
remove unused wallet columns

### DIFF
--- a/src/components/Wallets/Wallets.columns.js
+++ b/src/components/Wallets/Wallets.columns.js
@@ -36,36 +36,5 @@ export default function getColumns(props) {
       },
       copyText: rowIndex => filteredData[rowIndex].balance,
     },
-    {
-      id: 'unsettledInterest',
-      name: 'wallets.column.unsettled-interest',
-      width: 180,
-      renderer: (rowIndex) => {
-        const { unsettledInterest } = filteredData[rowIndex]
-        return (
-          <Cell
-            className='bitfinex-text-align-right'
-            tooltip={unsettledInterest}
-          >
-            {unsettledInterest}
-          </Cell>
-        )
-      },
-      copyText: rowIndex => filteredData[rowIndex].unsettledInterest,
-    },
-    {
-      id: 'balanceAvailable',
-      name: 'wallets.column.balance-available',
-      width: 200,
-      renderer: (rowIndex) => {
-        const { balanceAvailable } = filteredData[rowIndex]
-        return (
-          <Cell tooltip={balanceAvailable}>
-            {balanceAvailable}
-          </Cell>
-        )
-      },
-      copyText: rowIndex => filteredData[rowIndex].balanceAvailable,
-    },
   ]
 }

--- a/src/locales/en-US.messages.json
+++ b/src/locales/en-US.messages.json
@@ -189,6 +189,4 @@
   "wallets.nodata": "No related data in this date time. You can try another date time.",
   "wallets.column.currency": "CURRENCY",
   "wallets.column.balance": "BALANCE",
-  "wallets.column.unsettled-interest": "UNSETTLED INTEREST",
-  "wallets.column.balance-available": "BALANCE AVAILABLE"
 }

--- a/src/locales/zh-Hant.messages.json
+++ b/src/locales/zh-Hant.messages.json
@@ -188,6 +188,4 @@
   "wallets.nodata": "沒有相關資料。請嘗試選擇其他時間。",
   "wallets.column.currency": "貨幣",
   "wallets.column.balance": "餘額",
-  "wallets.column.unsettled-interest": "UNSETTLED INTEREST",
-  "wallets.column.balance-available": "BALANCE AVAILABLE"
 }

--- a/src/state/wallets/reducer.js
+++ b/src/state/wallets/reducer.js
@@ -24,15 +24,11 @@ export function walletsReducer(state = initialState, action) {
           type,
           currency,
           balance,
-          unsettledInterest,
-          balanceAvailable,
         } = entry
         return {
           type,
           currency,
           balance,
-          unsettledInterest,
-          balanceAvailable,
         }
       }).sort((a, b) => a.currency.localeCompare(b.currency))
       return {


### PR DESCRIPTION
upon @ezeswci 's request, 

```
unsettledInterest
balanceAvailable
```

will be removed from the endpoint and should be removed from the wallets column