### PR TITLE
show datetime with user pref timezone in  datetime selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-ui",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Report page to overview the user actions in Bitfinex and download related csv files",
   "repository": {
     "type": "git",

--- a/src/components/Main/CustomDialog.js
+++ b/src/components/Main/CustomDialog.js
@@ -10,7 +10,7 @@ import {
 } from '@blueprintjs/core'
 import { DateRangeInput } from '@blueprintjs/datetime'
 
-import { DATE_FORMAT } from 'state/utils'
+import { DEFAULT_DATETIME_FORMAT, momentFormatter } from 'state/utils'
 
 const SMALL_DATE_RANGE_POPOVER_PROPS = {
   position: Position.TOP,
@@ -30,12 +30,14 @@ class CustomDialog extends PureComponent {
       startQuery,
       startDate,
       t,
+      timezone,
     } = this.props
+    const { formatDate, parseDate } = momentFormatter(DEFAULT_DATETIME_FORMAT, timezone)
     const commonDateRangeProps = {
       allowSingleDayRange: true,
       closeOnSelection: true,
-      formatDate: DATE_FORMAT.formatDate,
-      parseDate: DATE_FORMAT.parseDate,
+      formatDate,
+      parseDate,
       onChange: handleRangeChange,
       value: [startDate, endDate],
       maxDate: this.maxDate,
@@ -89,12 +91,14 @@ CustomDialog.propTypes = {
   isCustomOpen: PropTypes.bool.isRequired,
   startQuery: PropTypes.func.isRequired,
   startDate: PropTypes.instanceOf(Date),
+  timezone: PropTypes.string,
   endDate: PropTypes.instanceOf(Date),
 }
 
 CustomDialog.defaultProps = {
   startDate: null,
   endDate: null,
+  timezone: '',
 }
 
 export default withNamespaces('translations')(CustomDialog)

--- a/src/components/Main/Main.container.js
+++ b/src/components/Main/Main.container.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom'
 import { exportCsv, prepareExport, setCustomTimeRange } from 'state/query/actions'
 import { showCustomDialog } from 'state/ui/actions'
 import { getAuthStatus, getIsShown } from 'state/auth/selectors'
-import { getMenuMode } from 'state/base/selectors'
+import { getMenuMode, getTimezone } from 'state/base/selectors'
 import { getIsCustomDialogOpen } from 'state/ui/selectors'
 
 import Main from './Main'
@@ -14,6 +14,7 @@ const mapStateToProps = (state = {}) => ({
   authStatus: getAuthStatus(state),
   menuMode: getMenuMode(state),
   isCustomOpen: getIsCustomDialogOpen(state),
+  timezone: getTimezone(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -111,6 +111,7 @@ class Main extends PureComponent {
       isCustomOpen,
       location,
       menuMode,
+      timezone,
     } = this.props
     const {
       endDate,
@@ -286,6 +287,7 @@ class Main extends PureComponent {
           startQuery={this.startQuery}
           startDate={startDate}
           endDate={endDate}
+          timezone={timezone}
         />
         <ExportDialog
           type={target}

--- a/src/components/Main/Main.props.js
+++ b/src/components/Main/Main.props.js
@@ -13,18 +13,3 @@ export const defaultProps = {
   authIsShown: false,
   authStatus: false,
 }
-
-export const customDialogPropTypes = {
-  endDate: PropTypes.instanceOf(Date),
-  handleCustomDialogClose: PropTypes.func.isRequired,
-  handleRangeChange: PropTypes.func.isRequired,
-  isCustomOpen: PropTypes.bool.isRequired,
-  menuMode: PropTypes.string,
-  startQuery: PropTypes.func.isRequired,
-  startDate: PropTypes.instanceOf(Date),
-  t: PropTypes.func.isRequired,
-}
-
-export const customDialogDefaultProps = {
-  menuMode: '',
-}

--- a/src/components/SyncPrefButton/SyncPrefButton.container.js
+++ b/src/components/SyncPrefButton/SyncPrefButton.container.js
@@ -4,6 +4,7 @@ import actions from 'state/sync/actions'
 import authActions from 'state/auth/actions'
 import { getStartTime, getSyncMode, getSyncPairs } from 'state/sync/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
+import { getTimezone } from 'state/base/selectors'
 
 import SyncPrefButton from './SyncPrefButton'
 
@@ -17,6 +18,7 @@ const mapStateToProps = (state = {}) => {
     syncMode: getSyncMode(state),
     syncPairs: pairs,
     startTime: getStartTime(state) || new Date(start).getTime(),
+    timezone: getTimezone(state),
   }
 }
 

--- a/src/components/SyncPrefButton/SyncPrefButton.js
+++ b/src/components/SyncPrefButton/SyncPrefButton.js
@@ -14,7 +14,7 @@ import MultiPairSelector from 'ui/MultiPairSelector'
 import { parsePairTag } from 'state/symbols/utils'
 import mode from 'state/sync/constants'
 import { dialogDescStyle, dialogFieldStyle, dialogSmallDescStyle } from 'ui/utils'
-import { DATE_FORMAT } from 'state/utils'
+import { DEFAULT_DATETIME_FORMAT, momentFormatter } from 'state/utils'
 import { platform } from 'var/config'
 
 import { propTypes, defaultProps } from './SyncPrefButton.props'
@@ -101,12 +101,14 @@ class SyncPrefButton extends PureComponent {
       syncPairs,
       t,
       textOnly,
+      timezone,
     } = this.props
     const {
       isOpen,
       tempPairs,
       tempTime,
     } = this.state
+    const { formatDate, parseDate } = momentFormatter(DEFAULT_DATETIME_FORMAT, timezone)
     const renderInSyncWarning = syncMode === mode.MODE_SYNCING
       ? (
         <Fragment>
@@ -176,8 +178,8 @@ class SyncPrefButton extends PureComponent {
                 </div>
                 <div className={dialogFieldStyle}>
                   <DateInput
-                    formatDate={DATE_FORMAT.formatDate}
-                    parseDate={DATE_FORMAT.parseDate}
+                    formatDate={formatDate}
+                    parseDate={parseDate}
                     onChange={this.handleDateChange}
                     value={tempTime}
                   />

--- a/src/components/SyncPrefButton/SyncPrefButton.props.js
+++ b/src/components/SyncPrefButton/SyncPrefButton.props.js
@@ -7,6 +7,7 @@ export const propTypes = {
   setPairs: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   textOnly: PropTypes.bool,
+  timezone: PropTypes.string,
 }
 
 export const defaultProps = {
@@ -15,4 +16,5 @@ export const defaultProps = {
   startTime: 0,
   setPairs: () => {},
   textOnly: false,
+  timezone: '',
 }

--- a/src/components/Wallets/Wallets.container.js
+++ b/src/components/Wallets/Wallets.container.js
@@ -7,6 +7,7 @@ import {
   getEntries,
   getTimestamp,
 } from 'state/wallets/selectors'
+import { getTimezone } from 'state/base/selectors'
 
 import Wallets from './Wallets'
 
@@ -14,6 +15,7 @@ const mapStateToProps = (state = {}) => ({
   currentTime: getTimestamp(state),
   entries: getEntries(state),
   loading: !getDataReceived(state),
+  timezone: getTimezone(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -16,7 +16,7 @@ import NoData from 'ui/NoData'
 import RefreshButton from 'ui/RefreshButton'
 import DataTable from 'ui/DataTable'
 import queryConstants from 'state/query/constants'
-import { DATE_FORMAT } from 'state/utils'
+import { DEFAULT_DATETIME_FORMAT, momentFormatter } from 'state/utils'
 import { isValidTimeStamp } from 'state/query/utils'
 import { platform } from 'var/config'
 
@@ -80,6 +80,7 @@ class Wallets extends PureComponent {
       loading,
       refresh,
       t,
+      timezone,
     } = this.props
     const { timestamp } = this.state
     const exchangeData = entries.filter(entry => entry.type === WALLET_EXCHANGE)
@@ -93,6 +94,7 @@ class Wallets extends PureComponent {
     const fundingRows = fundingData.length
     const hasNewTime = timestamp && currentTime !== timestamp.getTime()
     const timePrecision = platform.showSyncMode ? TimePrecision.SECOND : undefined
+    const { formatDate, parseDate } = momentFormatter(DEFAULT_DATETIME_FORMAT, timezone)
 
     const renderTimeSelection = (
       <Fragment>
@@ -106,8 +108,8 @@ class Wallets extends PureComponent {
           usePortal
         >
           <DateInput
-            formatDate={DATE_FORMAT.formatDate}
-            parseDate={DATE_FORMAT.parseDate}
+            formatDate={formatDate}
+            parseDate={parseDate}
             onChange={this.handleDateChange}
             value={timestamp}
             timePrecision={timePrecision}

--- a/src/components/Wallets/Wallets.props.js
+++ b/src/components/Wallets/Wallets.props.js
@@ -15,6 +15,7 @@ export const propTypes = {
   refresh: PropTypes.func.isRequired,
   setTimestamp: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
+  timezone: PropTypes.string,
 }
 
 export const defaultProps = {
@@ -24,4 +25,5 @@ export const defaultProps = {
   loading: true,
   refresh: () => {},
   setTimestamp: () => {},
+  timezone: '',
 }

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -168,15 +168,21 @@ export function getCurrentEntries(entries, offset, limit, pageOffset, pageSize) 
     : entries.slice(offset + pageOffset - limit, offset + pageOffset - limit + pageSize)
 }
 
-export function momentFormatter(format) {
-  return {
-    formatDate: date => moment(date).format(format),
-    parseDate: str => moment(str, format).toDate(),
-    placeholder: `${format} (moment)`,
-  }
+export function momentFormatter(format, timezone) {
+  return timezone
+    ? {
+      formatDate: date => moment.tz(date, timezone).format(format),
+      parseDate: str => moment.tz(str, format, timezone).toDate(),
+      placeholder: `${format} (moment)`,
+    }
+    : {
+      formatDate: date => moment(date).format(format),
+      parseDate: str => moment(str, format).toDate(),
+      placeholder: `${format} (moment)`,
+    }
 }
 
-export const DATE_FORMAT = momentFormatter('YYYY-MM-DD HH:mm:ss')
+export const DEFAULT_DATETIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
 
 export function getSideMsg(side) {
   let msg
@@ -199,7 +205,7 @@ export function getParsedUrlParams(searchUrl) {
 export default {
   checkFetch,
   checkEmail,
-  DATE_FORMAT,
+  DEFAULT_DATETIME_FORMAT,
   makeFetchCall,
   formatDate,
   formatTime,


### PR DESCRIPTION
Current datetime selector picks the time with local timezone.

This PR:
- show datetime with user pref timezone in  datetime selector

context: https://trello.com/c/LRqjum9s/240-add-selected-timezone-also-for-time-selector