### PR TITLE
Inactive symbols, rate filters, data copying

### DIFF
--- a/src/components/ConcentrationRisk/ConcentrationRisk.columns.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.columns.js
@@ -4,7 +4,7 @@ import { Cell } from '@blueprintjs/table'
 import { fixedFloat } from 'ui/utils'
 
 export default function getColumns(props) {
-  const { data, t } = props
+  const { data } = props
 
   return [
     {
@@ -37,10 +37,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { balanceUsd } = data[rowIndex]
-        return `${fixedFloat(balanceUsd)} ${t('column.usd')}`
-      },
+      copyText: rowIndex => fixedFloat(data[rowIndex].balanceUsd),
     },
     {
       id: 'percent',
@@ -58,10 +55,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { percent } = data[rowIndex]
-        return fixedFloat(percent)
-      },
+      copyText: rowIndex => fixedFloat(data[rowIndex].percent),
     },
   ]
 }

--- a/src/components/ConcentrationRisk/ConcentrationRisk.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.js
@@ -106,10 +106,7 @@ class ConcentrationRisk extends PureComponent {
 
     const { tableData, chartData } = this.parseData(filteredData)
     const numRows = tableData.length
-    const tableColumns = getColumns({
-      data: tableData,
-      t,
-    })
+    const tableColumns = getColumns({ data: tableData })
 
     let showContent
     if (!dataReceived && pageLoading) {

--- a/src/components/Derivatives/Derivatives.columns.js
+++ b/src/components/Derivatives/Derivatives.columns.js
@@ -46,7 +46,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].price,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].price),
     },
     {
       id: 'priceSpot',
@@ -64,7 +64,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].priceSpot,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].priceSpot),
     },
     {
       id: 'fundBal',
@@ -82,7 +82,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].fundBal,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].fundBal),
     },
     {
       id: 'fundingAccrued',
@@ -100,7 +100,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].fundingAccrued,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].fundingAccrued),
     },
     {
       id: 'fundingStep',

--- a/src/components/FundingCreditHistory/FundingCreditHistory.columns.js
+++ b/src/components/FundingCreditHistory/FundingCreditHistory.columns.js
@@ -74,7 +74,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amount,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     {
       id: 'status',
@@ -119,7 +119,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].rate,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].rate),
     },
     {
       id: 'period',

--- a/src/components/FundingLoanHistory/FundingLoanHistory.columns.js
+++ b/src/components/FundingLoanHistory/FundingLoanHistory.columns.js
@@ -74,7 +74,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amount,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     {
       id: 'status',
@@ -120,7 +120,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].rate,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].rate),
     },
     {
       id: 'period',
@@ -137,8 +137,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => `${filteredData[rowIndex].period} `
-        + `${t('column.days')}`,
+      copyText: rowIndex => `${filteredData[rowIndex].period} ${t('column.days')}`,
     },
     {
       id: 'mtsOpening',

--- a/src/components/FundingOfferHistory/FundingOfferHistory.columns.js
+++ b/src/components/FundingOfferHistory/FundingOfferHistory.columns.js
@@ -60,7 +60,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amountOrig,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amountOrig),
     },
     {
       id: 'amountExecuted',
@@ -77,7 +77,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amountExecuted,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amountExecuted),
     },
     {
       id: 'type',
@@ -123,7 +123,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].rate,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].rate),
     },
     {
       id: 'period',

--- a/src/components/Ledgers/Ledgers.columns.js
+++ b/src/components/Ledgers/Ledgers.columns.js
@@ -76,10 +76,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { amount, currency } = filteredData[rowIndex]
-        return `${amount} ${currency}`
-      },
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     ...insertIf(platform.showFrameworkMode, (
       {
@@ -98,10 +95,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: (rowIndex) => {
-          const { amountUsd } = filteredData[rowIndex]
-          return `${fixedFloat(amountUsd)} ${t('column.usd')}`
-        },
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].amountUsd),
       }
     )),
     {
@@ -121,10 +115,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { balance, currency } = filteredData[rowIndex]
-        return `${balance} ${currency}`
-      },
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].balance),
     },
     ...insertIf(platform.showFrameworkMode, (
       {
@@ -144,10 +135,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: (rowIndex) => {
-          const { balanceUsd } = filteredData[rowIndex]
-          return `${fixedFloat(balanceUsd)} ${t('column.usd')}`
-        },
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].balanceUsd),
       }
     )),
     {

--- a/src/components/Movements/Movements.columns.js
+++ b/src/components/Movements/Movements.columns.js
@@ -92,10 +92,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { amount, currency } = filteredData[rowIndex]
-        return `${amount} ${currency}`
-      },
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     ...insertIf(platform.showFrameworkMode, (
       {
@@ -114,10 +111,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: (rowIndex) => {
-          const { amountUsd } = filteredData[rowIndex]
-          return `${fixedFloat(amountUsd)} ${t('column.usd')}`
-        },
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].amountUsd),
       }
     )),
     {
@@ -142,10 +136,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { fees, currency } = filteredData[rowIndex]
-        return `${fees} ${currency}`
-      },
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].fees),
     },
     {
       id: 'destinationAddress',

--- a/src/components/Orders/Orders.columns.js
+++ b/src/components/Orders/Orders.columns.js
@@ -82,7 +82,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amountOrig,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amountOrig),
     },
     {
       id: 'amountExecuted',
@@ -99,7 +99,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amountExecuted,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amountExecuted),
     },
     {
       id: 'price',
@@ -117,7 +117,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].price,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].price),
     },
     {
       id: 'priceAvg',
@@ -135,7 +135,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].priceAvg,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].priceAvg),
     },
     {
       id: 'mtsCreate',
@@ -199,7 +199,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].priceTrailing,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].priceTrailing),
     },
     {
       id: 'typePrev',

--- a/src/components/Positions/Positions.columns.js
+++ b/src/components/Positions/Positions.columns.js
@@ -46,7 +46,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: rowIndex => filteredData[rowIndex].liquidationPrice,
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].liquidationPrice),
       },
       {
         id: 'pl',
@@ -63,7 +63,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: rowIndex => filteredData[rowIndex].pl,
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].pl),
       },
       {
         id: 'plPerc',
@@ -80,7 +80,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: rowIndex => filteredData[rowIndex].plPerc,
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].plPerc),
       },
     ]
     : []
