### PR TITLE
call nextFetch again when get empty array but has next page

### DIFF
--- a/src/state/__tests__/sagas.helper.test.js
+++ b/src/state/__tests__/sagas.helper.test.js
@@ -23,9 +23,14 @@ describe('Test fetchNext', () => {
     error: undefined,
   }
   const func = () => {}
+  const options = {
+    smallestMts: 0,
+    some: 'some',
+    params: 'params',
+  }
 
   it('Test Normal Case', () => {
-    const generator = cloneableGenerator(fetchNext)(normalResult.result, normalResult.error, func, 0, 'some', 'params')
+    const generator = cloneableGenerator(fetchNext)(normalResult.result, normalResult.error, func, options)
     const gen = generator.clone()
 
     expect(gen.next().value).toEqual(normalResult)
@@ -33,7 +38,7 @@ describe('Test fetchNext', () => {
   })
 
   it('Test Error Case', () => {
-    const generator = cloneableGenerator(fetchNext)(errorResult.result, errorResult.error, func, 0, 'some', 'params')
+    const generator = cloneableGenerator(fetchNext)(errorResult.result, errorResult.error, func, options)
     const gen = generator.clone()
 
     expect(gen.next().value).toEqual(errorResult)
@@ -41,41 +46,54 @@ describe('Test fetchNext', () => {
   })
 
   it('Test 1st no data Case', () => {
-    const generator = cloneableGenerator(fetchNext)(
-      hasNextResult.result, hasNextResult.error, func, 0, 'some', 'params',
-    )
+    const generator = cloneableGenerator(fetchNext)(hasNextResult.result, hasNextResult.error, func, options)
     const gen = generator.clone()
 
-    expect(gen.next().value).toEqual(call(func, hasNextResult.result.nextPage, 'some', 'params'))
-    expect(gen.next(normalResult).value)
-      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func,
-        hasNextResult.result.nextPage, 'some', 'params'))
+    expect(gen.next().value).toEqual(call(func, {
+      ...options,
+      smallestMts: hasNextResult.result.nextPage,
+    }))
+    expect(gen.next(normalResult).value).toEqual(call(fetchNext, normalResult.result, normalResult.error, func, {
+      ...options,
+      smallestMts: hasNextResult.result.nextPage,
+    }))
     expect(gen.next().done).toEqual(true)
   })
 
   it('Test 1st and 2nd no data Case', () => {
-    const generator = cloneableGenerator(fetchNext)(
-      hasNextResult.result, hasNextResult.error, func, 0, 'some', 'params',
-    )
+    const generator = cloneableGenerator(fetchNext)(hasNextResult.result, hasNextResult.error, func, options)
     const gen = generator.clone()
 
-    expect(gen.next().value).toEqual(call(func, hasNextResult.result.nextPage, 'some', 'params'))
-    expect(gen.next(hasNextResult).value)
-      .toEqual(call(fetchNext, hasNextResult.result, hasNextResult.error, func,
-        hasNextResult.result.nextPage, 'some', 'params'))
+    expect(gen.next().value).toEqual(call(func, {
+      ...options,
+      smallestMts: hasNextResult.result.nextPage,
+    }))
+    expect(gen.next(hasNextResult).value).toEqual(call(fetchNext, hasNextResult.result, hasNextResult.error, func, {
+      ...options,
+      smallestMts: hasNextResult.result.nextPage,
+    }))
     expect(gen.next().done).toEqual(true)
   })
 
   it('Test pass more params Case', () => {
+    const moreOptions = {
+      ...options,
+      more: 'more',
+    }
     const generator = cloneableGenerator(fetchNext)(
-      hasNextResult.result, hasNextResult.error, func, 0, 'some', 'more', 'params',
+      hasNextResult.result, hasNextResult.error, func, moreOptions,
     )
     const gen = generator.clone()
 
-    expect(gen.next().value).toEqual(call(func, hasNextResult.result.nextPage, 'some', 'more', 'params'))
+    expect(gen.next().value).toEqual(call(func, {
+      ...moreOptions,
+      smallestMts: hasNextResult.result.nextPage,
+    }))
     expect(gen.next(normalResult).value)
-      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func,
-        hasNextResult.result.nextPage, 'some', 'more', 'params'))
+      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func, {
+        ...moreOptions,
+        smallestMts: hasNextResult.result.nextPage,
+      }))
     expect(gen.next().done).toEqual(true)
   })
 })

