### PR TITLE
Currency mapping

### DIFF
--- a/src/components/Positions/Positions.props.js
+++ b/src/components/Positions/Positions.props.js
@@ -6,7 +6,7 @@ const POSITIONS_ENTRIES_PROPS = PropTypes.shape({
   liquidationPrice: PropTypes.number,
   marginFunding: PropTypes.number,
   marginFundingType: PropTypes.number,
-  mtsUpdate: PropTypes.number.isRequired,
+  mtsUpdate: PropTypes.number,
   pair: PropTypes.string.isRequired,
   pl: PropTypes.number,
   plPerc: PropTypes.number,

--- a/src/components/PositionsActive/PositionsActive.js
+++ b/src/components/PositionsActive/PositionsActive.js
@@ -34,10 +34,9 @@ const PAGE_SIZE = getPageSize(TYPE)
 
 class PositionsActive extends PureComponent {
   componentDidMount() {
-    const { loading, fetchActivepositions, match } = this.props
+    const { loading, fetchActivepositions } = this.props
     if (loading) {
-      const pair = (match.params && match.params.pair) || ''
-      fetchActivepositions(pair)
+      fetchActivepositions()
     }
   }
 

--- a/src/state/audit/reducer.js
+++ b/src/state/audit/reducer.js
@@ -1,5 +1,5 @@
 // data format https://github.com/bitfinexcom/bfx-api-node-models/blob/master/lib/position_hist.js
-import { formatSymbolToPair } from 'state/symbols/utils'
+import { formatSymbolToPair, mapSymbol } from 'state/symbols/utils'
 import queryTypes from 'state/query/constants'
 import authTypes from 'state/auth/constants'
 import {
@@ -54,7 +54,7 @@ export function positionsAuditReducer(state = initialState, action) {
         }
         return {
           id,
-          pair: formatSymbolToPair(symbol),
+          pair: formatSymbolToPair(symbol).split('/').map(mapSymbol).join('/'),
           amount,
           leverage,
           marginFunding,

--- a/src/state/fundingCreditHistory/reducer.js
+++ b/src/state/fundingCreditHistory/reducer.js
@@ -13,6 +13,7 @@ import {
   setSymbols,
   setTimeRange,
 } from 'state/reducers.helper'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -58,7 +59,7 @@ export function fundingCreditHistoryReducer(state = initialState, action) {
           status,
           symbol,
         } = entry
-        const currentSymbol = symbol.slice(1)
+        const currentSymbol = mapSymbol(symbol.slice(1))
         // save new symbol to updateCoins list
         if (updateCoins.indexOf(currentSymbol) === -1) {
           updateCoins.push(currentSymbol)

--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -6,7 +6,13 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols,
+  getSymbolsURL,
+  getSymbolsFromUrlParam,
+  mapRequestSymbols,
+  mapSymbol,
+} from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -30,8 +36,8 @@ function getReqFCredit({
 }) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
-  if (targetSymbols.length > 0) {
-    params.symbol = formatRawSymbols(targetSymbols)
+  if (targetSymbols.length) {
+    params.symbol = formatRawSymbols(mapRequestSymbols(targetSymbols))
   }
   return makeFetchCall('getFundingCreditHistory', auth, params)
 }
@@ -42,7 +48,7 @@ function* fetchFCredit({ payload: symbol }) {
     const symbolsUrl = getSymbolsURL(targetSymbols)
     // set symbol from url
     if (symbol && symbol !== symbolsUrl) {
-      targetSymbols = getSymbolsFromUrlParam(symbol)
+      targetSymbols = getSymbolsFromUrlParam(symbol).map(mapSymbol)
       yield put(actions.setTargetSymbols(targetSymbols))
     }
     const auth = yield select(selectAuth)

--- a/src/state/fundingLoanHistory/reducer.js
+++ b/src/state/fundingLoanHistory/reducer.js
@@ -13,6 +13,7 @@ import {
   setSymbols,
   setTimeRange,
 } from 'state/reducers.helper'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -57,7 +58,7 @@ export function fundingLoanHistoryReducer(state = initialState, action) {
           status,
           symbol,
         } = entry
-        const currentSymbol = symbol.slice(1)
+        const currentSymbol = mapSymbol(symbol.slice(1))
         // save new symbol to updateCoins list
         if (updateCoins.indexOf(currentSymbol) === -1) {
           updateCoins.push(currentSymbol)

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -6,7 +6,9 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols, getSymbolsURL, getSymbolsFromUrlParam, mapRequestSymbols, mapSymbol,
+} from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -30,8 +32,8 @@ function getReqFLoan({
 }) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
-  if (targetSymbols.length > 0) {
-    params.symbol = formatRawSymbols(targetSymbols)
+  if (targetSymbols.length) {
+    params.symbol = formatRawSymbols(mapRequestSymbols(targetSymbols))
   }
   return makeFetchCall('getFundingLoanHistory', auth, params)
 }
@@ -42,7 +44,7 @@ function* fetchFLoan({ payload: symbol }) {
     const symbolsUrl = getSymbolsURL(targetSymbols)
     // set symbol from url
     if (symbol && symbol !== symbolsUrl) {
-      targetSymbols = getSymbolsFromUrlParam(symbol)
+      targetSymbols = getSymbolsFromUrlParam(symbol).map(mapSymbol)
       yield put(actions.setTargetSymbols(targetSymbols))
     }
     const auth = yield select(selectAuth)

--- a/src/state/fundingOfferHistory/reducer.js
+++ b/src/state/fundingOfferHistory/reducer.js
@@ -13,6 +13,7 @@ import {
   setSymbols,
   setTimeRange,
 } from 'state/reducers.helper'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -56,7 +57,7 @@ export function fundingOfferHistoryReducer(state = initialState, action) {
           symbol,
           type,
         } = entry
-        const currentSymbol = symbol.slice(1)
+        const currentSymbol = mapSymbol(symbol.slice(1))
         // save new symbol to updateCoins list
         if (updateCoins.indexOf(currentSymbol) === -1) {
           updateCoins.push(currentSymbol)

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -6,7 +6,13 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols,
+  getSymbolsURL,
+  getSymbolsFromUrlParam,
+  mapRequestSymbols,
+  mapSymbol,
+} from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -30,8 +36,8 @@ function getReqFOffer({
 }) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
-  if (targetSymbols.length > 0) {
-    params.symbol = formatRawSymbols(targetSymbols)
+  if (targetSymbols.length) {
+    params.symbol = formatRawSymbols(mapRequestSymbols(targetSymbols))
   }
   return makeFetchCall('getFundingOfferHistory', auth, params)
 }
@@ -42,7 +48,7 @@ function* fetchFOffer({ payload: symbol }) {
     const symbolsUrl = getSymbolsURL(targetSymbols)
     // set symbol from url
     if (symbol && symbol !== symbolsUrl) {
-      targetSymbols = getSymbolsFromUrlParam(symbol)
+      targetSymbols = getSymbolsFromUrlParam(symbol).map(mapSymbol)
       yield put(actions.setTargetSymbols(targetSymbols))
     }
     const auth = yield select(selectAuth)

--- a/src/state/fundingPayment/reducer.js
+++ b/src/state/fundingPayment/reducer.js
@@ -10,11 +10,13 @@ import {
   fetchPrev,
   getPageOffset,
   jumpPage,
+  mapDescription,
   removeSymbol,
   setQueryLimit,
   setSymbols,
   setTimeRange,
 } from 'state/reducers.helper'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -49,23 +51,22 @@ export function fpaymentReducer(state = initialState, action) {
           mts,
           wallet,
         } = entry
+        const mappedCurrency = mapSymbol(currency)
         // save new symbol to updateCoins list
-        if (updateCoins.indexOf(currency) === -1) {
-          updateCoins.push(currency)
+        if (updateCoins.indexOf(mappedCurrency) === -1) {
+          updateCoins.push(mappedCurrency)
         }
         // log smallest mts
-        if (nextPage === false
-          && (!smallestMts || smallestMts > mts)
-        ) {
+        if (nextPage === false && (!smallestMts || smallestMts > mts)) {
           smallestMts = mts
         }
         return {
           id,
-          currency,
+          currency: mappedCurrency,
           mts,
           amount,
           balance,
-          description,
+          description: mapDescription(description),
           wallet,
         }
       })

--- a/src/state/fundingPayment/saga.js
+++ b/src/state/fundingPayment/saga.js
@@ -10,7 +10,9 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import {
+  getSymbolsURL, getSymbolsFromUrlParam, mapRequestSymbols, mapSymbol,
+} from 'state/symbols/utils'
 import { getPageSize } from 'state/query/utils'
 import { frameworkCheck } from 'state/ui/saga'
 import { fetchNext } from 'state/sagas.helper'
@@ -30,8 +32,8 @@ function getReqLedgers({
   queryLimit,
 }) {
   const params = getTimeFrame(query, smallestMts)
-  if (targetSymbols.length > 0) {
-    params.symbol = targetSymbols
+  if (targetSymbols.length) {
+    params.symbol = mapRequestSymbols(targetSymbols)
   }
   if (queryLimit) {
     params.limit = queryLimit
@@ -54,7 +56,7 @@ function* fetchFPayment({ payload: symbol }) {
     const symbolsUrl = getSymbolsURL(targetSymbols)
     // set symbol from url
     if (symbol && symbol !== symbolsUrl) {
-      targetSymbols = getSymbolsFromUrlParam(symbol)
+      targetSymbols = getSymbolsFromUrlParam(symbol).map(mapSymbol)
       yield put(actions.setTargetSymbols(targetSymbols))
     }
     const auth = yield select(selectAuth)

--- a/src/state/ledgers/reducer.js
+++ b/src/state/ledgers/reducer.js
@@ -13,8 +13,10 @@ import {
   removeSymbol,
   setQueryLimit,
   setSymbols,
+  mapDescription,
   setTimeRange,
 } from 'state/reducers.helper'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -51,25 +53,24 @@ export function ledgersReducer(state = initialState, action) {
           mts,
           wallet,
         } = entry
+        const mappedCurrency = mapSymbol(currency)
         // save new symbol to updateCoins list
-        if (updateCoins.indexOf(currency) === -1) {
-          updateCoins.push(currency)
+        if (updateCoins.indexOf(mappedCurrency) === -1) {
+          updateCoins.push(mappedCurrency)
         }
         // log smallest mts
-        if (nextPage === false
-          && (!smallestMts || smallestMts > mts)
-        ) {
+        if (nextPage === false && (!smallestMts || smallestMts > mts)) {
           smallestMts = mts
         }
         return {
           id,
-          currency,
+          currency: mappedCurrency,
           mts,
           amount,
           amountUsd,
           balance,
           balanceUsd,
-          description,
+          description: mapDescription(description),
           wallet,
         }
       })

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -10,10 +10,11 @@ import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
-import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import {
+  getSymbolsURL, getSymbolsFromUrlParam, mapSymbol, mapRequestSymbols,
+} from 'state/symbols/utils'
 import { getPageSize } from 'state/query/utils'
 import { fetchNext } from 'state/sagas.helper'
-
 import { frameworkCheck } from 'state/ui/saga'
 
 import types from './constants'
@@ -31,8 +32,8 @@ function getReqLedgers({
   queryLimit,
 }) {
   const params = getTimeFrame(query, smallestMts)
-  if (targetSymbols.length > 0) {
-    params.symbol = targetSymbols
+  if (targetSymbols.length) {
+    params.symbol = mapRequestSymbols(targetSymbols)
   }
   if (queryLimit) {
     params.limit = queryLimit
@@ -52,7 +53,7 @@ function* fetchLedgers({ payload: symbol }) {
     const symbolsUrl = getSymbolsURL(targetSymbols)
     // set symbol from url
     if (symbol && symbol !== symbolsUrl) {
-      targetSymbols = getSymbolsFromUrlParam(symbol)
+      targetSymbols = getSymbolsFromUrlParam(symbol).map(mapSymbol)
       yield put(actions.setTargetSymbols(targetSymbols))
     }
     const auth = yield select(selectAuth)

--- a/src/state/movements/reducer.js
+++ b/src/state/movements/reducer.js
@@ -13,6 +13,7 @@ import {
   setSymbols,
   setTimeRange,
 } from 'state/reducers.helper'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -50,19 +51,18 @@ export function movementsReducer(state = initialState, action) {
           status,
           transactionId,
         } = entry
+        const mappedCurrency = mapSymbol(currency)
         // save new symbol to updateCoins list
-        if (updateCoins.indexOf(currency) === -1) {
-          updateCoins.push(currency)
+        if (updateCoins.indexOf(mappedCurrency) === -1) {
+          updateCoins.push(mappedCurrency)
         }
         // log smallest mts
-        if (nextPage === false
-          && (!smallestMts || smallestMts > mtsUpdated)
-        ) {
+        if (nextPage === false && (!smallestMts || smallestMts > mtsUpdated)) {
           smallestMts = mtsUpdated
         }
         return {
           id,
-          currency,
+          currency: mappedCurrency,
           currencyName,
           mtsStarted,
           mtsUpdated,

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -11,7 +11,9 @@ import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { getQueryLimit, getPageSize } from 'state/query/utils'
-import { getSymbolsURL, getSymbolsFromUrlParam } from 'state/symbols/utils'
+import {
+  getSymbolsURL, getSymbolsFromUrlParam, mapRequestSymbols, mapSymbol,
+} from 'state/symbols/utils'
 import { fetchNext } from 'state/sagas.helper'
 
 import types from './constants'
@@ -30,8 +32,8 @@ function getReqMovements({
 }) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
-  if (targetSymbols.length > 0) {
-    params.symbol = targetSymbols
+  if (targetSymbols.length) {
+    params.symbol = mapRequestSymbols(targetSymbols)
   }
   return makeFetchCall('getMovements', auth, params)
 }
@@ -42,7 +44,7 @@ function* fetchMovements({ payload: symbol }) {
     const symbolsUrl = getSymbolsURL(targetSymbols)
     // set symbol from url
     if (symbol && symbol !== symbolsUrl) {
-      targetSymbols = getSymbolsFromUrlParam(symbol)
+      targetSymbols = getSymbolsFromUrlParam(symbol).map(mapSymbol)
       yield put(actions.setTargetSymbols(targetSymbols))
     }
     const auth = yield select(selectAuth)

--- a/src/state/orders/reducer.js
+++ b/src/state/orders/reducer.js
@@ -1,5 +1,7 @@
 // https://docs.bitfinex.com/v2/reference#orders-history
-import { formatInternalSymbol, formatSymbolToPair } from 'state/symbols/utils'
+import {
+  formatInternalSymbol, formatSymbolToPair, mapSymbol, mapPair,
+} from 'state/symbols/utils'
 import baseTypes from 'state/base/constants'
 import queryTypes from 'state/query/constants'
 import authTypes from 'state/auth/constants'
@@ -62,22 +64,20 @@ export function ordersReducer(state = initialState, action) {
           type,
           typePrev,
         } = entry
-        const internalPair = formatInternalSymbol(symbol)
+        const internalPair = mapPair(formatInternalSymbol(symbol))
         // save new pair to updatePairs list
         if (updatePairs.indexOf(internalPair) === -1) {
           updatePairs.push(internalPair)
         }
         // log smallest mts
-        if (nextPage === false
-          && (!smallestMts || smallestMts > mtsUpdate)
-        ) {
+        if (nextPage === false && (!smallestMts || smallestMts > mtsUpdate)) {
           smallestMts = mtsUpdate
         }
         return {
           id,
           gid,
           cid,
-          pair: formatSymbolToPair(symbol),
+          pair: formatSymbolToPair(symbol).split('/').map(mapSymbol).join('/'),
           mtsCreate,
           mtsUpdate,
           amount,

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -6,7 +6,9 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getPairsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols, getSymbolsURL, getPairsFromUrlParam, mapPair, mapRequestPairs,
+} from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -29,8 +31,8 @@ function getReqOrders({
   queryLimit,
 }) {
   const params = getTimeFrame(query, smallestMts)
-  if (targetPairs.length > 0) {
-    params.symbol = formatRawSymbols(targetPairs)
+  if (targetPairs.length) {
+    params.symbol = formatRawSymbols(mapRequestPairs(targetPairs))
   }
   if (queryLimit) {
     params.limit = queryLimit
@@ -44,7 +46,7 @@ function* fetchOrders({ payload: pair }) {
     const pairsUrl = getSymbolsURL(targetPairs)
     // set pair from url
     if (pair && pair !== pairsUrl) {
-      targetPairs = getPairsFromUrlParam(pair)
+      targetPairs = getPairsFromUrlParam(pair).map(mapPair)
       yield put(actions.setTargetPairs(targetPairs))
     }
     const auth = yield select(selectAuth)

--- a/src/state/positions/reducer.js
+++ b/src/state/positions/reducer.js
@@ -1,5 +1,7 @@
 // data format https://github.com/bitfinexcom/bfx-api-node-models/blob/master/lib/position_hist.js
-import { formatInternalSymbol, formatSymbolToPair } from 'state/symbols/utils'
+import {
+  formatInternalSymbol, formatSymbolToPair, mapSymbol, mapPair,
+} from 'state/symbols/utils'
 import queryTypes from 'state/query/constants'
 import authTypes from 'state/auth/constants'
 import {
@@ -50,7 +52,7 @@ export function positionsReducer(state = initialState, action) {
           status,
           symbol,
         } = entry
-        const internalPair = formatInternalSymbol(symbol)
+        const internalPair = mapPair(formatInternalSymbol(symbol))
         // save new pair to updatePairs list
         if (updatePairs.indexOf(internalPair) === -1) {
           updatePairs.push(internalPair)
@@ -63,7 +65,7 @@ export function positionsReducer(state = initialState, action) {
         }
         return {
           id,
-          pair: formatSymbolToPair(symbol),
+          pair: formatSymbolToPair(symbol).split('/').map(mapSymbol).join('/'),
           amount,
           leverage,
           marginFunding,

--- a/src/state/positions/saga.js
+++ b/src/state/positions/saga.js
@@ -8,7 +8,9 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getPairsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols, getSymbolsURL, getPairsFromUrlParam, mapPair, mapRequestPairs,
+} from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -32,8 +34,8 @@ function getReqPositions({
 }) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
-  if (targetPairs.length > 0) {
-    params.symbol = formatRawSymbols(targetPairs)
+  if (targetPairs.length) {
+    params.symbol = formatRawSymbols(mapRequestPairs(targetPairs))
   }
   return makeFetchCall('getPositionsHistory', auth, params)
 }
@@ -44,7 +46,7 @@ function* fetchPositions({ payload: pair }) {
     const pairsUrl = getSymbolsURL(targetPairs)
     // set pair from url
     if (pair && pair !== pairsUrl) {
-      targetPairs = getPairsFromUrlParam(pair)
+      targetPairs = getPairsFromUrlParam(pair).map(mapPair)
       yield put(actions.setTargetPairs(targetPairs))
     }
     const auth = yield select(selectAuth)

--- a/src/state/positionsActive/reducer.js
+++ b/src/state/positionsActive/reducer.js
@@ -1,5 +1,7 @@
 // data format https://github.com/bitfinexcom/bfx-api-node-models/blob/master/lib/position_hist.js
-import { formatInternalSymbol, formatSymbolToPair } from 'state/symbols/utils'
+import {
+  formatInternalSymbol, formatSymbolToPair, mapSymbol, mapPair,
+} from 'state/symbols/utils'
 import queryTypes from 'state/query/constants'
 import authTypes from 'state/auth/constants'
 import {
@@ -53,7 +55,7 @@ export function positionsActiveReducer(state = initialState, action) {
           status,
           symbol,
         } = entry
-        const internalPair = formatInternalSymbol(symbol)
+        const internalPair = mapPair(formatInternalSymbol(symbol))
         // save new pair to updatePairs list
         if (updatePairs.indexOf(internalPair) === -1) {
           updatePairs.push(internalPair)
@@ -64,7 +66,7 @@ export function positionsActiveReducer(state = initialState, action) {
         }
         return {
           id,
-          pair: formatSymbolToPair(symbol),
+          pair: formatSymbolToPair(symbol).split('/').map(mapSymbol).join('/'),
           amount,
           basesPrice,
           leverage,

--- a/src/state/positionsActive/saga.js
+++ b/src/state/positionsActive/saga.js
@@ -7,7 +7,6 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { getSymbolsURL, getPairsFromUrlParam } from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -16,7 +15,7 @@ import { getQueryLimit, getPageSize } from 'state/query/utils'
 
 import types from './constants'
 import actions from './actions'
-import { getActivePositions, getTargetPairs } from './selectors'
+import { getActivePositions } from './selectors'
 
 const TYPE = queryTypes.MENU_POSITIONS_ACTIVE
 const LIMIT = getQueryLimit(TYPE)
@@ -26,23 +25,10 @@ function getReqPositions({ auth }) {
   return makeFetchCall('getActivePositions', auth)
 }
 
-function* fetchPositions({ payload: pair }) {
+function* fetchPositions() {
   try {
-    let targetPairs = yield select(getTargetPairs)
-    const pairsUrl = getSymbolsURL(targetPairs)
-    // set pair from url
-    if (pair && pair !== pairsUrl) {
-      targetPairs = getPairsFromUrlParam(pair)
-      yield put(actions.setTargetPairs(targetPairs))
-    }
     const auth = yield select(selectAuth)
-    const query = yield select(getQuery)
-    const { result, error } = yield call(getReqPositions, {
-      smallestMts: 0,
-      auth,
-      query,
-      targetPairs,
-    })
+    const { result, error } = yield call(getReqPositions, { auth })
     yield put(actions.updateAPositions(result, LIMIT, PAGE_SIZE))
     if (error) {
       yield put(actions.fetchFail({

--- a/src/state/publicFunding/reducer.js
+++ b/src/state/publicFunding/reducer.js
@@ -41,9 +41,7 @@ export function publicFundingReducer(state = initialState, action) {
           rate,
         } = entry
         // log smallest mts
-        if (nextPage === false
-          && (!smallestMts || smallestMts > mts)
-        ) {
+        if (nextPage === false && (!smallestMts || smallestMts > mts)) {
           smallestMts = mts
         }
         return {

--- a/src/state/publicFunding/saga.js
+++ b/src/state/publicFunding/saga.js
@@ -6,7 +6,7 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols } from 'state/symbols/utils'
+import { formatRawSymbols, mapRequestSymbols, mapSymbol } from 'state/symbols/utils'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -31,19 +31,18 @@ function getReqPublicFunding({
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetSymbol) {
-    params.symbol = formatRawSymbols(targetSymbol)
+    params.symbol = formatRawSymbols(mapRequestSymbols(targetSymbol, true))
   }
   return makeFetchCall('getPublicTrades', auth, params)
 }
 
 function* fetchPublicFunding({ payload: symbol }) {
   try {
-    const urlSymbol = symbol && symbol.toLowerCase()
     let targetSymbol = yield select(getTargetSymbol)
     // set symbol from url
-    if (urlSymbol && urlSymbol !== targetSymbol) {
-      yield put(actions.setTargetSymbol(urlSymbol))
-      targetSymbol = urlSymbol
+    if (symbol && symbol !== targetSymbol) {
+      yield put(actions.setTargetSymbol(mapSymbol(symbol)))
+      targetSymbol = symbol
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)

--- a/src/state/publicTrades/reducer.js
+++ b/src/state/publicTrades/reducer.js
@@ -9,12 +9,13 @@ import {
   getPageOffset,
   jumpPage,
 } from 'state/reducers.helper'
+import { mapPair } from 'state/symbols/utils'
 
 import types from './constants'
 
 const initialState = {
   ...baseState,
-  targetPair: 'BTCUSD',
+  targetPair: mapPair('BTCUSD'),
 }
 
 const TYPE = queryTypes.MENU_PUBLIC_TRADES

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -6,7 +6,7 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols } from 'state/symbols/utils'
+import { formatRawSymbols, mapRequestPairs } from 'state/symbols/utils'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -31,19 +31,18 @@ function getReqPublicTrades({
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
   if (targetPair) {
-    params.symbol = formatRawSymbols(targetPair)
+    params.symbol = formatRawSymbols(mapRequestPairs(targetPair, true))
   }
   return makeFetchCall('getPublicTrades', auth, params)
 }
 
 function* fetchPublicTrades({ payload: pair }) {
   try {
-    const urlPair = pair && pair.toLowerCase()
     let targetPair = yield select(getTargetPair)
     // set pair from url
-    if (urlPair && urlPair !== targetPair) {
-      yield put(actions.setTargetPair(urlPair))
-      targetPair = urlPair
+    if (pair && pair !== targetPair) {
+      yield put(actions.setTargetPair(pair))
+      targetPair = pair
     }
     const auth = yield select(selectAuth)
     const query = yield select(getQuery)

--- a/src/state/reducers.helper.js
+++ b/src/state/reducers.helper.js
@@ -1,3 +1,4 @@
+import symbolMap from 'state/symbols/map'
 import queryTypes from 'state/query/constants'
 import { getFilterType, getPageSize } from 'state/query/utils'
 
@@ -141,6 +142,12 @@ export function setSymbols(state, payload, initialState) {
   }
 }
 
+// 'BAB from wallet exchange' -> 'BCH from wallet exchange'
+export const mapDescription = (description) => {
+  const mapKeys = Object.keys(symbolMap)
+  return mapKeys.reduce((desc, symbol) => desc.replace(new RegExp(symbol, 'g'), symbolMap[symbol]), description)
+}
+
 /* pairs */
 export function addPair(state, payload, initialState) {
   return state.targetPairs.includes(payload)
@@ -196,5 +203,6 @@ export default {
   removeSymbol,
   setPairs,
   setSymbols,
+  mapDescription,
   setTimeRange,
 }

--- a/src/state/symbols/map.js
+++ b/src/state/symbols/map.js
@@ -1,0 +1,13 @@
+export const getSymbolMap = () => {
+  const mapping = localStorage.getItem('symbolMap')
+  return mapping ? JSON.parse(mapping) : {}
+}
+
+const symbolMap = getSymbolMap() || {}
+
+export const setSymbolMap = (map) => {
+  localStorage.setItem('symbolMap', JSON.stringify(map))
+  Object.assign(symbolMap, map)
+}
+
+export default symbolMap

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -1,6 +1,10 @@
+import _castArray from 'lodash/castArray'
+
 import authTypes from 'state/auth/constants'
+import { mapPair } from 'state/symbols/utils'
 
 import types from './constants'
+import { setSymbolMap } from './map'
 
 const initialState = {
   coins: [], // symbol
@@ -17,18 +21,34 @@ export function symbolsReducer(state = initialState, action) {
       const coins = []
       const dict = {}
       const explorersDict = {}
-      currencies.forEach(({ id, name, explorer }) => {
+      const symbolMapping = {}
+      currencies.forEach((currency) => {
+        const {
+          id, name, explorer, symbol,
+        } = currency
         const cid = id.toUpperCase()
-        dict[cid] = name
+        if (id === 'BAB') { // skip duplicate BAB/BCH
+          symbolMapping[cid] = 'BCH'
+          return
+        }
+        if (symbol) {
+          symbolMapping[cid] = symbol
+          explorersDict[symbol] = explorer
+          dict[symbol] = name
+          coins.push(symbol)
+          return
+        }
         explorersDict[cid] = explorer
+        dict[cid] = name
         coins.push(cid)
       })
+      setSymbolMap(symbolMapping)
       return {
         ...state,
         coins: coins.sort(),
         currencies: dict,
         explorers: explorersDict,
-        pairs: (pairs && pairs.sort()) || [],
+        pairs: _castArray(pairs).map(mapPair).sort(),
       }
     }
     case authTypes.LOGOUT:

--- a/src/state/symbols/saga.js
+++ b/src/state/symbols/saga.js
@@ -4,7 +4,6 @@ import {
   select,
   takeLatest,
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 
 import { makeFetchCall } from 'state/utils'
 import { updateErrorStatus } from 'state/status/actions'
@@ -24,9 +23,7 @@ function* fetchSymbols({ payload: success }) {
 
   try {
     const auth = yield select(selectAuth)
-    yield call(delay, 1000)
-    const allsymbols = yield call(getSymbols, auth)
-    const { result, error } = allsymbols
+    const { result, error } = yield call(getSymbols, auth)
     if (result) {
       yield put(actions.updateSymbols(result))
     }

--- a/src/state/symbols/selectors.js
+++ b/src/state/symbols/selectors.js
@@ -4,10 +4,12 @@ export const getCoins = state => getSymbols(state).coins
 export const getCurrencies = state => getSymbols(state).currencies
 export const getExplorers = state => getSymbols(state).explorers || {}
 export const getPairs = state => getSymbols(state).pairs
+export const getSymbolMapping = state => getSymbols(state).symbolMapping
 
 export default {
   getCoins,
   getCurrencies,
   getExplorers,
   getPairs,
+  getSymbolMapping,
 }

--- a/src/state/tickers/reducer.js
+++ b/src/state/tickers/reducer.js
@@ -1,5 +1,7 @@
 // https://docs.bitfinex.com/v2/reference#TICKERS-history
-import { formatInternalSymbol, formatSymbolToPair } from 'state/symbols/utils'
+import {
+  formatInternalSymbol, formatSymbolToPair, mapSymbol, mapPair,
+} from 'state/symbols/utils'
 import queryTypes from 'state/query/constants'
 import authTypes from 'state/auth/constants'
 import {
@@ -19,7 +21,7 @@ import types from './constants'
 
 const initialState = {
   ...basePairState,
-  targetPairs: ['btcusd'],
+  targetPairs: [mapPair('BTCUSD')],
 }
 
 const TYPE = queryTypes.MENU_TICKERS
@@ -46,7 +48,7 @@ export function TickersReducer(state = initialState, action) {
           mtsUpdate,
           symbol,
         } = entry
-        const internalPair = formatInternalSymbol(symbol)
+        const internalPair = mapPair(formatInternalSymbol(symbol))
         // save new pair to updatePairs list
         if (updatePairs.indexOf(internalPair) === -1) {
           updatePairs.push(internalPair)
@@ -61,7 +63,7 @@ export function TickersReducer(state = initialState, action) {
           ask,
           bid,
           mtsUpdate,
-          pair: formatSymbolToPair(symbol),
+          pair: formatSymbolToPair(symbol).split('/').map(mapSymbol).join('/'),
         }
       })
       const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)

--- a/src/state/tickers/saga.js
+++ b/src/state/tickers/saga.js
@@ -6,7 +6,9 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getPairsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols, getSymbolsURL, getPairsFromUrlParam, mapPair, mapRequestPairs,
+} from 'state/symbols/utils'
 import { selectAuth } from 'state/auth/selectors'
 import { getQuery, getTimeFrame } from 'state/query/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -30,8 +32,8 @@ function getReqTickers({
 }) {
   const params = getTimeFrame(query, smallestMts)
   params.limit = LIMIT
-  if (targetPairs.length > 0) {
-    params.symbol = formatRawSymbols(targetPairs)
+  if (targetPairs.length) {
+    params.symbol = formatRawSymbols(mapRequestPairs(targetPairs))
   }
   return makeFetchCall('getTickersHistory', auth, params)
 }
@@ -42,7 +44,7 @@ function* fetchTickers({ payload: pair }) {
     const pairsUrl = getSymbolsURL(targetPairs)
     // set pair from url
     if (pair && pair !== pairsUrl) {
-      targetPairs = getPairsFromUrlParam(pair)
+      targetPairs = getPairsFromUrlParam(pair).map(mapPair)
       yield put(actions.setTargetPairs(targetPairs))
     }
     const auth = yield select(selectAuth)

--- a/src/state/trades/reducer.js
+++ b/src/state/trades/reducer.js
@@ -1,5 +1,7 @@
 // https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist
-import { formatInternalSymbol, formatSymbolToPair } from 'state/symbols/utils'
+import {
+  formatInternalSymbol, formatSymbolToPair, mapSymbol, mapPair,
+} from 'state/symbols/utils'
 import baseTypes from 'state/base/constants'
 import queryTypes from 'state/query/constants'
 import authTypes from 'state/auth/constants'
@@ -48,20 +50,18 @@ export function tradesReducer(state = initialState, action) {
           orderPrice,
           orderType,
         } = entry
-        const internalPair = formatInternalSymbol(symbol)
+        const internalPair = mapPair(formatInternalSymbol(symbol))
         // save new pair to updatePairs list
         if (updatePairs.indexOf(internalPair) === -1) {
           updatePairs.push(internalPair)
         }
         // log smallest mts
-        if (nextPage === false
-          && (!smallestMts || smallestMts > mtsCreate)
-        ) {
+        if (nextPage === false && (!smallestMts || smallestMts > mtsCreate)) {
           smallestMts = mtsCreate
         }
         return {
           id,
-          pair: formatSymbolToPair(symbol),
+          pair: formatSymbolToPair(symbol).split('/').map(mapSymbol).join('/'),
           mtsCreate,
           orderID,
           execAmount,
@@ -70,7 +70,7 @@ export function tradesReducer(state = initialState, action) {
           orderPrice,
           maker,
           fee: Math.abs(fee),
-          feeCurrency,
+          feeCurrency: mapSymbol(feeCurrency),
         }
       })
       const [offset, pageOffset] = getPageOffset(state, entries, limit, pageSize)

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -6,7 +6,9 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, getSymbolsURL, getPairsFromUrlParam } from 'state/symbols/utils'
+import {
+  formatRawSymbols, getSymbolsURL, getPairsFromUrlParam, mapPair, mapRequestPairs,
+} from 'state/symbols/utils'
 import { getQuery, getTargetQueryLimit, getTimeFrame } from 'state/query/selectors'
 import { selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus } from 'state/status/actions'
@@ -29,8 +31,8 @@ function getReqTrades({
   queryLimit,
 }) {
   const params = getTimeFrame(query, smallestMts)
-  if (targetPairs.length > 0) {
-    params.symbol = formatRawSymbols(targetPairs)
+  if (targetPairs.length) {
+    params.symbol = formatRawSymbols(mapRequestPairs(targetPairs))
   }
   if (queryLimit) {
     params.limit = queryLimit
@@ -44,7 +46,7 @@ function* fetchTrades({ payload: pair }) {
     const pairsUrl = getSymbolsURL(targetPairs)
     // set pair from url
     if (pair && pair !== pairsUrl) {
-      targetPairs = getPairsFromUrlParam(pair)
+      targetPairs = getPairsFromUrlParam(pair).map(mapPair)
       yield put(actions.setTargetPairs(targetPairs))
     }
     const auth = yield select(selectAuth)

--- a/src/state/wallets/reducer.js
+++ b/src/state/wallets/reducer.js
@@ -1,5 +1,6 @@
 // https://docs.bitfinex.com/v2/reference#rest-auth-wallets
 import authTypes from 'state/auth/constants'
+import { mapSymbol } from 'state/symbols/utils'
 
 import types from './constants'
 
@@ -28,7 +29,7 @@ export function walletsReducer(state = initialState, action) {
         } = entry
         return {
           type,
-          currency,
+          currency: mapSymbol(currency),
           balance,
           balanceUsd,
         }

--- a/src/ui/MultiPairSelector/MultiPairSelector.js
+++ b/src/ui/MultiPairSelector/MultiPairSelector.js
@@ -11,6 +11,32 @@ import { formatPair, parsePairTag } from 'state/symbols/utils'
 import { propTypes, defaultProps } from './MultiPairSelector.props'
 
 class MultiPairSelector extends PureComponent {
+  filterPair = (query, pair) => pair.indexOf(query.replace('/', '').toUpperCase()) >= 0
+
+  renderTag = pair => formatPair(pair)
+
+  renderPair = (pair, { modifiers }) => {
+    if (!modifiers.matchesPredicate) {
+      return null
+    }
+    const { currentFilters, existingPairs, togglePair } = this.props
+    const isCurrent = currentFilters.map(currentPair => currentPair.toUpperCase()).includes(pair)
+    const className = existingPairs.includes(pair) && !isCurrent
+      ? 'bitfinex-queried-symbol' : ''
+
+    return (
+      <MenuItem
+        className={className}
+        active={modifiers.active}
+        intent={isCurrent ? Intent.PRIMARY : Intent.NONE}
+        disabled={modifiers.disabled}
+        key={pair}
+        onClick={() => togglePair(pair)}
+        text={formatPair(pair)}
+      />
+    )
+  }
+
   render() {
     const {
       currentFilters,
@@ -20,42 +46,21 @@ class MultiPairSelector extends PureComponent {
       t,
     } = this.props
 
-    const renderPair = (pair, { modifiers }) => {
-      if (!modifiers.matchesPredicate) {
-        return null
-      }
-      const isCurrent = currentFilters.map(currentPair => currentPair.toUpperCase()).includes(pair)
-      const className = existingPairs.includes(pair) && !isCurrent
-        ? 'bitfinex-queried-symbol' : ''
-
-      return (
-        <MenuItem
-          className={className}
-          active={modifiers.active}
-          intent={isCurrent ? Intent.PRIMARY : Intent.NONE}
-          disabled={modifiers.disabled}
-          key={pair}
-          onClick={() => togglePair(pair)}
-          text={formatPair(pair)}
-        />
-      )
-    }
-
-    const filterPair = (query, pair) => pair.toLowerCase().indexOf(query.replace('/', '').toLowerCase()) >= 0
-    const renderTag = pair => formatPair(pair)
-
     return (
       <MultiSelect
         className='bitfinex-multi-select'
         disabled={pairs.length === 0}
         placeholder={t('selector.filter.pair')}
         items={pairs || existingPairs}
-        itemRenderer={renderPair}
-        itemPredicate={filterPair}
+        itemRenderer={this.renderPair}
+        itemPredicate={this.filterPair}
         onItemSelect={togglePair}
         popoverProps={{ minimal: true }}
-        tagInputProps={{ tagProps: { minimal: true }, onRemove: pair => togglePair(parsePairTag(pair).toUpperCase()) }}
-        tagRenderer={renderTag}
+        tagInputProps={{
+          tagProps: { minimal: true },
+          onRemove: pair => togglePair(parsePairTag(pair)),
+        }}
+        tagRenderer={this.renderTag}
         selectedItems={currentFilters.map(pair => pair.toLowerCase())}
         resetOnSelect
       />

--- a/src/ui/MultiSymbolSelector/MultiSymbolSelector.js
+++ b/src/ui/MultiSymbolSelector/MultiSymbolSelector.js
@@ -9,53 +9,56 @@ import { MultiSelect } from '@blueprintjs/select'
 import { propTypes, defaultProps } from './MultiSymbolSelector.props'
 
 class MultiSymbolSelector extends PureComponent {
+  filterSymbol = (query, coin) => coin.indexOf(query.toUpperCase()) >= 0
+
+  renderSymbol = (symbol, { modifiers }) => {
+    if (!modifiers.matchesPredicate) {
+      return null
+    }
+    const {
+      currencies, currentFilters, existingCoins, toggleSymbol,
+    } = this.props
+
+    const isCurrent = currentFilters.includes(symbol)
+    const className = existingCoins.includes(symbol) && !isCurrent
+      ? 'bitfinex-queried-symbol'
+      : ''
+
+    return (
+      <MenuItem
+        className={className}
+        active={modifiers.active}
+        intent={isCurrent ? Intent.PRIMARY : Intent.NONE}
+        disabled={modifiers.disabled}
+        key={symbol}
+        onClick={() => toggleSymbol(symbol)}
+        text={symbol}
+        label={currencies[symbol]}
+      />
+    )
+  }
+
   render() {
     const {
       coins,
-      currencies,
       currentFilters,
       existingCoins,
       toggleSymbol,
       t,
     } = this.props
 
-    const renderSymbol = (symbol, { modifiers }) => {
-      if (!modifiers.matchesPredicate) {
-        return null
-      }
-      const isCurrent = currentFilters.includes(symbol)
-      const className = existingCoins.includes(symbol) && !isCurrent
-        ? 'bitfinex-queried-symbol' : ''
-
-      return (
-        <MenuItem
-          className={className}
-          active={modifiers.active}
-          intent={isCurrent ? Intent.PRIMARY : Intent.NONE}
-          disabled={modifiers.disabled}
-          key={symbol}
-          onClick={() => toggleSymbol(symbol)}
-          text={symbol}
-          label={currencies[symbol]}
-        />
-      )
-    }
-
-    const filterSymbol = (query, coin) => coin.toLowerCase().indexOf(query.toLowerCase()) >= 0
-    const renderTag = coin => coin.toUpperCase()
-
     return (
       <MultiSelect
         className='bitfinex-multi-select'
-        disabled={coins.length === 0}
+        disabled={!coins.length}
         placeholder={t('selector.filter.symbol')}
         items={coins || existingCoins}
-        itemRenderer={renderSymbol}
-        itemPredicate={filterSymbol}
+        itemRenderer={this.renderSymbol}
+        itemPredicate={this.filterSymbol}
         onItemSelect={toggleSymbol}
         popoverProps={{ minimal: true }}
         tagInputProps={{ tagProps: { minimal: true }, onRemove: toggleSymbol }}
-        tagRenderer={renderTag}
+        tagRenderer={coin => coin}
         selectedItems={currentFilters}
         resetOnSelect
       />

--- a/src/ui/PairSelector.js
+++ b/src/ui/PairSelector.js
@@ -10,44 +10,41 @@ import { Select } from '@blueprintjs/select'
 import { formatPair } from 'state/symbols/utils'
 
 class PairSelector extends PureComponent {
-  render() {
-    const {
-      currentPair,
-      existingPairs,
-      onPairSelect,
-      pairs,
-      wildCard,
-    } = this.props
+  filterPair = (query, pair) => pair.indexOf(query.replace('/', '').toUpperCase()) >= 0
 
-    const renderPair = (pair, { modifiers }) => {
-      if (!modifiers.matchesPredicate) {
-        return null
-      }
-      const isCurrent = currentPair === pair
-      const className = (wildCard.includes(pair) || existingPairs.includes(pair)) && !isCurrent
-        ? 'bitfinex-queried-symbol' : ''
-
-      return (
-        <MenuItem
-          className={className}
-          active={modifiers.active}
-          intent={isCurrent ? Intent.PRIMARY : Intent.NONE}
-          disabled={modifiers.disabled}
-          key={pair}
-          onClick={() => onPairSelect(pair)}
-          text={formatPair(pair)}
-        />
-      )
+  renderPair = (pair, { modifiers }) => {
+    if (!modifiers.matchesPredicate) {
+      return null
     }
+    const {
+      currentPair, existingPairs, wildCard, onPairSelect,
+    } = this.props
+    const isCurrent = currentPair === pair
+    const className = (wildCard.includes(pair) || existingPairs.includes(pair)) && !isCurrent
+      ? 'bitfinex-queried-symbol' : ''
 
-    const filterPair = (query, pair) => pair.toLowerCase().indexOf(query.replace('/', '').toLowerCase()) >= 0
+    return (
+      <MenuItem
+        className={className}
+        active={modifiers.active}
+        intent={isCurrent ? Intent.PRIMARY : Intent.NONE}
+        disabled={modifiers.disabled}
+        key={pair}
+        onClick={() => onPairSelect(pair)}
+        text={formatPair(pair)}
+      />
+    )
+  }
+
+  render() {
+    const { currentPair, onPairSelect, pairs } = this.props
 
     return (
       <Select
         disabled={!pairs.length}
         items={pairs}
-        itemRenderer={renderPair}
-        itemPredicate={filterPair}
+        itemRenderer={this.renderPair}
+        itemPredicate={this.filterPair}
         onItemSelect={onPairSelect}
       >
         <Button

--- a/src/var/config.js
+++ b/src/var/config.js
@@ -30,7 +30,7 @@ const platforms = {
     KEY_URL: 'https://www.bitfinex.com/api',
     HOME_URL: 'http://localhost:3000',
     showAuthPage: true,
-    showSyncMode: false,
+    showSyncMode: true,
     showFrameworkMode: false,
     autoAuth: true,
   },

--- a/src/var/config.js
+++ b/src/var/config.js
@@ -30,7 +30,7 @@ const platforms = {
     KEY_URL: 'https://www.bitfinex.com/api',
     HOME_URL: 'http://localhost:3000',
     showAuthPage: true,
-    showSyncMode: true,
+    showSyncMode: false,
     showFrameworkMode: false,
     autoAuth: true,
   },


### PR DESCRIPTION
Adds mapping for currency and pairs
`BAB` symbol is removed from currencies
Requests with `BAB` (mapped 'BCH') are sent with both symbols unless endpoint expects a string (public trades/funding), in which case it's only `BAB`