@@ -103,7 +103,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: rowIndex => filteredData[rowIndex].collateral,
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].collateral),
       },
       {
         id: 'meta',
@@ -137,7 +137,7 @@ export default function getColumns(props) {
         return (
           <Cell tooltip={id}>
             <Fragment>
-              <a href='#' onClick={onIdClick} value={id}>{id}</a>
+              <a href='#' onClick={onIdClick}>{id}</a>
             </Fragment>
           </Cell>
         )
@@ -174,7 +174,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amount,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     {
       id: 'basePrice',
@@ -192,7 +192,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].basePrice,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].basePrice),
     },
     ...ACTIVE_POSITIONS_COLS,
     {
@@ -211,7 +211,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].marginFunding,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].marginFunding),
     },
     {
       id: 'marginFundingType',

--- a/src/components/PublicFunding/PublicFunding.columns.js
+++ b/src/components/PublicFunding/PublicFunding.columns.js
@@ -63,7 +63,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amount,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     {
       id: 'rate',
@@ -80,7 +80,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].rate,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].rate),
     },
     {
       id: 'period',

--- a/src/components/PublicTrades/PublicTrades.columns.js
+++ b/src/components/PublicTrades/PublicTrades.columns.js
@@ -84,7 +84,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].price,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].price),
     },
     {
       id: 'amount',
@@ -102,7 +102,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].amount,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].amount),
     },
     {
       id: 'pair',

--- a/src/components/Tickers/Tickers.columns.js
+++ b/src/components/Tickers/Tickers.columns.js
@@ -46,7 +46,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].bid,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].bid),
     },
     {
       id: 'ask',
@@ -64,7 +64,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].ask,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].ask),
     },
     {
       id: 'mtsUpdate',

--- a/src/components/Trades/Trades.columns.js
+++ b/src/components/Trades/Trades.columns.js
@@ -93,7 +93,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].execAmount,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].execAmount),
     },
     {
       id: 'execPrice',
@@ -136,10 +136,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: (rowIndex) => {
-        const { fee, feeCurrency } = filteredData[rowIndex]
-        return `${fee} ${feeCurrency}`
-      },
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].fee),
     },
     {
       id: 'feePercent',

--- a/src/components/Wallets/Wallets.columns.js
+++ b/src/components/Wallets/Wallets.columns.js
@@ -6,7 +6,7 @@ import { COLUMN_WIDTHS } from 'utils/columns'
 import { platform } from 'var/config'
 
 export default function getColumns(props) {
-  const { filteredData, t } = props
+  const { filteredData } = props
 
   return [
     {
@@ -39,7 +39,7 @@ export default function getColumns(props) {
           </Cell>
         )
       },
-      copyText: rowIndex => filteredData[rowIndex].balance,
+      copyText: rowIndex => fixedFloat(filteredData[rowIndex].balance),
     },
     ...insertIf(platform.showFrameworkMode, (
       {
@@ -58,10 +58,7 @@ export default function getColumns(props) {
             </Cell>
           )
         },
-        copyText: (rowIndex) => {
-          const { balanceUsd } = filteredData[rowIndex]
-          return `${fixedFloat(balanceUsd)} ${t('column.usd')}`
-        },
+        copyText: rowIndex => fixedFloat(filteredData[rowIndex].balanceUsd),
       }
     )),
   ]

