### PR TITLE
Faster symbols loading

### DIFF
--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -49,6 +49,8 @@ function* checkAuth() {
     const { result, error } = yield call(getAuth, auth)
 
     if (result) {
+      yield put(fetchSymbols())
+
       if (platform.showFrameworkMode) {
         if (!WS.isConnected) {
           WS.connect()
@@ -77,7 +79,6 @@ function* checkAuth() {
           yield put(setOwnerEmail(wsAuth))
         }
       } else {
-        yield put(fetchSymbols())
         yield call(fetchEmail)
       }
 

--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -13,9 +13,7 @@ import { makeFetchCall } from 'state/utils'
 import { setSyncState } from 'state/base/actions'
 import { getSyncState } from 'state/base/selectors'
 import { selectAuth } from 'state/auth/selectors'
-import { getSymbolsFetchStatus } from 'state/symbols/selectors'
 import { updateErrorStatus, updateStatus } from 'state/status/actions'
-import { fetchSymbols } from 'state/symbols/actions'
 import {
   mapRequestSymbols, formatInternalSymbol, formatRawSymbols, formatSymbolToPair,
   isPair, isSymbol, mapRequestPairs, mapSymbol,
@@ -255,7 +253,6 @@ function* initSync() {
     }
   }
 
-  yield put(fetchSymbols())
   yield call(getSyncPref)
 }
 
@@ -281,11 +278,6 @@ function* requestsRedirectUpdate({ payload }) {
     }
   } else {
     yield put(actions.forceQueryFromDb())
-
-    const areSymbolsFetched = select(getSymbolsFetchStatus)
-    if (!areSymbolsFetched) {
-      yield put(fetchSymbols()) // if user synced after starting offline while in online mode
-    }
   }
 }
 


### PR DESCRIPTION
Adds faster symbols loading, so the request is sent before any request for data.
Fixes mapping in cases where data was loaded before symbols.
Dependency: https://github.com/bitfinexcom/bfx-reports-framework/pull/52