### PR TITLE
add transactionId column in movement

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -30,7 +30,7 @@
       "period": "PERIOD",
       "days": "Day(s)",
       "opening": "OPENED",
-      "lastpayout": "CLOSED",
+      "lastpayout": "LAST PAYOUT",
       "positionpair": "POSITION PAIR",
       "updated": "DATE"
     },
@@ -136,7 +136,7 @@
     },
     "noid": {
       "title": "No Positions ID",
-      "noid.description": "Please select from the Positions page to query the Positions changelog by ID."
+      "description": "Please select from the Positions page to query the Positions changelog by ID."
     }
   },
   "positions": {

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -105,7 +105,8 @@
       "amount": "AMOUNT",
       "fees": "FEES",
       "status": "STATUS",
-      "destination": "DESTINATION"
+      "destination": "DESTINATION",
+      "transactionId": "TRANSACTION ID"
     }
   },
   "nodata": "No related data in this time range. You can try another time range.",

--- a/public/locales/zh-TW/translations.json
+++ b/public/locales/zh-TW/translations.json
@@ -105,7 +105,8 @@
       "amount": "數量",
       "fees": "費用",
       "status": "狀態",
-      "destination": "去處"
+      "destination": "去處",
+      "transactionId": "交易編號"
     }
   },
   "nodata": "沒有相關資料。請試試其他時間範圍。",

--- a/public/locales/zh-TW/translations.json
+++ b/public/locales/zh-TW/translations.json
@@ -30,7 +30,7 @@
       "period": "期間",
       "days": "天",
       "opening": "開始",
-      "lastpayout": "結束",
+      "lastpayout": "最後付款",
       "positionpair": "POSITION PAIR",
       "updated": "日期"
     },

--- a/src/components/Movements/Movements.columns.js
+++ b/src/components/Movements/Movements.columns.js
@@ -136,5 +136,19 @@ export default function getColumns(props) {
       },
       copyText: rowIndex => filteredData[rowIndex].destinationAddress,
     },
+    {
+      id: 'transid',
+      name: 'movements.column.transactionId',
+      width: 80,
+      renderer: (rowIndex) => {
+        const { transactionId } = filteredData[rowIndex]
+        return (
+          <Cell tooltip={transactionId}>
+            {transactionId}
+          </Cell>
+        )
+      },
+      copyText: rowIndex => filteredData[rowIndex].transactionId,
+    },
   ]
 }


### PR DESCRIPTION
This PR
- Add TRANSACTION ID column in movement table
- rename CLOSE to LAST PAYOUT in funding credit
- positions audit description translation fix

context:　https://trello.com/c/lo5dBjnN/233-add-fields