### PR TITLE
fix wallet query button string

### DIFF
--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -120,7 +120,7 @@ class Wallets extends PureComponent {
           intent={hasNewTime ? Intent.PRIMARY : null}
           disabled={!hasNewTime}
         >
-          {t('wallets.query')}
+          {t('wallets.query.title')}
         </Button>
       </Fragment>
     )


### PR DESCRIPTION
The string is changed from `wallets.query` to `wallets.query.title` during migration from react-i18n to i18next