### PR TITLE
(fix) Incorrect symbols mapping in Ledgers description

### DIFF
--- a/src/state/symbols/utils/mapping.js
+++ b/src/state/symbols/utils/mapping.js
@@ -27,11 +27,7 @@ export const mapDescription = (description) => {
   const descPairsMapped = pairMapKeys
     .reduce((desc, symbol) => desc.replace(new RegExp(symbol, 'g'), SymbolMap.pairs[symbol]), description)
   return symbolMapKeys.reduce((desc, symbol) => desc.replace(
-    new RegExp(
-      `\\b${symbol}\\b|\\b${symbol}\\b[ ]|[ ]\\b${symbol}\\b|\\b${symbol}\\b[)]|[(]\\b${symbol}\\b`,
-      'g',
-    ),
-    (str) => str.replace(new RegExp(symbol, 'g'), SymbolMap.symbols[symbol]),
+    new RegExp(`\\b${symbol}\\b`, 'g'), (str) => str.replace(new RegExp(symbol, 'g'), SymbolMap.symbols[symbol]),
   ), descPairsMapped)
 }
 

--- a/src/state/symbols/utils/mapping.js
+++ b/src/state/symbols/utils/mapping.js
@@ -28,7 +28,7 @@ export const mapDescription = (description) => {
     .reduce((desc, symbol) => desc.replace(new RegExp(symbol, 'g'), SymbolMap.pairs[symbol]), description)
   return symbolMapKeys.reduce((desc, symbol) => desc.replace(
     new RegExp(
-      `^${symbol}|${symbol}$|${symbol}[ ]|[ ]${symbol}|${symbol}[)]|[(]${symbol}`,
+      `\\b${symbol}\\b|\\b${symbol}\\b[ ]|[ ]\\b${symbol}\\b|\\b${symbol}\\b[)]|[(]\\b${symbol}\\b`,
       'g',
     ),
     (str) => str.replace(new RegExp(symbol, 'g'), SymbolMap.symbols[symbol]),


### PR DESCRIPTION
#### Task: [Issue with MegaDOGE ](https://app.asana.com/0/1163495710802945/1200877155367746/f) 

#### Description:
- Fixed incorrect symbols mapping in Ledgers `mapDescription` that produces issues with `DOGE` and `MegaDOGE`
- Optimized symbols comparison

#### Preview:
<img width="900" alt="fix-doge" src="https://user-images.githubusercontent.com/41899906/131534412-797cc277-82c7-4087-8270-63efa5c2f153.png">
