### PR TITLE
jump to the current last page if the current offset does not match the fetch limit

### DIFF
--- a/src/state/audit/actions.js
+++ b/src/state/audit/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Positions Audit.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updatePAudit(payload) {
+export function updatePAudit(data, limit, pageSize) {
   return {
     type: types.UPDATE_PAUDIT,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/audit/reducer.js
+++ b/src/state/audit/reducer.js
@@ -7,6 +7,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   setTimeRange,
 } from 'state/reducers.helper'
@@ -30,7 +31,8 @@ export function positionsAuditReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       let smallestMts
       const entries = res.map((entry) => {
         const {
@@ -70,14 +72,15 @@ export function positionsAuditReducer(state = initialState, action) {
           status,
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
         dataReceived: true,
         entries: [...state.entries, ...entries],
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/audit/saga.js
+++ b/src/state/audit/saga.js
@@ -12,7 +12,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -20,6 +20,7 @@ import { getPositionsAudit, getTargetIds } from './selectors'
 
 const TYPE = queryTypes.MENU_POSITIONS_AUDIT
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqPositionsAudit(auth, query, targetIds, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -48,7 +49,7 @@ function* fetchPositionsAudit({ payload: ids }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPositionsAudit, auth, query, targetIds, 0)
-    yield put(actions.updatePAudit(result))
+    yield put(actions.updatePAudit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -81,7 +82,7 @@ function* fetchNextPositionsAudit() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPositionsAudit, auth, query, targetIds, smallestMts)
-    yield put(actions.updatePAudit(result))
+    yield put(actions.updatePAudit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/fundingCreditHistory/actions.js
+++ b/src/state/fundingCreditHistory/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update funding credit history.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateFCredit(payload) {
+export function updateFCredit(data, limit, pageSize) {
   return {
     type: types.UPDATE_FCREDIT,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/fundingCreditHistory/reducer.js
+++ b/src/state/fundingCreditHistory/reducer.js
@@ -7,6 +7,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removeSymbol,
   setSymbols,
@@ -31,7 +32,8 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingCoins } = state
       const updateCoins = [...existingCoins]
       let smallestMts
@@ -88,6 +90,7 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
           positionPair,
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -95,8 +98,8 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -11,7 +11,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -19,6 +19,7 @@ import { getTargetSymbols, getFundingCreditHistory } from './selectors'
 
 const TYPE = queryTypes.MENU_FCREDIT
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqFCredit(auth, query, targetSymbols, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -41,7 +42,7 @@ function* fetchFCredit({ payload: symbol }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqFCredit, auth, query, targetSymbols, 0)
-    yield put(actions.updateFCredit(result))
+    yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -74,7 +75,7 @@ function* fetchNextFCredit() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqFCredit, auth, query, targetSymbols, smallestMts)
-    yield put(actions.updateFCredit(result))
+    yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/fundingLoanHistory/actions.js
+++ b/src/state/fundingLoanHistory/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update funding loan history.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateFLoan(payload) {
+export function updateFLoan(data, limit, pageSize) {
   return {
     type: types.UPDATE_FLOAN,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/fundingLoanHistory/reducer.js
+++ b/src/state/fundingLoanHistory/reducer.js
@@ -7,6 +7,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removeSymbol,
   setSymbols,
@@ -31,7 +32,8 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingCoins } = state
       const updateCoins = [...existingCoins]
       let smallestMts
@@ -86,6 +88,7 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
           noClose,
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -93,8 +96,8 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -11,7 +11,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -19,6 +19,7 @@ import { getTargetSymbols, getFundingLoanHistory } from './selectors'
 
 const TYPE = queryTypes.MENU_FLOAN
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqFLoan(auth, query, targetSymbols, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -41,7 +42,7 @@ function* fetchFLoan({ payload: symbol }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqFLoan, auth, query, targetSymbols, 0)
-    yield put(actions.updateFLoan(result))
+    yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -74,7 +75,7 @@ function* fetchNextFLoan() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqFLoan, auth, query, targetSymbols, smallestMts)
-    yield put(actions.updateFLoan(result))
+    yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/fundingOfferHistory/actions.js
+++ b/src/state/fundingOfferHistory/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update funding offer history.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateFOffer(payload) {
+export function updateFOffer(data, limit, pageSize) {
   return {
     type: types.UPDATE_FOFFER,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/fundingOfferHistory/reducer.js
+++ b/src/state/fundingOfferHistory/reducer.js
@@ -7,6 +7,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removeSymbol,
   setSymbols,
@@ -31,7 +32,8 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingCoins } = state
       const updateCoins = [...existingCoins]
       let smallestMts
@@ -84,6 +86,7 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
           rateReal,
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -91,8 +94,8 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -11,7 +11,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -19,6 +19,7 @@ import { getTargetSymbols, getFundingOfferHistory } from './selectors'
 
 const TYPE = queryTypes.MENU_FOFFER
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqFOffer(auth, query, targetSymbols, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -41,7 +42,7 @@ function* fetchFOffer({ payload: symbol }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqFOffer, auth, query, targetSymbols, 0)
-    yield put(actions.updateFOffer(result))
+    yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -74,7 +75,7 @@ function* fetchNextFOffer() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqFOffer, auth, query, targetSymbols, smallestMts)
-    yield put(actions.updateFOffer(result))
+    yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/ledgers/__tests__/state.test.js
+++ b/src/state/ledgers/__tests__/state.test.js
@@ -210,19 +210,23 @@ describe('ledger state', () => {
       offset: 5000,
       pageOffset: 4875,
     })
-  })
 
-  // jump from p81 to p80
-  expect(reducer(
-    {
+    // jump from p81 to p80
+    expect(reducer(
+      {
+        ...initBlockState,
+        offset: 15000,
+        pageOffset: 0,
+      },
+      actions.jumpPage(80, LIMIT),
+    )).toEqual({
       ...initBlockState,
-      offset: 15000,
-      pageOffset: 0,
-    },
-    actions.jumpPage(80, LIMIT),
-  )).toEqual({
-    ...initBlockState,
-    offset: 10000,
-    pageOffset: 4875,
+      offset: 10000,
+      pageOffset: 4875,
+    })
   })
+})
+
+it('should handle jump page < LIMIT correctly', () => {
+
 })

--- a/src/state/ledgers/actions.js
+++ b/src/state/ledgers/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Ledgers.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateLedgers(payload) {
+export function updateLedgers(data, limit, pageSize) {
   return {
     type: types.UPDATE_LEDGERS,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/ledgers/reducer.js
+++ b/src/state/ledgers/reducer.js
@@ -8,6 +8,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removeSymbol,
   setQueryLimit,
@@ -33,7 +34,8 @@ export function ledgersReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingCoins } = state
       const updateCoins = [...existingCoins]
       let smallestMts
@@ -67,6 +69,7 @@ export function ledgersReducer(state = initialState, action) {
           wallet,
         }
       })
+      let [offset, pageOffset] = getPageOffset(state, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -74,8 +77,8 @@ export function ledgersReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/ledgers/reducer.js
+++ b/src/state/ledgers/reducer.js
@@ -69,7 +69,7 @@ export function ledgersReducer(state = initialState, action) {
           wallet,
         }
       })
-      let [offset, pageOffset] = getPageOffset(state, limit, pageSize)
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -11,6 +11,7 @@ import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selecto
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import { getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -42,8 +43,9 @@ function* fetchLedgers({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
+    const pageSize = getPageSize(TYPE)
     const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
-    yield put(actions.updateLedgers(result))
+    yield put(actions.updateLedgers(result, queryLimit, pageSize))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -71,6 +73,7 @@ function* fetchNextLedgers() {
     } = yield select(getLedgers)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
+    const pageSize = getPageSize(TYPE)
     // data exist, no need to fetch again
     if (entries.length - queryLimit >= offset) {
       return
@@ -78,7 +81,7 @@ function* fetchNextLedgers() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit)
-    yield put(actions.updateLedgers(result))
+    yield put(actions.updateLedgers(result, queryLimit, pageSize))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -18,6 +18,7 @@ import actions from './actions'
 import { getTargetSymbols, getLedgers } from './selectors'
 
 const TYPE = queryTypes.MENU_LEDGERS
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqLedgers(auth, query, targetSymbols, smallestMts, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
@@ -43,9 +44,8 @@ function* fetchLedgers({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const pageSize = getPageSize(TYPE)
     const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
-    yield put(actions.updateLedgers(result, queryLimit, pageSize))
+    yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -73,7 +73,6 @@ function* fetchNextLedgers() {
     } = yield select(getLedgers)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const pageSize = getPageSize(TYPE)
     // data exist, no need to fetch again
     if (entries.length - queryLimit >= offset) {
       return
@@ -81,7 +80,7 @@ function* fetchNextLedgers() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit)
-    yield put(actions.updateLedgers(result, queryLimit, pageSize))
+    yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/movements/__tests__/state.test.js
+++ b/src/state/movements/__tests__/state.test.js
@@ -80,19 +80,19 @@ describe('ledger state', () => {
       offset: 25,
       pageOffset: 0,
     })
-  })
 
-  // jump from p3 to p2
-  expect(reducer(
-    {
+    // jump from p3 to p2
+    expect(reducer(
+      {
+        ...initBlockState,
+        offset: 75,
+        pageOffset: 0,
+      },
+      actions.jumpPage(2, LIMIT),
+    )).toEqual({
       ...initBlockState,
-      offset: 75,
+      offset: 50,
       pageOffset: 0,
-    },
-    actions.jumpPage(2, LIMIT),
-  )).toEqual({
-    ...initBlockState,
-    offset: 50,
-    pageOffset: 0,
+    })
   })
 })

--- a/src/state/movements/actions.js
+++ b/src/state/movements/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Movements.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateMovements(payload) {
+export function updateMovements(data, limit, pageSize) {
   return {
     type: types.UPDATE_MOVEMENTS,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/movements/reducer.js
+++ b/src/state/movements/reducer.js
@@ -7,6 +7,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removeSymbol,
   setSymbols,
@@ -31,7 +32,8 @@ export function movementsReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingCoins } = state
       const updateCoins = [...existingCoins]
       let smallestMts
@@ -71,6 +73,7 @@ export function movementsReducer(state = initialState, action) {
           transactionId,
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -78,8 +81,8 @@ export function movementsReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingCoins: updateCoins.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -10,7 +10,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
 
 import types from './constants'
@@ -19,6 +19,7 @@ import { getTargetSymbols, getMovements } from './selectors'
 
 const TYPE = queryTypes.MENU_MOVEMENTS
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqMovements(auth, query, targetSymbols, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -41,7 +42,7 @@ function* fetchMovements({ payload: symbol }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqMovements, auth, query, targetSymbols, 0)
-    yield put(actions.updateMovements(result))
+    yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -74,7 +75,7 @@ function* fetchNextMovements() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqMovements, auth, query, targetSymbols, smallestMts)
-    yield put(actions.updateMovements(result))
+    yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/orders/actions.js
+++ b/src/state/orders/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Orders.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateOrders(payload) {
+export function updateOrders(data, limit, pageSize) {
   return {
     type: types.UPDATE_ORDERS,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/orders/reducer.js
+++ b/src/state/orders/reducer.js
@@ -9,6 +9,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removePair,
   setPairs,
@@ -94,7 +95,7 @@ export function ordersReducer(state = initialState, action) {
           placedId,
         }
       })
-      let [offset, pageOffset] = getPageOffset(state, limit, pageSize)
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,

--- a/src/state/orders/reducer.js
+++ b/src/state/orders/reducer.js
@@ -34,7 +34,8 @@ export function ordersReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingPairs } = state
       const updatePairs = [...existingPairs]
       let smallestMts
@@ -93,6 +94,7 @@ export function ordersReducer(state = initialState, action) {
           placedId,
         }
       })
+      let [offset, pageOffset] = getPageOffset(state, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -100,8 +102,8 @@ export function ordersReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingPairs: updatePairs.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -11,6 +11,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
+import { getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -42,8 +43,9 @@ function* fetchOrders({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
+    const pageSize = getPageSize(TYPE)
     const { result = [], error } = yield call(getReqOrders, auth, query, targetPairs, 0, queryLimit)
-    yield put(actions.updateOrders(result))
+    yield put(actions.updateOrders(result, queryLimit, pageSize))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -71,6 +73,7 @@ function* fetchNextOrders() {
     } = yield select(getOrders)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
+    const pageSize = getPageSize(TYPE)
     // data exist, no need to fetch again
     if (entries.length - queryLimit >= offset) {
       return
@@ -78,7 +81,7 @@ function* fetchNextOrders() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqOrders, auth, query, targetPairs, smallestMts, queryLimit)
-    yield put(actions.updateOrders(result))
+    yield put(actions.updateOrders(result, queryLimit, pageSize))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -18,6 +18,7 @@ import actions from './actions'
 import { getOrders, getTargetPairs } from './selectors'
 
 const TYPE = queryTypes.MENU_ORDERS
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqOrders(auth, query, targetPairs, smallestMts, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
@@ -43,9 +44,8 @@ function* fetchOrders({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const pageSize = getPageSize(TYPE)
     const { result = [], error } = yield call(getReqOrders, auth, query, targetPairs, 0, queryLimit)
-    yield put(actions.updateOrders(result, queryLimit, pageSize))
+    yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -73,7 +73,6 @@ function* fetchNextOrders() {
     } = yield select(getOrders)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const pageSize = getPageSize(TYPE)
     // data exist, no need to fetch again
     if (entries.length - queryLimit >= offset) {
       return
@@ -81,7 +80,7 @@ function* fetchNextOrders() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqOrders, auth, query, targetPairs, smallestMts, queryLimit)
-    yield put(actions.updateOrders(result, queryLimit, pageSize))
+    yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/positions/actions.js
+++ b/src/state/positions/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Positions.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updatePositions(payload) {
+export function updatePositions(data, limit, pageSize) {
   return {
     type: types.UPDATE_POSITIONS,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/positions/reducer.js
+++ b/src/state/positions/reducer.js
@@ -8,6 +8,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removePair,
   setPairs,
@@ -32,7 +33,8 @@ export function positionsReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingPairs } = state
       const updatePairs = [...existingPairs]
       let smallestMts
@@ -79,6 +81,7 @@ export function positionsReducer(state = initialState, action) {
           status,
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -86,8 +89,8 @@ export function positionsReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingPairs: updatePairs.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/positions/saga.js
+++ b/src/state/positions/saga.js
@@ -13,7 +13,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -21,6 +21,7 @@ import { getPositions, getTargetPairs } from './selectors'
 
 const TYPE = queryTypes.MENU_POSITIONS
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqPositions(auth, query, targetPairs, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -43,7 +44,7 @@ function* fetchPositions({ payload: pair }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPositions, auth, query, targetPairs, 0)
-    yield put(actions.updatePositions(result))
+    yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -76,7 +77,7 @@ function* fetchNextPositions() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPositions, auth, query, targetPairs, smallestMts)
-    yield put(actions.updatePositions(result))
+    yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/publicTrades/actions.js
+++ b/src/state/publicTrades/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update public Trades.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updatePublicTrades(payload) {
+export function updatePublicTrades(data, limit, pageSize) {
   return {
     type: types.UPDATE_PUBLIC_TRADES,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/publicTrades/reducer.js
+++ b/src/state/publicTrades/reducer.js
@@ -6,6 +6,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
 } from 'state/reducers.helper'
 
@@ -28,7 +29,8 @@ export function publicTradesReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       let smallestMts
       const entries = res.map((entry) => {
         const {
@@ -51,14 +53,15 @@ export function publicTradesReducer(state = initialState, action) {
           type: parseFloat(amount) > 0 ? 'BUY' : 'SELL',
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
         dataReceived: true,
         entries: [...state.entries, ...entries],
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -11,7 +11,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -19,6 +19,7 @@ import { getPublicTrades, getTargetPair } from './selectors'
 
 const TYPE = queryTypes.MENU_PUBLIC_TRADES
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqPublicTrades(auth, query, targetPair, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -41,7 +42,7 @@ function* fetchPublicTrades({ payload: pair }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPublicTrades, auth, query, targetPair, 0)
-    yield put(actions.updatePublicTrades(result))
+    yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -74,7 +75,7 @@ function* fetchNextPublicTrades() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqPublicTrades, auth, query, targetPair, smallestMts)
-    yield put(actions.updatePublicTrades(result))
+    yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/reducers.helper.js
+++ b/src/state/reducers.helper.js
@@ -59,16 +59,16 @@ export function setTimeRange(type, state, initialState) {
 }
 
 /* pagination */
-export function getPageOffset(state, limit, pageSize) {
+export function getPageOffset(state, entries, limit, pageSize) {
   // show current page instead of the next page
   return (state.offset % limit !== 0)
     ? [
       (Math.floor(state.offset / limit) + 1) * limit,
-      limit - pageSize // current last page
+      limit - pageSize, // current last page
     ]
     : [
       state.offset + entries.length,
-      0
+      0,
     ]
 }
 

--- a/src/state/reducers.helper.js
+++ b/src/state/reducers.helper.js
@@ -59,6 +59,19 @@ export function setTimeRange(type, state, initialState) {
 }
 
 /* pagination */
+export function getPageOffset(state, limit, pageSize) {
+  // show current page instead of the next page
+  return (state.offset % limit !== 0)
+    ? [
+      (Math.floor(state.offset / limit) + 1) * limit,
+      limit - pageSize // current last page
+    ]
+    : [
+      state.offset + entries.length,
+      0
+    ]
+}
+
 export function fetchNext(type, state, LIMIT) {
   return (state.entries.length - LIMIT >= state.offset)
     ? {
@@ -176,6 +189,7 @@ export default {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   paginateState,
   removePair,

--- a/src/state/tickers/actions.js
+++ b/src/state/tickers/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Tickers.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateTickers(payload) {
+export function updateTickers(data, limit, pageSize) {
   return {
     type: types.UPDATE_TICKERS,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/tickers/reducer.js
+++ b/src/state/tickers/reducer.js
@@ -8,6 +8,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removePair,
   setPairs,
@@ -33,7 +34,8 @@ export function TickersReducer(state = initialState, action) {
           dataReceived: true,
         }
       }
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingPairs } = state
       const updatePairs = [...existingPairs]
       let smallestMts
@@ -62,6 +64,7 @@ export function TickersReducer(state = initialState, action) {
           pair: formatSymbolToPair(symbol),
         }
       })
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -69,8 +72,8 @@ export function TickersReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingPairs: updatePairs.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/tickers/saga.js
+++ b/src/state/tickers/saga.js
@@ -11,7 +11,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getQueryLimit } from 'state/query/utils'
+import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -19,6 +19,7 @@ import { getTickers, getTargetPairs } from './selectors'
 
 const TYPE = queryTypes.MENU_TICKERS
 const LIMIT = getQueryLimit(TYPE)
+const PAGE_SIZE = getPageSize(TYPE)
 
 function getReqTickers(auth, query, targetPairs, smallestMts) {
   const params = getTimeFrame(query, smallestMts)
@@ -41,7 +42,7 @@ function* fetchTickers({ payload: pair }) {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqTickers, auth, query, targetPairs, 0)
-    yield put(actions.updateTickers(result))
+    yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -74,7 +75,7 @@ function* fetchNextTickers() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqTickers, auth, query, targetPairs, smallestMts)
-    yield put(actions.updateTickers(result))
+    yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/trades/actions.js
+++ b/src/state/trades/actions.js
@@ -70,12 +70,18 @@ export function refresh() {
 
 /**
  * Create an action to update Trades.
- * @param {Object[]} payload data set
+ * @param {Object[]} data data set
+ * @param {number} limit query limit
+ * @param {number} pageSize page size
  */
-export function updateTrades(payload) {
+export function updateTrades(data, limit, pageSize) {
   return {
     type: types.UPDATE_TRADES,
-    payload,
+    payload: {
+      data,
+      limit,
+      pageSize,
+    },
   }
 }
 

--- a/src/state/trades/reducer.js
+++ b/src/state/trades/reducer.js
@@ -28,7 +28,8 @@ export function tradesReducer(state = initialState, action) {
   const { type, payload } = action
   switch (type) {
     case types.UPDATE_TRADES: {
-      const { res, nextPage } = payload
+      const { data, limit, pageSize } = payload
+      const { res, nextPage } = data
       const { existingPairs } = state
       const updatePairs = [...existingPairs]
       let smallestMts
@@ -71,6 +72,7 @@ export function tradesReducer(state = initialState, action) {
           feeCurrency,
         }
       })
+      let [offset, pageOffset] = getPageOffset(state, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,
@@ -78,8 +80,8 @@ export function tradesReducer(state = initialState, action) {
         entries: [...state.entries, ...entries],
         existingPairs: updatePairs.sort(),
         smallestMts: nextPage !== false ? nextPage : smallestMts - 1,
-        offset: state.offset + entries.length,
-        pageOffset: 0,
+        offset,
+        pageOffset,
         pageLoading: false,
         nextPage,
       }

--- a/src/state/trades/reducer.js
+++ b/src/state/trades/reducer.js
@@ -9,6 +9,7 @@ import {
   fetchFail,
   fetchNext,
   fetchPrev,
+  getPageOffset,
   jumpPage,
   removePair,
   setPairs,
@@ -72,7 +73,7 @@ export function tradesReducer(state = initialState, action) {
           feeCurrency,
         }
       })
-      let [offset, pageOffset] = getPageOffset(state, limit, pageSize)
+      const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)
       return {
         ...state,
         currentEntriesSize: entries.length,

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -18,6 +18,8 @@ import actions from './actions'
 import { getTrades, getTargetPairs } from './selectors'
 
 const TYPE = queryTypes.MENU_TRADES
+const PAGE_SIZE = getPageSize(TYPE)
+
 function getReqTrades(auth, query, targetPairs, smallestMts, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
   if (targetPairs.length > 0) {
@@ -42,9 +44,8 @@ function* fetchTrades({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const pageSize = getPageSize(TYPE)
     const { result = [], error } = yield call(getReqTrades, auth, query, targetPairs, 0, queryLimit)
-    yield put(actions.updateTrades(result, queryLimit, pageSize))
+    yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -72,7 +73,6 @@ function* fetchNextTrades() {
     } = yield select(getTrades)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const pageSize = getPageSize(TYPE)
     // data exist, no need to fetch again
     if (entries.length - queryLimit >= offset) {
       return
@@ -80,7 +80,7 @@ function* fetchNextTrades() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqTrades, auth, query, targetPairs, smallestMts, queryLimit)
-    yield put(actions.updateTrades(result, queryLimit, pageSize))
+    yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -11,6 +11,7 @@ import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selecto
 import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
+import { getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
@@ -41,8 +42,9 @@ function* fetchTrades({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
+    const pageSize = getPageSize(TYPE)
     const { result = [], error } = yield call(getReqTrades, auth, query, targetPairs, 0, queryLimit)
-    yield put(actions.updateTrades(result))
+    yield put(actions.updateTrades(result, queryLimit, pageSize))
 
     if (error) {
       yield put(actions.fetchFail({
@@ -70,6 +72,7 @@ function* fetchNextTrades() {
     } = yield select(getTrades)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
+    const pageSize = getPageSize(TYPE)
     // data exist, no need to fetch again
     if (entries.length - queryLimit >= offset) {
       return
@@ -77,7 +80,7 @@ function* fetchNextTrades() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result = [], error } = yield call(getReqTrades, auth, query, targetPairs, smallestMts, queryLimit)
-    yield put(actions.updateTrades(result))
+    yield put(actions.updateTrades(result, queryLimit, pageSize))
 
     if (error) {
       yield put(actions.fetchFail({


### PR DESCRIPTION
pagination fix: when the current dataset is smaller than LIMIT (ex: only return 497 of 500 as limit), click the `>>` button will jump to the next page (497 + new fetched data length)

New behavior (if current dataset is 4 pages (and jump to any of them))

if the current offset match the fetch LIMIT, act as usual;
if the current offset does not match the fetch LIMIT, jump to the current last page (p4) to let user see the new entries at the bottom.

context:　https://trello.com/c/4jB8qx67/222-bug-on-generating-next-page