### PR TITLE
Sync data persist

### DIFF
--- a/src/state/reducers.js
+++ b/src/state/reducers.js
@@ -33,7 +33,7 @@ import uiReducer from './ui/reducer'
 import walletsReducer from './wallets/reducer'
 import winLossReducer from './winLoss/reducer'
 
-const PERSIST_WHITELIST = ['base']
+const PERSIST_WHITELIST = ['base', 'sync']
 
 const PERSIST_VERSION = 0 // starts with -1
 const PERSIST_DEBUG = false


### PR DESCRIPTION
Enables persist of sync config for `public trades`, `public funding` and `tickers`, which avoids blink of preferences section