--- a/src/state/__tests__/sagas.helper.test.js
+++ b/src/state/__tests__/sagas.helper.test.js
@@ -1,0 +1,74 @@
+import { call } from 'redux-saga/effects'
+import { cloneableGenerator } from 'redux-saga/utils'
+
+import { fetchNext } from 'state/sagas.helper'
+
+describe('Test fetchNext', () => {
+  const normalResult = {
+    result: {
+      res: [],
+      nextPage: false,
+    },
+    error: undefined,
+  }
+  const errorResult = {
+    result: undefined,
+    error: 'error',
+  }
+  const hasNextResult = {
+    result: {
+      res: [],
+      nextPage: true,
+    },
+    error: undefined,
+  }
+  const func = () => {}
+
+  it('Test Normal Case', () => {
+    const generator = cloneableGenerator(fetchNext)(normalResult.result, normalResult.error, func, 'some', 'params')
+    const gen = generator.clone()
+
+    expect(gen.next().value).toEqual(normalResult)
+    expect(gen.next().done).toEqual(true)
+  })
+
+  it('Test Error Case', () => {
+    const generator = cloneableGenerator(fetchNext)(errorResult.result, errorResult.error, func, 'some', 'params')
+    const gen = generator.clone()
+
+    expect(gen.next().value).toEqual(errorResult)
+    expect(gen.next().done).toEqual(true)
+  })
+
+  it('Test 1st no data Case', () => {
+    const generator = cloneableGenerator(fetchNext)(hasNextResult.result, hasNextResult.error, func, 'some', 'params')
+    const gen = generator.clone()
+
+    expect(gen.next().value).toEqual(call(func, 'some', 'params'))
+    expect(gen.next(normalResult).value)
+      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func, 'some', 'params'))
+    expect(gen.next().done).toEqual(true)
+  })
+
+  it('Test 1st and 2nd no data Case', () => {
+    const generator = cloneableGenerator(fetchNext)(hasNextResult.result, hasNextResult.error, func, 'some', 'params')
+    const gen = generator.clone()
+
+    expect(gen.next().value).toEqual(call(func, 'some', 'params'))
+    expect(gen.next(hasNextResult).value)
+      .toEqual(call(fetchNext, hasNextResult.result, hasNextResult.error, func, 'some', 'params'))
+    expect(gen.next().done).toEqual(true)
+  })
+
+  it('Test pass more params Case', () => {
+    const generator = cloneableGenerator(fetchNext)(
+      hasNextResult.result, hasNextResult.error, func, 'some', 'more', 'params',
+    )
+    const gen = generator.clone()
+
+    expect(gen.next().value).toEqual(call(func, 'some', 'more', 'params'))
+    expect(gen.next(normalResult).value)
+      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func, 'some', 'more', 'params'))
+    expect(gen.next().done).toEqual(true)
+  })
+})

--- a/src/state/__tests__/sagas.helper.test.js
+++ b/src/state/__tests__/sagas.helper.test.js
@@ -18,14 +18,14 @@ describe('Test fetchNext', () => {
   const hasNextResult = {
     result: {
       res: [],
-      nextPage: true,
+      nextPage: '12345678',
     },
     error: undefined,
   }
   const func = () => {}
 
   it('Test Normal Case', () => {
-    const generator = cloneableGenerator(fetchNext)(normalResult.result, normalResult.error, func, 'some', 'params')
+    const generator = cloneableGenerator(fetchNext)(normalResult.result, normalResult.error, func, 0, 'some', 'params')
     const gen = generator.clone()
 
     expect(gen.next().value).toEqual(normalResult)
@@ -33,7 +33,7 @@ describe('Test fetchNext', () => {
   })
 
   it('Test Error Case', () => {
-    const generator = cloneableGenerator(fetchNext)(errorResult.result, errorResult.error, func, 'some', 'params')
+    const generator = cloneableGenerator(fetchNext)(errorResult.result, errorResult.error, func, 0, 'some', 'params')
     const gen = generator.clone()
 
     expect(gen.next().value).toEqual(errorResult)
@@ -41,34 +41,41 @@ describe('Test fetchNext', () => {
   })
 
   it('Test 1st no data Case', () => {
-    const generator = cloneableGenerator(fetchNext)(hasNextResult.result, hasNextResult.error, func, 'some', 'params')
+    const generator = cloneableGenerator(fetchNext)(
+      hasNextResult.result, hasNextResult.error, func, 0, 'some', 'params',
+    )
     const gen = generator.clone()
 
-    expect(gen.next().value).toEqual(call(func, 'some', 'params'))
+    expect(gen.next().value).toEqual(call(func, hasNextResult.result.nextPage, 'some', 'params'))
     expect(gen.next(normalResult).value)
-      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func, 'some', 'params'))
+      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func,
+        hasNextResult.result.nextPage, 'some', 'params'))
     expect(gen.next().done).toEqual(true)
   })
 
   it('Test 1st and 2nd no data Case', () => {
-    const generator = cloneableGenerator(fetchNext)(hasNextResult.result, hasNextResult.error, func, 'some', 'params')
+    const generator = cloneableGenerator(fetchNext)(
+      hasNextResult.result, hasNextResult.error, func, 0, 'some', 'params',
+    )
     const gen = generator.clone()
 
-    expect(gen.next().value).toEqual(call(func, 'some', 'params'))
+    expect(gen.next().value).toEqual(call(func, hasNextResult.result.nextPage, 'some', 'params'))
     expect(gen.next(hasNextResult).value)
-      .toEqual(call(fetchNext, hasNextResult.result, hasNextResult.error, func, 'some', 'params'))
+      .toEqual(call(fetchNext, hasNextResult.result, hasNextResult.error, func,
+        hasNextResult.result.nextPage, 'some', 'params'))
     expect(gen.next().done).toEqual(true)
   })
 
   it('Test pass more params Case', () => {
     const generator = cloneableGenerator(fetchNext)(
-      hasNextResult.result, hasNextResult.error, func, 'some', 'more', 'params',
+      hasNextResult.result, hasNextResult.error, func, 0, 'some', 'more', 'params',
     )
     const gen = generator.clone()
 
-    expect(gen.next().value).toEqual(call(func, 'some', 'more', 'params'))
+    expect(gen.next().value).toEqual(call(func, hasNextResult.result.nextPage, 'some', 'more', 'params'))
     expect(gen.next(normalResult).value)
-      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func, 'some', 'more', 'params'))
+      .toEqual(call(fetchNext, normalResult.result, normalResult.error, func,
+        hasNextResult.result.nextPage, 'some', 'more', 'params'))
     expect(gen.next().done).toEqual(true)
   })
 })

