### PR TITLE
formatRawSymbols t/f prefix correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-ui",
-  "version": "2.9.1",
+  "version": "2.9.3",
   "description": "Report page to overview the user actions in Bitfinex and download related csv files",
   "repository": {
     "type": "git",

--- a/src/state/symbols/__tests__/utils.test.js
+++ b/src/state/symbols/__tests__/utils.test.js
@@ -100,9 +100,24 @@ describe('trading/funding symbols convertion', () => {
     expect(formatRawSymbols('BTCUSD')).toEqual('tBTCUSD')
   })
 
+  it('formatRawSymbols trxusd -> tTRXUSD', () => {
+    expect(formatRawSymbols('trxusd')).toEqual('tTRXUSD')
+    expect(formatRawSymbols('TRXUSD')).toEqual('tTRXUSD')
+  })
+
+  it('formatRawSymbols funusd -> tFUNUSD', () => {
+    expect(formatRawSymbols('funusd')).toEqual('tFUNUSD')
+    expect(formatRawSymbols('FUNUSD')).toEqual('tFUNUSD')
+  })
+
   it('formatRawSymbols [\'btcusd\'] -> tBTCUSD', () => {
     expect(formatRawSymbols(['btcusd'])).toEqual('tBTCUSD')
     expect(formatRawSymbols(['BTCUSD'])).toEqual('tBTCUSD')
+  })
+
+  it('formatRawSymbols [\'trxusd\'] -> tTRXUSD', () => {
+    expect(formatRawSymbols(['trxusd'])).toEqual('tTRXUSD')
+    expect(formatRawSymbols(['TRXUSD'])).toEqual('tTRXUSD')
   })
 
   it('formatRawSymbols [\'btcusd\', \'ethusd\'] -> [\'tBTCUSD\', \'tETHUSD\']', () => {
@@ -111,8 +126,22 @@ describe('trading/funding symbols convertion', () => {
     expect(formatRawSymbols(['BTCUSD', 'ETHUSD'])).toEqual(['tBTCUSD', 'tETHUSD'])
   })
 
+  it('formatRawSymbols [\'trxusd\', \'funusd\'] -> [\'tTRXUSD\', \'tFUNUSD\']', () => {
+    expect(formatRawSymbols(['trxusd', 'funusd'])).toEqual(['tTRXUSD', 'tFUNUSD'])
+    expect(formatRawSymbols(['TRXUSD', 'funusd'])).toEqual(['tTRXUSD', 'tFUNUSD'])
+    expect(formatRawSymbols(['TRXUSD', 'FUNUSD'])).toEqual(['tTRXUSD', 'tFUNUSD'])
+  })
+
   it('formatRawSymbols USD -> fUSD', () => {
     expect(formatRawSymbols('USD')).toEqual('fUSD')
+  })
+
+  it('formatRawSymbols TRX -> fTRX', () => {
+    expect(formatRawSymbols('TRX')).toEqual('fTRX')
+  })
+
+  it('formatRawSymbols FUN -> fFUN', () => {
+    expect(formatRawSymbols('FUN')).toEqual('fFUN')
   })
 
   it('formatRawSymbols [\'USD\'] -> fUSD', () => {

--- a/src/state/symbols/utils.js
+++ b/src/state/symbols/utils.js
@@ -25,7 +25,8 @@ export function addPrefix(symbol = '') {
   const sym = `${symbol}`
   const first = sym.charAt(0)
   // already okay
-  if (first === 't' || first === 'f') {
+  if ((sym.length === 4 || sym.length === 7)
+    && (first === 't' || first === 'f')) {
     return sym
   }
   // pretty pair ex. BTC:IOTA


### PR DESCRIPTION
TRXUSD is not format correctly to tTRXUSD, same as `FUNUSD` etc

context:　https://trello.com/c/uYSl4TUi/231-pairselector-wrongly-show-trx-xxx-pair