### PR TITLE
Add date formats with 4 digit years

### DIFF
--- a/src/state/base/constants.js
+++ b/src/state/base/constants.js
@@ -1,7 +1,14 @@
 export default {
   MENU_MODE_ICON: 'icon',
   MENU_MODE_NORMAL: 'normal',
-  DATE_FORMATS: ['DD-MM-YY', 'MM-DD-YY', 'YY-MM-DD'],
+  DATE_FORMATS: [
+    'DD-MM-YY',
+    'DD-MM-YYYY',
+    'MM-DD-YY',
+    'MM-DD-YYYY',
+    'YY-MM-DD',
+    'YYYY-MM-DD',
+  ],
   DEFAULT_TIMEZONE: 'Etc/UTC',
   SET_SYNC_STATE: 'BITFINEX/SYNC/SET_STATE',
   SET_DATE_FORMAT: 'BITFINEX/DATEFORMAT/SET',


### PR DESCRIPTION
#### Task: [Add new options for CSVs that have 4 digit years](https://app.asana.com/0/1163495710802945/1199642274304979/f) 

#### Description:
- Added new options for CSVs that have 4 digit years
- Depends on [bfx-report/pull/228](https://github.com/bitfinexcom/bfx-report/pull/228) 

#### Preview:
<img width="565" alt="csv-4-digits-years" src="https://user-images.githubusercontent.com/41899906/121223379-2403b280-c890-11eb-8305-2b8ba51fd5d5.png">

