### PR TITLE
hide auth token while apply filter by coin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-ui",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Report page to overview the user actions in Bitfinex and download related csv files",
   "repository": {
     "type": "git",

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -108,8 +108,8 @@ export function generateUrl(type, params, symbols) {
     return ''
   }
   return symbols
-    ? `${getPath(type)}/${getSymbolsURL(symbols)}${params}`
-    : `${getPath(type)}${params}`
+    ? `${getPath(type)}/${getSymbolsURL(symbols)}${getNoAuthTokenUrlString(params)}`
+    : `${getPath(type)}${getNoAuthTokenUrlString(params)}`
 }
 
 export function handleAddSymbolFilter(type, symbol, props) {

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -107,9 +107,10 @@ export function generateUrl(type, params, symbols) {
     console.error('Unsupport route type ', type)
     return ''
   }
+  const noAuthTokenParams = getNoAuthTokenUrlString(params)
   return symbols
-    ? `${getPath(type)}/${getSymbolsURL(symbols)}${getNoAuthTokenUrlString(params)}`
-    : `${getPath(type)}${getNoAuthTokenUrlString(params)}`
+    ? `${getPath(type)}/${getSymbolsURL(symbols)}${noAuthTokenParams}`
+    : `${getPath(type)}${noAuthTokenParams}`
 }
 
 export function handleAddSymbolFilter(type, symbol, props) {

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -100,6 +100,14 @@ export function checkFetch(prevProps, props, type) {
   }
 }
 
+// remove authToken param from url but keep others
+export function getNoAuthTokenUrlString(searchUrl) {
+  const parsed = queryString.parse(searchUrl)
+  const params = _omit(parsed, 'authToken')
+  const queries = queryString.stringify(params, { encode: false })
+  return queries ? `?${queries}` : ''
+}
+
 // genereate url with route and params
 export function generateUrl(type, params, symbols) {
   if (!isValidRouteType(type)) {
@@ -186,14 +194,6 @@ export function getSideMsg(side) {
 
 export function getParsedUrlParams(searchUrl) {
   return queryString.parse(searchUrl)
-}
-
-// remove authToken param from url but keep others
-export function getNoAuthTokenUrlString(searchUrl) {
-  const parsed = queryString.parse(searchUrl)
-  const params = _omit(parsed, 'authToken')
-  const queries = queryString.stringify(params, { encode: false })
-  return queries ? `?${queries}` : ''
 }
 
 export default {


### PR DESCRIPTION
When applying filter by coin, the authToken appears on the URL

context: https://trello.com/c/3smXQqwV/230-showing-auth-token