--- a/src/components/Wallets/Wallets.data.js
+++ b/src/components/Wallets/Wallets.data.js
@@ -20,9 +20,9 @@ const WalletsData = (props) => {
   const exchangeData = entries.filter(entry => entry.type === WALLET_EXCHANGE)
   const marginData = entries.filter(entry => entry.type === WALLET_MARGIN)
   const fundingData = entries.filter(entry => entry.type === WALLET_FUNDING)
-  const exchangeColumns = getColumns({ filteredData: exchangeData, t })
-  const marginColumns = getColumns({ filteredData: marginData, t })
-  const fundingColumns = getColumns({ filteredData: fundingData, t })
+  const exchangeColumns = getColumns({ filteredData: exchangeData })
+  const marginColumns = getColumns({ filteredData: marginData })
+  const fundingColumns = getColumns({ filteredData: fundingData })
 
   return (
     <div className='tables-row'>

--- a/src/state/filters/reducer.js
+++ b/src/state/filters/reducer.js
@@ -51,7 +51,7 @@ function filtersReducer(state = initialState, action) {
         [section]: filters,
         queries: {
           ...state.queries,
-          [section]: calculateFilterQuery(filters),
+          [section]: calculateFilterQuery(filters, section),
         },
       }
     }

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -16,11 +16,12 @@ export function symbolsReducer(state = initialState, action) {
   const { type, payload } = action
   switch (type) {
     case types.UPDATE_SYMBOLS: {
-      const { currencies, pairs } = payload
+      const { currencies, inactiveSymbols, pairs } = payload
       const coins = []
       const dict = {}
       const explorersDict = {}
       const symbolMapping = {}
+
       currencies.forEach((currency) => {
         const { id, explorer } = currency
         let { name, symbol } = currency
@@ -43,7 +44,7 @@ export function symbolsReducer(state = initialState, action) {
       })
       setSymbolMap(symbolMapping)
 
-      const formattedPairs = pairs.map(formatPair).map(mapPair).sort()
+      const formattedPairs = [...pairs, ...inactiveSymbols].map(formatPair).map(mapPair).sort()
 
       return {
         ...state,

--- a/src/ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns.js
+++ b/src/ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns.js
@@ -26,6 +26,10 @@ const {
   STRING,
 } = DATA_TYPES
 
+export const TRANSFORMS = {
+  PERCENTAGE: 'percentage',
+}
+
 const LEDGERS_COLUMNS = [
   { id: 'id', name: 'id', type: INTEGER, filter: true, hidden: true },
   { id: 'description', name: 'description', type: STRING, filter: true },
@@ -106,7 +110,7 @@ const SECTION_COLUMNS = {
     { id: 'amountExecuted', name: 'amount-exe', type: INTEGER, filter: true },
     { id: 'type', name: 'type', type: STRING, filter: true },
     { id: 'status', name: 'status', type: STRING, filter: true },
-    { id: 'rate', name: 'rate', type: STRING, filter: true },
+    { id: 'rate', name: 'rate', type: NUMBER, filter: true, transform: TRANSFORMS.PERCENTAGE },
     { id: 'period', name: 'period', type: INTEGER, filter: true },
     { id: 'mtsUpdate', name: 'date' },
   ],
@@ -118,7 +122,7 @@ const SECTION_COLUMNS = {
     { id: 'amount', name: 'amount', type: NUMBER, filter: true },
     { id: 'status', name: 'status', type: STRING, filter: true },
     { id: 'type', name: 'type', type: STRING, filter: true },
-    { id: 'rate', name: 'rate', type: STRING, filter: true },
+    { id: 'rate', name: 'rate', type: NUMBER, filter: true, transform: TRANSFORMS.PERCENTAGE },
     { id: 'period', name: 'period', type: INTEGER, filter: true },
     { id: 'mtsOpening', name: 'opened' },
     { id: 'mtsLastPayout', name: 'closed' },
@@ -132,7 +136,7 @@ const SECTION_COLUMNS = {
     { id: 'amount', name: 'amount', type: NUMBER, filter: true },
     { id: 'status', name: 'status', type: STRING, filter: true },
     { id: 'type', name: 'type', type: STRING, filter: true },
-    { id: 'rate', name: 'rate', type: STRING, filter: true },
+    { id: 'rate', name: 'rate', type: NUMBER, filter: true, transform: TRANSFORMS.PERCENTAGE },
     { id: 'period', name: 'period', type: INTEGER, filter: true },
     { id: 'mtsOpening', name: 'opened' },
     { id: 'mtsLastPayout', name: 'lastpayout' },
@@ -156,7 +160,7 @@ const SECTION_COLUMNS = {
     { id: 'id', name: 'id', type: INTEGER, filter: true, hidden: true },
     { id: 'mts', name: 'time' },
     { id: 'amount', name: 'amount', type: NUMBER, filter: true },
-    { id: 'rate', name: 'rate', type: NUMBER, filter: true },
+    { id: 'rate', name: 'rate', type: NUMBER, filter: true, transform: TRANSFORMS.PERCENTAGE },
     { id: 'period', name: 'period', type: INTEGER, filter: true },
     { id: 'currency', name: 'currency', hidden: true },
   ],


### PR DESCRIPTION
Adds inactive symbols to pairs selection
Fixes rate filters
Removes `currency` from table copy result: `amount`, `balance`, `fees`
Adds rounding to table copy result whenever displayed value is rounded, for consistency