### PR TITLE
 fix menu selection from active positions to positions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-ui",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Report page to overview the user actions in Bitfinex and download related csv files",
   "repository": {
     "type": "git",

--- a/src/components/PositionsActive/PositionsActive.container.js
+++ b/src/components/PositionsActive/PositionsActive.container.js
@@ -35,8 +35,6 @@ const mapDispatchToProps = dispatch => ({
   fetchPrev: queryLimit => dispatch(actions.fetchPrevAPositions(queryLimit)),
   jumpPage: (page, queryLimit) => dispatch(actions.jumpPage(page, queryLimit)),
   refresh: () => dispatch(actions.refresh()),
-  addTargetPair: pair => dispatch(actions.addTargetPair(pair)),
-  removeTargetPair: pair => dispatch(actions.removeTargetPair(pair)),
 })
 
 const PositionsContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(PositionsActive))

--- a/src/components/PositionsActive/PositionsActive.js
+++ b/src/components/PositionsActive/PositionsActive.js
@@ -78,7 +78,7 @@ class PositionsActive extends PureComponent {
   jumpToPositions(e) {
     e.preventDefault()
     const { history } = this.props
-    history.push(`${getPath(queryConstants.MENU_POSITIONS)}/`
+    history.push(`${getPath(queryConstants.MENU_POSITIONS)}`
       + `${getNoAuthTokenUrlString(history.location.search)}`)
   }
 


### PR DESCRIPTION
followup of #226, fix menu selection from active positions to positions 

Issue:

1. click the `Positions` from menu list
1. click the `Active` button in button group
1. click the `Closed` button in button group

actual:
the `Ledgers` menu list is marked

expect:
the `Positions` menu list is marked
