### PR TITLE
fix formatPair for t-prefixed pairs

### DIFF
--- a/src/state/symbols/__tests__/utils.test.js
+++ b/src/state/symbols/__tests__/utils.test.js
@@ -35,6 +35,18 @@ describe('pair convertion', () => {
     expect(formatPair('ethusd')).toEqual('ETH/USD')
   })
 
+  it('formatPair trxusd -> TRX/USD', () => {
+    expect(formatPair('trxusd')).toEqual('TRX/USD')
+  })
+
+  it('formatPair trxbtc -> TRX/BTC', () => {
+    expect(formatPair('trxbtc')).toEqual('TRX/BTC')
+  })
+
+  it('formatPair tknusd -> TKN/USD', () => {
+    expect(formatPair('tknusd')).toEqual('TKN/USD')
+  })
+
   it('formatPair ALL -> ALL', () => {
     expect(formatPair('ALL')).toEqual('ALL')
   })

--- a/src/state/symbols/utils.js
+++ b/src/state/symbols/utils.js
@@ -62,7 +62,7 @@ export function addPrefix(symbol = '') {
  */
 const removePrefix = (symbol = '') => {
   const s = symbol.charAt(0)
-  return (s === 't' || s === 'f')
+  return (symbol.length > 6 && (s === 't' || s === 'f'))
     ? symbol.substring(1).toUpperCase()
     : symbol.toUpperCase()
 }


### PR DESCRIPTION
context:　https://trello.com/c/uYSl4TUi/231-pairselector-wrongly-show-trx-xxx-pair
