### PR TITLE
[sync mode] fix key input is left after selection in public trades

### DIFF
--- a/src/ui/MultiPairSelector/MultiPairSelector.js
+++ b/src/ui/MultiPairSelector/MultiPairSelector.js
@@ -58,6 +58,7 @@ class MultiPairSelector extends PureComponent {
         tagInputProps={{ tagProps: { minimal: true }, onRemove: handleTagRemove }}
         tagRenderer={renderTag}
         selectedItems={currentFilters}
+        resetOnSelect
       />
     )
   }

--- a/src/ui/MultiSymbolSelector/MultiSymbolSelector.js
+++ b/src/ui/MultiSymbolSelector/MultiSymbolSelector.js
@@ -62,6 +62,7 @@ class MultiSymbolSelector extends PureComponent {
         tagInputProps={{ tagProps: { minimal: true }, onRemove: handleTagRemove }}
         tagRenderer={renderTag}
         selectedItems={currentFilters}
+        resetOnSelect
       />
     )
   }


### PR DESCRIPTION
In sync mode, we need to specify some pairs in public trades for offline sync 
If the user tried to input something to filter the list, the query field will leave some key input after selection.

This PR:
reset query string when a user selects an item from the menu