--- a/src/state/audit/saga.js
+++ b/src/state/audit/saga.js
@@ -23,8 +23,12 @@ const TYPE = queryTypes.MENU_POSITIONS_AUDIT
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqPositionsAudit(smallestMts, auth, query, targetIds) {
+function getReqPositionsAudit({
+  smallestMts,
+  auth,
+  query,
+  targetIds,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetIds) {
@@ -50,10 +54,18 @@ function* fetchPositionsAudit({ payload: ids }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPositionsAudit, 0, auth, query, targetIds)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPositionsAudit, 0, auth, query, targetIds,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqPositionsAudit, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetIds,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositionsAudit, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetIds,
+    })
     yield put(actions.updatePAudit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -86,10 +98,18 @@ function* fetchNextPositionsAudit() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPositionsAudit, smallestMts, auth, query, targetIds)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPositionsAudit, smallestMts, auth, query, targetIds,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqPositionsAudit, {
+      smallestMts,
+      auth,
+      query,
+      targetIds,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositionsAudit, {
+      smallestMts,
+      auth,
+      query,
+      targetIds,
+    })
     yield put(actions.updatePAudit(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/audit/saga.js
+++ b/src/state/audit/saga.js
@@ -13,6 +13,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -22,7 +23,8 @@ const TYPE = queryTypes.MENU_POSITIONS_AUDIT
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqPositionsAudit(auth, query, targetIds, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqPositionsAudit(smallestMts, auth, query, targetIds) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetIds) {
@@ -48,7 +50,10 @@ function* fetchPositionsAudit({ payload: ids }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqPositionsAudit, auth, query, targetIds, 0)
+    const { result: resulto, error: erroro } = yield call(getReqPositionsAudit, 0, auth, query, targetIds)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqPositionsAudit, 0, auth, query, targetIds,
+    )
     yield put(actions.updatePAudit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -81,7 +86,10 @@ function* fetchNextPositionsAudit() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqPositionsAudit, auth, query, targetIds, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqPositionsAudit, smallestMts, auth, query, targetIds)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqPositionsAudit, smallestMts, auth, query, targetIds,
+    )
     yield put(actions.updatePAudit(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -12,6 +12,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -41,7 +42,8 @@ function* fetchFCredit({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqFCredit, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqFCredit, auth, query, targetSymbols, 0)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFCredit, auth, query, targetSymbols, 0)
     yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -74,7 +76,10 @@ function* fetchNextFCredit() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqFCredit, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqFCredit, auth, query, targetSymbols, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqFCredit, auth, query, targetSymbols, smallestMts,
+    )
     yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -22,7 +22,8 @@ const TYPE = queryTypes.MENU_FCREDIT
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqFCredit(auth, query, targetSymbols, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqFCredit(smallestMts, auth, query, targetSymbols) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -42,8 +43,8 @@ function* fetchFCredit({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFCredit, auth, query, targetSymbols, 0)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFCredit, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqFCredit, 0, auth, query, targetSymbols)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFCredit, 0, auth, query, targetSymbols)
     yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -76,9 +77,9 @@ function* fetchNextFCredit() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFCredit, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqFCredit, smallestMts, auth, query, targetSymbols)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqFCredit, auth, query, targetSymbols, smallestMts,
+      fetchNext, resulto, erroro, getReqFCredit, smallestMts, auth, query, targetSymbols,
     )
     yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -22,8 +22,12 @@ const TYPE = queryTypes.MENU_FCREDIT
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqFCredit(smallestMts, auth, query, targetSymbols) {
+function getReqFCredit({
+  smallestMts,
+  auth,
+  query,
+  targetSymbols,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -43,8 +47,18 @@ function* fetchFCredit({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFCredit, 0, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFCredit, 0, auth, query, targetSymbols)
+    const { result: resulto, error: erroro } = yield call(getReqFCredit, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFCredit, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -77,10 +91,18 @@ function* fetchNextFCredit() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFCredit, smallestMts, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqFCredit, smallestMts, auth, query, targetSymbols,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqFCredit, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFCredit, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateFCredit(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -22,8 +22,12 @@ const TYPE = queryTypes.MENU_FLOAN
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqFLoan(smallestMts, auth, query, targetSymbols) {
+function getReqFLoan({
+  smallestMts,
+  auth,
+  query,
+  targetSymbols,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -43,8 +47,18 @@ function* fetchFLoan({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFLoan, 0, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFLoan, 0, auth, query, targetSymbols)
+    const { result: resulto, error: erroro } = yield call(getReqFLoan, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFLoan, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -77,10 +91,18 @@ function* fetchNextFLoan() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFLoan, smallestMts, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqFLoan, smallestMts, auth, query, targetSymbols,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqFLoan, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFLoan, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -22,7 +22,8 @@ const TYPE = queryTypes.MENU_FLOAN
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqFLoan(auth, query, targetSymbols, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqFLoan(smallestMts, auth, query, targetSymbols) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -42,8 +43,8 @@ function* fetchFLoan({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFLoan, auth, query, targetSymbols, 0)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFLoan, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqFLoan, 0, auth, query, targetSymbols)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFLoan, 0, auth, query, targetSymbols)
     yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -76,9 +77,9 @@ function* fetchNextFLoan() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFLoan, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqFLoan, smallestMts, auth, query, targetSymbols)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqFLoan, auth, query, targetSymbols, smallestMts,
+      fetchNext, resulto, erroro, getReqFLoan, smallestMts, auth, query, targetSymbols,
     )
     yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -12,6 +12,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -41,7 +42,8 @@ function* fetchFLoan({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqFLoan, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqFLoan, auth, query, targetSymbols, 0)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFLoan, auth, query, targetSymbols, 0)
     yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -74,7 +76,10 @@ function* fetchNextFLoan() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqFLoan, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqFLoan, auth, query, targetSymbols, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqFLoan, auth, query, targetSymbols, smallestMts,
+    )
     yield put(actions.updateFLoan(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -22,7 +22,8 @@ const TYPE = queryTypes.MENU_FOFFER
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqFOffer(auth, query, targetSymbols, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqFOffer(smallestMts, auth, query, targetSymbols) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -42,8 +43,8 @@ function* fetchFOffer({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFOffer, auth, query, targetSymbols, 0)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFOffer, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqFOffer, 0, auth, query, targetSymbols)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFOffer, 0, auth, query, targetSymbols)
     yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -76,9 +77,9 @@ function* fetchNextFOffer() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFOffer, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqFOffer, smallestMts, auth, query, targetSymbols)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqFOffer, auth, query, targetSymbols, smallestMts,
+      fetchNext, resulto, erroro, getReqFOffer, smallestMts, auth, query, targetSymbols,
     )
     yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -12,6 +12,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -41,7 +42,8 @@ function* fetchFOffer({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqFOffer, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqFOffer, auth, query, targetSymbols, 0)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFOffer, auth, query, targetSymbols, 0)
     yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -74,7 +76,10 @@ function* fetchNextFOffer() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqFOffer, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqFOffer, auth, query, targetSymbols, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqFOffer, auth, query, targetSymbols, smallestMts,
+    )
     yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -22,8 +22,12 @@ const TYPE = queryTypes.MENU_FOFFER
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqFOffer(smallestMts, auth, query, targetSymbols) {
+function getReqFOffer({
+  smallestMts,
+  auth,
+  query,
+  targetSymbols,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -43,8 +47,18 @@ function* fetchFOffer({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFOffer, 0, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFOffer, 0, auth, query, targetSymbols)
+    const { result: resulto, error: erroro } = yield call(getReqFOffer, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFOffer, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -77,10 +91,18 @@ function* fetchNextFOffer() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqFOffer, smallestMts, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqFOffer, smallestMts, auth, query, targetSymbols,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqFOffer, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqFOffer, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateFOffer(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingPayment/saga.js
+++ b/src/state/fundingPayment/saga.js
@@ -21,7 +21,8 @@ import { getTargetSymbols, getFPayment } from './selectors'
 const TYPE = queryTypes.MENU_FPAYMENT
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqLedgers(auth, query, targetSymbols, smallestMts, queryLimit) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqLedgers(smallestMts, auth, query, targetSymbols, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
   if (targetSymbols.length > 0) {
     params.symbol = targetSymbols
@@ -47,9 +48,9 @@ function* fetchFPayment({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, 0, auth, query, targetSymbols, queryLimit)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, 0, queryLimit,
+      fetchNext, resulto, erroro, getReqLedgers, 0, auth, query, targetSymbols, queryLimit,
     )
     yield put(actions.updateFPayment(result, queryLimit, PAGE_SIZE))
 
@@ -86,10 +87,10 @@ function* fetchNextFPayment() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result: resulto, error: erroro } = yield call(
-      getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+      getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
     )
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+      fetchNext, resulto, erroro, getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
     )
     yield put(actions.updateFPayment(result, queryLimit, PAGE_SIZE))
 

--- a/src/state/fundingPayment/saga.js
+++ b/src/state/fundingPayment/saga.js
@@ -21,8 +21,13 @@ import { getTargetSymbols, getFPayment } from './selectors'
 const TYPE = queryTypes.MENU_FPAYMENT
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqLedgers(smallestMts, auth, query, targetSymbols, queryLimit) {
+function getReqLedgers({
+  smallestMts,
+  auth,
+  query,
+  targetSymbols,
+  queryLimit,
+}) {
   const params = getTimeFrame(query, smallestMts)
   if (targetSymbols.length > 0) {
     params.symbol = targetSymbols
@@ -48,10 +53,20 @@ function* fetchFPayment({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqLedgers, 0, auth, query, targetSymbols, queryLimit)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, 0, auth, query, targetSymbols, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqLedgers, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
     yield put(actions.updateFPayment(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -86,12 +101,20 @@ function* fetchNextFPayment() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(
-      getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
-    )
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqLedgers, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
     yield put(actions.updateFPayment(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/fundingPayment/saga.js
+++ b/src/state/fundingPayment/saga.js
@@ -12,6 +12,7 @@ import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
 import { getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -46,7 +47,10 @@ function* fetchFPayment({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, 0, queryLimit,
+    )
     yield put(actions.updateFPayment(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -81,7 +85,12 @@ function* fetchNextFPayment() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit)
+    const { result: resulto, error: erroro } = yield call(
+      getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+    )
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+    )
     yield put(actions.updateFPayment(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -21,7 +21,8 @@ import { getTargetSymbols, getLedgers } from './selectors'
 const TYPE = queryTypes.MENU_LEDGERS
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqLedgers(auth, query, targetSymbols, smallestMts, queryLimit) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqLedgers(smallestMts, auth, query, targetSymbols, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
   if (targetSymbols.length > 0) {
     params.symbol = targetSymbols
@@ -45,9 +46,9 @@ function* fetchLedgers({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, 0, auth, query, targetSymbols, queryLimit)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, 0, queryLimit,
+      fetchNext, resulto, erroro, getReqLedgers, 0, auth, query, targetSymbols, queryLimit,
     )
     yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
@@ -84,10 +85,10 @@ function* fetchNextLedgers() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result: resulto = {}, error: erroro } = yield call(
-      getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+      getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
     )
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+      fetchNext, resulto, erroro, getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
     )
     yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -12,6 +12,7 @@ import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
 import { getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -44,7 +45,10 @@ function* fetchLedgers({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, auth, query, targetSymbols, 0, queryLimit)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, 0, queryLimit,
+    )
     yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -79,7 +83,12 @@ function* fetchNextLedgers() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit)
+    const { result: resulto = {}, error: erroro } = yield call(
+      getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+    )
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqLedgers, auth, query, targetSymbols, smallestMts, queryLimit,
+    )
     yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -21,8 +21,13 @@ import { getTargetSymbols, getLedgers } from './selectors'
 const TYPE = queryTypes.MENU_LEDGERS
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqLedgers(smallestMts, auth, query, targetSymbols, queryLimit) {
+function getReqLedgers({
+  smallestMts,
+  auth,
+  query,
+  targetSymbols,
+  queryLimit,
+}) {
   const params = getTimeFrame(query, smallestMts)
   if (targetSymbols.length > 0) {
     params.symbol = targetSymbols
@@ -46,10 +51,20 @@ function* fetchLedgers({ payload: symbol }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqLedgers, 0, auth, query, targetSymbols, queryLimit)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, 0, auth, query, targetSymbols, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqLedgers, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqLedgers, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
     yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -84,12 +99,20 @@ function* fetchNextLedgers() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto = {}, error: erroro } = yield call(
-      getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
-    )
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqLedgers, smallestMts, auth, query, targetSymbols, queryLimit,
-    )
+    const { result: resulto = {}, error: erroro } = yield call(getReqLedgers, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqLedgers, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+      queryLimit,
+    })
     yield put(actions.updateLedgers(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -22,8 +22,12 @@ const TYPE = queryTypes.MENU_MOVEMENTS
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqMovements(smallestMts, auth, query, targetSymbols) {
+function getReqMovements({
+  smallestMts,
+  auth,
+  query,
+  targetSymbols,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -43,10 +47,18 @@ function* fetchMovements({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqMovements, 0, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqMovements, 0, auth, query, targetSymbols,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqMovements, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqMovements, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -79,10 +91,18 @@ function* fetchNextMovements() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqMovements, smallestMts, auth, query, targetSymbols)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqMovements, smallestMts, auth, query, targetSymbols,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqMovements, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqMovements, {
+      smallestMts,
+      auth,
+      query,
+      targetSymbols,
+    })
     yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -22,7 +22,8 @@ const TYPE = queryTypes.MENU_MOVEMENTS
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqMovements(auth, query, targetSymbols, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqMovements(smallestMts, auth, query, targetSymbols) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbols.length > 0) {
@@ -42,9 +43,9 @@ function* fetchMovements({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqMovements, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqMovements, 0, auth, query, targetSymbols)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqMovements, auth, query, targetSymbols, 0,
+      fetchNext, resulto, erroro, getReqMovements, 0, auth, query, targetSymbols,
     )
     yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
@@ -78,9 +79,9 @@ function* fetchNextMovements() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqMovements, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqMovements, smallestMts, auth, query, targetSymbols)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqMovements, auth, query, targetSymbols, smallestMts,
+      fetchNext, resulto, erroro, getReqMovements, smallestMts, auth, query, targetSymbols,
     )
     yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -12,6 +12,7 @@ import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
 import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -41,7 +42,10 @@ function* fetchMovements({ payload: symbol }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqMovements, auth, query, targetSymbols, 0)
+    const { result: resulto, error: erroro } = yield call(getReqMovements, auth, query, targetSymbols, 0)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqMovements, auth, query, targetSymbols, 0,
+    )
     yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -74,7 +78,10 @@ function* fetchNextMovements() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqMovements, auth, query, targetSymbols, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqMovements, auth, query, targetSymbols, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqMovements, auth, query, targetSymbols, smallestMts,
+    )
     yield put(actions.updateMovements(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -21,7 +21,8 @@ import { getOrders, getTargetPairs } from './selectors'
 const TYPE = queryTypes.MENU_ORDERS
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqOrders(auth, query, targetPairs, smallestMts, queryLimit) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqOrders(smallestMts, auth, query, targetPairs, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
   if (targetPairs.length > 0) {
     params.symbol = formatRawSymbols(targetPairs)
@@ -45,9 +46,9 @@ function* fetchOrders({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqOrders, auth, query, targetPairs, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqOrders, 0, auth, query, targetPairs, queryLimit)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqOrders, auth, query, targetPairs, 0, queryLimit,
+      fetchNext, resulto, erroro, getReqOrders, 0, auth, query, targetPairs, queryLimit,
     )
     yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
@@ -84,10 +85,10 @@ function* fetchNextOrders() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result: resulto, error: erroro } = yield call(
-      getReqOrders, auth, query, targetPairs, smallestMts, queryLimit,
+      getReqOrders, smallestMts, auth, query, targetPairs, queryLimit,
     )
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqOrders, auth, query, targetPairs, smallestMts, queryLimit,
+      fetchNext, resulto, erroro, getReqOrders, smallestMts, auth, query, targetPairs, queryLimit,
     )
     yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -12,6 +12,7 @@ import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selecto
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -44,7 +45,10 @@ function* fetchOrders({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result = [], error } = yield call(getReqOrders, auth, query, targetPairs, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqOrders, auth, query, targetPairs, 0, queryLimit)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqOrders, auth, query, targetPairs, 0, queryLimit,
+    )
     yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -79,7 +83,12 @@ function* fetchNextOrders() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqOrders, auth, query, targetPairs, smallestMts, queryLimit)
+    const { result: resulto, error: erroro } = yield call(
+      getReqOrders, auth, query, targetPairs, smallestMts, queryLimit,
+    )
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqOrders, auth, query, targetPairs, smallestMts, queryLimit,
+    )
     yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -21,8 +21,13 @@ import { getOrders, getTargetPairs } from './selectors'
 const TYPE = queryTypes.MENU_ORDERS
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqOrders(smallestMts, auth, query, targetPairs, queryLimit) {
+function getReqOrders({
+  smallestMts,
+  auth,
+  query,
+  targetPairs,
+  queryLimit,
+}) {
   const params = getTimeFrame(query, smallestMts)
   if (targetPairs.length > 0) {
     params.symbol = formatRawSymbols(targetPairs)
@@ -46,10 +51,20 @@ function* fetchOrders({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqOrders, 0, auth, query, targetPairs, queryLimit)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqOrders, 0, auth, query, targetPairs, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqOrders, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqOrders, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
     yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -84,12 +99,20 @@ function* fetchNextOrders() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(
-      getReqOrders, smallestMts, auth, query, targetPairs, queryLimit,
-    )
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqOrders, smallestMts, auth, query, targetPairs, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqOrders, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqOrders, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
     yield put(actions.updateOrders(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/positions/saga.js
+++ b/src/state/positions/saga.js
@@ -14,6 +14,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -43,7 +44,8 @@ function* fetchPositions({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqPositions, auth, query, targetPairs, 0)
+    const { result: resulto, error: erroro } = yield call(getReqPositions, auth, query, targetPairs, 0)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositions, auth, query, targetPairs, 0)
     yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -76,7 +78,10 @@ function* fetchNextPositions() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqPositions, auth, query, targetPairs, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqPositions, auth, query, targetPairs, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqPositions, auth, query, targetPairs, smallestMts,
+    )
     yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/positions/saga.js
+++ b/src/state/positions/saga.js
@@ -24,7 +24,8 @@ const TYPE = queryTypes.MENU_POSITIONS
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqPositions(auth, query, targetPairs, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqPositions(smallestMts, auth, query, targetPairs) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPairs.length > 0) {
@@ -44,8 +45,8 @@ function* fetchPositions({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPositions, auth, query, targetPairs, 0)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositions, auth, query, targetPairs, 0)
+    const { result: resulto, error: erroro } = yield call(getReqPositions, 0, auth, query, targetPairs)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositions, 0, auth, query, targetPairs)
     yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -78,9 +79,9 @@ function* fetchNextPositions() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPositions, auth, query, targetPairs, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqPositions, smallestMts, auth, query, targetPairs)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPositions, auth, query, targetPairs, smallestMts,
+      fetchNext, resulto, erroro, getReqPositions, smallestMts, auth, query, targetPairs,
     )
     yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/positions/saga.js
+++ b/src/state/positions/saga.js
@@ -24,8 +24,12 @@ const TYPE = queryTypes.MENU_POSITIONS
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqPositions(smallestMts, auth, query, targetPairs) {
+function getReqPositions({
+  smallestMts,
+  auth,
+  query,
+  targetPairs,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPairs.length > 0) {
@@ -45,8 +49,18 @@ function* fetchPositions({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPositions, 0, auth, query, targetPairs)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositions, 0, auth, query, targetPairs)
+    const { result: resulto, error: erroro } = yield call(getReqPositions, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositions, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+    })
     yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -79,10 +93,18 @@ function* fetchNextPositions() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPositions, smallestMts, auth, query, targetPairs)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPositions, smallestMts, auth, query, targetPairs,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqPositions, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPositions, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+    })
     yield put(actions.updatePositions(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -22,8 +22,12 @@ const TYPE = queryTypes.MENU_PUBLIC_TRADES
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqPublicTrades(smallestMts, auth, query, targetPair) {
+function getReqPublicTrades({
+  smallestMts,
+  auth,
+  query,
+  targetPair,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPair) {
@@ -43,10 +47,18 @@ function* fetchPublicTrades({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, 0, auth, query, targetPair)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPublicTrades, 0, auth, query, targetPair,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPair,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPublicTrades, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPair,
+    })
     yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -79,10 +91,18 @@ function* fetchNextPublicTrades() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, smallestMts, auth, query, targetPair)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPublicTrades, smallestMts, auth, query, targetPair,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, {
+      smallestMts,
+      auth,
+      query,
+      targetPair,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqPublicTrades, {
+      smallestMts,
+      auth,
+      query,
+      targetPair,
+    })
     yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -12,6 +12,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -41,7 +42,10 @@ function* fetchPublicTrades({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqPublicTrades, auth, query, targetPair, 0)
+    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, auth, query, targetPair, 0)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqPublicTrades, auth, query, targetPair, 0,
+    )
     yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -74,7 +78,10 @@ function* fetchNextPublicTrades() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqPublicTrades, auth, query, targetPair, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, auth, query, targetPair, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqPublicTrades, auth, query, targetPair, smallestMts,
+    )
     yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -22,7 +22,8 @@ const TYPE = queryTypes.MENU_PUBLIC_TRADES
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqPublicTrades(auth, query, targetPair, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqPublicTrades(smallestMts, auth, query, targetPair) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPair) {
@@ -42,9 +43,9 @@ function* fetchPublicTrades({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, auth, query, targetPair, 0)
+    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, 0, auth, query, targetPair)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPublicTrades, auth, query, targetPair, 0,
+      fetchNext, resulto, erroro, getReqPublicTrades, 0, auth, query, targetPair,
     )
     yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 
@@ -78,9 +79,9 @@ function* fetchNextPublicTrades() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, auth, query, targetPair, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqPublicTrades, smallestMts, auth, query, targetPair)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqPublicTrades, auth, query, targetPair, smallestMts,
+      fetchNext, resulto, erroro, getReqPublicTrades, smallestMts, auth, query, targetPair,
     )
     yield put(actions.updatePublicTrades(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/sagas.helper.js
+++ b/src/state/sagas.helper.js
@@ -1,11 +1,13 @@
 import { call } from 'redux-saga/effects'
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-export function* fetchNext(result, error, func, ...params) {
+export function* fetchNext(result, error, func, options) {
   if (result && result.res && result.res.length === 0 && result.nextPage) {
-    const args = [result.nextPage, ...params.slice(1, params.length)]
-    const { result: result1 = {}, error: error1 } = yield call(func, ...args)
-    return yield call(fetchNext, result1, error1, func, ...args)
+    const args = {
+      ...options,
+      smallestMts: result.nextPage,
+    }
+    const { result: result1 = {}, error: error1 } = yield call(func, args)
+    return yield call(fetchNext, result1, error1, func, args)
   }
   return { result, error }
 }

--- a/src/state/sagas.helper.js
+++ b/src/state/sagas.helper.js
@@ -1,9 +1,11 @@
 import { call } from 'redux-saga/effects'
 
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
 export function* fetchNext(result, error, func, ...params) {
   if (result && result.res && result.res.length === 0 && result.nextPage) {
-    const { result: result1 = {}, error: error1 } = yield call(func, ...params)
-    return yield call(fetchNext, result1, error1, func, ...params)
+    const args = [result.nextPage, ...params.slice(1, params.length)]
+    const { result: result1 = {}, error: error1 } = yield call(func, ...args)
+    return yield call(fetchNext, result1, error1, func, ...args)
   }
   return { result, error }
 }

--- a/src/state/sagas.helper.js
+++ b/src/state/sagas.helper.js
@@ -1,0 +1,13 @@
+import { call } from 'redux-saga/effects'
+
+export function* fetchNext(result, error, func, ...params) {
+  if (result && result.res && result.res.length === 0 && result.nextPage) {
+    const { result: result1 = {}, error: error1 } = yield call(func, ...params)
+    return yield call(fetchNext, result1, error1, func, ...params)
+  }
+  return { result, error }
+}
+
+export default {
+  fetchNext,
+}

--- a/src/state/tickers/saga.js
+++ b/src/state/tickers/saga.js
@@ -12,6 +12,7 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -41,7 +42,8 @@ function* fetchTickers({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqTickers, auth, query, targetPairs, 0)
+    const { result: resulto, error: erroro } = yield call(getReqTickers, auth, query, targetPairs, 0)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTickers, auth, query, targetPairs, 0)
     yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -74,7 +76,10 @@ function* fetchNextTickers() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqTickers, auth, query, targetPairs, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqTickers, auth, query, targetPairs, smallestMts)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqTickers, auth, query, targetPairs, smallestMts,
+    )
     yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/tickers/saga.js
+++ b/src/state/tickers/saga.js
@@ -22,8 +22,12 @@ const TYPE = queryTypes.MENU_TICKERS
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqTickers(smallestMts, auth, query, targetPairs) {
+function getReqTickers({
+  smallestMts,
+  auth,
+  query,
+  targetPairs,
+}) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPairs.length > 0) {
@@ -43,8 +47,18 @@ function* fetchTickers({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqTickers, 0, auth, query, targetPairs)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTickers, 0, auth, query, targetPairs)
+    const { result: resulto, error: erroro } = yield call(getReqTickers, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTickers, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+    })
     yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -77,10 +91,18 @@ function* fetchNextTickers() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqTickers, smallestMts, auth, query, targetPairs)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqTickers, smallestMts, auth, query, targetPairs,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqTickers, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTickers, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+    })
     yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {

--- a/src/state/tickers/saga.js
+++ b/src/state/tickers/saga.js
@@ -22,7 +22,8 @@ const TYPE = queryTypes.MENU_TICKERS
 const LIMIT = getQueryLimit(TYPE)
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqTickers(auth, query, targetPairs, smallestMts) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqTickers(smallestMts, auth, query, targetPairs) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPairs.length > 0) {
@@ -42,8 +43,8 @@ function* fetchTickers({ payload: pair }) {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqTickers, auth, query, targetPairs, 0)
-    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTickers, auth, query, targetPairs, 0)
+    const { result: resulto, error: erroro } = yield call(getReqTickers, 0, auth, query, targetPairs)
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTickers, 0, auth, query, targetPairs)
     yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 
     if (error) {
@@ -76,9 +77,9 @@ function* fetchNextTickers() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(getReqTickers, auth, query, targetPairs, smallestMts)
+    const { result: resulto, error: erroro } = yield call(getReqTickers, smallestMts, auth, query, targetPairs)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqTickers, auth, query, targetPairs, smallestMts,
+      fetchNext, resulto, erroro, getReqTickers, smallestMts, auth, query, targetPairs,
     )
     yield put(actions.updateTickers(result, LIMIT, PAGE_SIZE))
 

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -21,8 +21,13 @@ import { getTrades, getTargetPairs } from './selectors'
 const TYPE = queryTypes.MENU_TRADES
 const PAGE_SIZE = getPageSize(TYPE)
 
-// make sure the first params is the `smallestMts` to be processed by fetchNext helper
-function getReqTrades(smallestMts, auth, query, targetPairs, queryLimit) {
+function getReqTrades({
+  smallestMts,
+  auth,
+  query,
+  targetPairs,
+  queryLimit,
+}) {
   const params = getTimeFrame(query, smallestMts)
   if (targetPairs.length > 0) {
     params.symbol = formatRawSymbols(targetPairs)
@@ -46,10 +51,20 @@ function* fetchTrades({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqTrades, 0, auth, query, targetPairs, queryLimit)
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqTrades, 0, auth, query, targetPairs, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqTrades, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTrades, {
+      smallestMts: 0,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
     yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -84,12 +99,20 @@ function* fetchNextTrades() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result: resulto, error: erroro } = yield call(
-      getReqTrades, smallestMts, auth, query, targetPairs, queryLimit,
-    )
-    const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqTrades, smallestMts, auth, query, targetPairs, queryLimit,
-    )
+    const { result: resulto, error: erroro } = yield call(getReqTrades, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
+    const { result = {}, error } = yield call(fetchNext, resulto, erroro, getReqTrades, {
+      smallestMts,
+      auth,
+      query,
+      targetPairs,
+      queryLimit,
+    })
     yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
     if (error) {

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -21,7 +21,8 @@ import { getTrades, getTargetPairs } from './selectors'
 const TYPE = queryTypes.MENU_TRADES
 const PAGE_SIZE = getPageSize(TYPE)
 
-function getReqTrades(auth, query, targetPairs, smallestMts, queryLimit) {
+// make sure the first params is the `smallestMts` to be processed by fetchNext helper
+function getReqTrades(smallestMts, auth, query, targetPairs, queryLimit) {
   const params = getTimeFrame(query, smallestMts)
   if (targetPairs.length > 0) {
     params.symbol = formatRawSymbols(targetPairs)
@@ -45,9 +46,9 @@ function* fetchTrades({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result: resulto, error: erroro } = yield call(getReqTrades, auth, query, targetPairs, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqTrades, 0, auth, query, targetPairs, queryLimit)
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqTrades, auth, query, targetPairs, 0, queryLimit,
+      fetchNext, resulto, erroro, getReqTrades, 0, auth, query, targetPairs, queryLimit,
     )
     yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
@@ -84,10 +85,10 @@ function* fetchNextTrades() {
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
     const { result: resulto, error: erroro } = yield call(
-      getReqTrades, auth, query, targetPairs, smallestMts, queryLimit,
+      getReqTrades, smallestMts, auth, query, targetPairs, queryLimit,
     )
     const { result = {}, error } = yield call(
-      fetchNext, resulto, erroro, getReqTrades, auth, query, targetPairs, smallestMts, queryLimit,
+      fetchNext, resulto, erroro, getReqTrades, smallestMts, auth, query, targetPairs, queryLimit,
     )
     yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -12,6 +12,7 @@ import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getPageSize } from 'state/query/utils'
+import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
 import actions from './actions'
@@ -44,7 +45,10 @@ function* fetchTrades({ payload: pair }) {
     const query = yield select(getQuery)
     const getQueryLimit = yield select(getTargetQueryLimit)
     const queryLimit = getQueryLimit(TYPE)
-    const { result = [], error } = yield call(getReqTrades, auth, query, targetPairs, 0, queryLimit)
+    const { result: resulto, error: erroro } = yield call(getReqTrades, auth, query, targetPairs, 0, queryLimit)
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqTrades, auth, query, targetPairs, 0, queryLimit,
+    )
     yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
     if (error) {
@@ -79,7 +83,12 @@ function* fetchNextTrades() {
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)
-    const { result = [], error } = yield call(getReqTrades, auth, query, targetPairs, smallestMts, queryLimit)
+    const { result: resulto, error: erroro } = yield call(
+      getReqTrades, auth, query, targetPairs, smallestMts, queryLimit,
+    )
+    const { result = {}, error } = yield call(
+      fetchNext, resulto, erroro, getReqTrades, auth, query, targetPairs, smallestMts, queryLimit,
+    )
     yield put(actions.updateTrades(result, queryLimit, PAGE_SIZE))
 
     if (error) {


### PR DESCRIPTION
This PR
- add `fetchNext` saga helper
  - the fetch request will behave the same, unless
  - `the result is an empty array but has the nextPage = true property`, call the fetch function again
  - take returned `nextPage` value as the fetch function's lastest mts param
- apply to all data request saga except the wallet fetch request (which has different data structure)
- add the related unit tests

context: https://trello.com/c/HbuOvgp9/242-next-request