### PR TITLE
(improvement) Add win/loss vs account balance report

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -392,6 +392,11 @@
       "pair": "Pair Filter",
       "category": "Category Filter"
     },
+    "report-type": {
+      "title": "Select Report Type",
+      "win_loss": "Win/Loss",
+      "win_loss_vs_acc_balance": "Win/Loss vs Account Balance"
+    },
     "unrealized-profits": {
       "title": "Show Unrealized Profits",
       "yes": "Yes",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -61,7 +61,8 @@
   },
   "charts": {
     "cumulative": "Cumulative",
-    "percentage": "Percentage"
+    "percentage": "Percentage",
+    "percent": "%"
   },
   "column": {
     "actual-price": "Actual Price",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -61,7 +61,6 @@
   },
   "charts": {
     "cumulative": "Cumulative",
-    "percentage": "Percentage",
     "percent": "%"
   },
   "column": {

--- a/public/locales/es-EM/translations.json
+++ b/public/locales/es-EM/translations.json
@@ -61,7 +61,8 @@
   },
   "charts": {
     "cumulative": "Acumulativo",
-    "percentage": "Porcentaje"
+    "percentage": "Porcentaje",
+    "percent": "%"
   },
   "column": {
     "actual-price": "Precio Actual",

--- a/public/locales/es-EM/translations.json
+++ b/public/locales/es-EM/translations.json
@@ -61,7 +61,6 @@
   },
   "charts": {
     "cumulative": "Acumulativo",
-    "percentage": "Porcentaje",
     "percent": "%"
   },
   "column": {

--- a/public/locales/ru/translations.json
+++ b/public/locales/ru/translations.json
@@ -61,7 +61,8 @@
   },
   "charts": {
     "cumulative": "Суммарный",
-    "percentage": "Проценты"
+    "percentage": "Проценты",
+    "percent": "%"
   },
   "column": {
     "actual-price": "Актуальная цена",

--- a/public/locales/ru/translations.json
+++ b/public/locales/ru/translations.json
@@ -61,7 +61,6 @@
   },
   "charts": {
     "cumulative": "Суммарный",
-    "percentage": "Проценты",
     "percent": "%"
   },
   "column": {

--- a/public/locales/tr/translations.json
+++ b/public/locales/tr/translations.json
@@ -61,7 +61,8 @@
   },
   "charts": {
     "cumulative": "Kümülatif",
-    "percentage": "Yüzde"
+    "percentage": "Yüzde",
+    "percent": "%"
   },
   "column": {
     "actual-price": "Gerçek Fiyat",

--- a/public/locales/tr/translations.json
+++ b/public/locales/tr/translations.json
@@ -61,7 +61,6 @@
   },
   "charts": {
     "cumulative": "Kümülatif",
-    "percentage": "Yüzde",
     "percent": "%"
   },
   "column": {

--- a/public/locales/zh-CN/translations.json
+++ b/public/locales/zh-CN/translations.json
@@ -61,7 +61,6 @@
   },
   "charts": {
     "cumulative": "累计",
-    "percentage": "百分比",
     "percent": "%"
   },
   "column": {

--- a/public/locales/zh-CN/translations.json
+++ b/public/locales/zh-CN/translations.json
@@ -61,7 +61,8 @@
   },
   "charts": {
     "cumulative": "累计",
-    "percentage": "百分比"
+    "percentage": "百分比",
+    "percent": "%"
   },
   "column": {
     "actual-price": "实际价格",

--- a/public/locales/zh-TW/translations.json
+++ b/public/locales/zh-TW/translations.json
@@ -61,7 +61,8 @@
   },
   "charts": {
     "cumulative": "累計",
-    "percentage": "百分比"
+    "percentage": "百分比",
+    "percent": "%"
   },
   "column": {
     "actual-price": "實際價格",

--- a/public/locales/zh-TW/translations.json
+++ b/public/locales/zh-TW/translations.json
@@ -61,7 +61,6 @@
   },
   "charts": {
     "cumulative": "累計",
-    "percentage": "百分比",
     "percent": "%"
   },
   "column": {

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -17,7 +17,10 @@ import TimeRange from 'ui/TimeRange'
 import QueryButton from 'ui/QueryButton'
 import RefreshButton from 'ui/RefreshButton'
 import TimeFrameSelector from 'ui/TimeFrameSelector'
-import parseChartData from 'ui/Charts/Charts.helpers'
+import {
+  parseChartData,
+  parseVSAccBalanceChartData,
+} from 'ui/Charts/Charts.helpers'
 import ReportTypeSelector from 'ui/ReportTypeSelector'
 import UnrealizedProfitSelector from 'ui/UnrealizedProfitSelector'
 import queryConstants from 'state/query/constants'
@@ -26,6 +29,23 @@ import { checkFetch, checkInit } from 'state/utils'
 import { propTypes, defaultProps } from './AverageWinLoss.props'
 
 const TYPE = queryConstants.MENU_WIN_LOSS
+
+const prepareChartData = (entries, t, timeframe, isVSAccBalanceData) => {
+  if (isVSAccBalanceData) {
+    const { chartData, dataKeys } = parseVSAccBalanceChartData({
+      data: _sortBy(entries, ['mts']),
+      timeframe,
+      t,
+    })
+    return { chartData, dataKeys }
+  }
+
+  const { chartData, presentCurrencies } = parseChartData({
+    data: _sortBy(entries, ['mts']),
+    timeframe,
+  })
+  return { chartData, dataKeys: presentCurrencies }
+}
 
 class AverageWinLoss extends PureComponent {
   componentDidMount() {
@@ -78,10 +98,19 @@ class AverageWinLoss extends PureComponent {
       },
     } = this.props
 
-    const { chartData, presentCurrencies } = parseChartData({
-      data: _sortBy(entries, ['mts']),
-      timeframe: currTimeframe,
-    })
+    // const { chartData, presentCurrencies } = parseChartData({
+    //   data: _sortBy(entries, ['mts']),
+    //   timeframe: currTimeframe,
+    // })
+
+    // const { chartData, dataKeys } = parseVSAccBalanceChartData({
+    //   data: _sortBy(entries, ['mts']),
+    //   timeframe: currTimeframe,
+    //   t,
+    // })
+    const { chartData, dataKeys } = prepareChartData(
+      entries, t, currTimeframe, isVsAccountBalanceSelected,
+    )
 
     let showContent
     if (!dataReceived && pageLoading) {
@@ -92,7 +121,8 @@ class AverageWinLoss extends PureComponent {
       showContent = (
         <Chart
           data={chartData}
-          dataKeys={presentCurrencies}
+          // dataKeys={presentCurrencies}
+          dataKeys={dataKeys}
         />
       )
     }

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -30,7 +30,9 @@ import { propTypes, defaultProps } from './AverageWinLoss.props'
 
 const TYPE = queryConstants.MENU_WIN_LOSS
 
-const prepareChartData = (entries, t, timeframe, isVSAccBalanceData) => {
+const prepareChartData = (
+  entries, timeframe, isVSAccBalanceData, t,
+) => {
   if (isVSAccBalanceData) {
     const { chartData, dataKeys } = parseVSAccBalanceChartData({
       data: _sortBy(entries, ['mts']),
@@ -98,18 +100,8 @@ class AverageWinLoss extends PureComponent {
       },
     } = this.props
 
-    // const { chartData, presentCurrencies } = parseChartData({
-    //   data: _sortBy(entries, ['mts']),
-    //   timeframe: currTimeframe,
-    // })
-
-    // const { chartData, dataKeys } = parseVSAccBalanceChartData({
-    //   data: _sortBy(entries, ['mts']),
-    //   timeframe: currTimeframe,
-    //   t,
-    // })
     const { chartData, dataKeys } = prepareChartData(
-      entries, t, currTimeframe, isVsAccountBalanceSelected,
+      entries, currTimeframe, isVsAccountBalanceSelected, t,
     )
 
     let showContent

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -69,7 +69,11 @@ class AverageWinLoss extends PureComponent {
       pageLoading,
       dataReceived,
       currentFetchParams: { timeframe: currTimeframe },
-      params: { timeframe, isUnrealizedProfitExcluded },
+      params: {
+        timeframe,
+        isUnrealizedProfitExcluded,
+        isVsAccountBalanceSelected,
+      },
     } = this.props
 
     const { chartData, presentCurrencies } = parseChartData({
@@ -124,8 +128,8 @@ class AverageWinLoss extends PureComponent {
                 {t('selector.report-type.title')}
               </SectionHeaderItemLabel>
               <ReportTypeSelector
-                value={isUnrealizedProfitExcluded}
-                onChange={this.handleUnrealizedProfitChange}
+                value={isVsAccountBalanceSelected}
+                onChange={this.handleReportTypeChange}
               />
             </SectionHeaderItem>
             <QueryButton

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -18,6 +18,7 @@ import QueryButton from 'ui/QueryButton'
 import RefreshButton from 'ui/RefreshButton'
 import TimeFrameSelector from 'ui/TimeFrameSelector'
 import parseChartData from 'ui/Charts/Charts.helpers'
+import ReportTypeSelector from 'ui/ReportTypeSelector'
 import UnrealizedProfitSelector from 'ui/UnrealizedProfitSelector'
 import queryConstants from 'state/query/constants'
 import { checkFetch, checkInit } from 'state/utils'
@@ -48,6 +49,11 @@ class AverageWinLoss extends PureComponent {
   handleUnrealizedProfitChange = (isUnrealizedProfitExcluded) => {
     const { setParams } = this.props
     setParams({ isUnrealizedProfitExcluded })
+  }
+
+  handleReportTypeChange = (isVsAccountBalanceSelected) => {
+    const { setParams } = this.props
+    setParams({ isVsAccountBalanceSelected })
   }
 
   hasChanges = () => {
@@ -109,6 +115,15 @@ class AverageWinLoss extends PureComponent {
                 {t('selector.unrealized-profits.title')}
               </SectionHeaderItemLabel>
               <UnrealizedProfitSelector
+                value={isUnrealizedProfitExcluded}
+                onChange={this.handleUnrealizedProfitChange}
+              />
+            </SectionHeaderItem>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.report-type.title')}
+              </SectionHeaderItemLabel>
+              <ReportTypeSelector
                 value={isUnrealizedProfitExcluded}
                 onChange={this.handleUnrealizedProfitChange}
               />

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -68,7 +68,9 @@ class AverageWinLoss extends PureComponent {
       refresh,
       pageLoading,
       dataReceived,
-      currentFetchParams: { timeframe: currTimeframe },
+      currentFetchParams: {
+        timeframe: currTimeframe,
+      },
       params: {
         timeframe,
         isUnrealizedProfitExcluded,

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -113,7 +113,6 @@ class AverageWinLoss extends PureComponent {
       showContent = (
         <Chart
           data={chartData}
-          // dataKeys={presentCurrencies}
           dataKeys={dataKeys}
         />
       )

--- a/src/components/LoanReport/LoanReport.container.js
+++ b/src/components/LoanReport/LoanReport.container.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
+import { withTranslation } from 'react-i18next'
 
 import {
   fetchLoanReport,
@@ -41,5 +42,6 @@ const mapDispatchToProps = {
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
+  withTranslation('translations'),
   withRouter,
 )(LoanReport)

--- a/src/components/LoanReport/LoanReport.container.js
+++ b/src/components/LoanReport/LoanReport.container.js
@@ -4,40 +4,40 @@ import { withRouter } from 'react-router-dom'
 import { withTranslation } from 'react-i18next'
 
 import {
-  fetchLoanReport,
   refresh,
-  addTargetSymbol,
-  removeTargetSymbol,
-  setTargetSymbols,
   setParams,
+  addTargetSymbol,
+  fetchLoanReport,
+  setTargetSymbols,
+  removeTargetSymbol,
 } from 'state/loanReport/actions'
 import {
-  getCurrentFetchParams,
-  getDataReceived,
+  getParams,
   getEntries,
   getPageLoading,
-  getParams,
+  getDataReceived,
   getTargetSymbols,
+  getCurrentFetchParams,
 } from 'state/loanReport/selectors'
 
 import LoanReport from './LoanReport'
 
 const mapStateToProps = state => ({
-  currentFetchParams: getCurrentFetchParams(state),
-  entries: getEntries(state),
   params: getParams(state),
-  targetSymbols: getTargetSymbols(state),
-  dataReceived: getDataReceived(state),
+  entries: getEntries(state),
   pageLoading: getPageLoading(state),
+  dataReceived: getDataReceived(state),
+  targetSymbols: getTargetSymbols(state),
+  currentFetchParams: getCurrentFetchParams(state),
 })
 
 const mapDispatchToProps = {
-  fetchData: fetchLoanReport,
   refresh,
   setParams,
   addTargetSymbol,
-  removeTargetSymbol,
   setTargetSymbols,
+  removeTargetSymbol,
+  fetchData: fetchLoanReport,
 }
 
 export default compose(

--- a/src/components/LoanReport/LoanReport.container.js
+++ b/src/components/LoanReport/LoanReport.container.js
@@ -1,3 +1,4 @@
+import { compose } from 'redux'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 
@@ -38,6 +39,7 @@ const mapDispatchToProps = {
   setTargetSymbols,
 }
 
-const LoanReportContainer = withRouter(connect(mapStateToProps, mapDispatchToProps)(LoanReport))
-
-export default LoanReportContainer
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  withRouter,
+)(LoanReport)

--- a/src/components/LoanReport/LoanReport.js
+++ b/src/components/LoanReport/LoanReport.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react'
-import { withTranslation } from 'react-i18next'
 import { Card, Elevation } from '@blueprintjs/core'
 import _sortBy from 'lodash/sortBy'
 import _isEqual from 'lodash/isEqual'
@@ -131,4 +130,4 @@ class LoanReport extends PureComponent {
 LoanReport.propTypes = propTypes
 LoanReport.defaultProps = defaultProps
 
-export default withTranslation('translations')(LoanReport)
+export default LoanReport

--- a/src/components/LoanReport/LoanReport.js
+++ b/src/components/LoanReport/LoanReport.js
@@ -6,20 +6,20 @@ import _isEqual from 'lodash/isEqual'
 
 import {
   SectionHeader,
-  SectionHeaderTitle,
   SectionHeaderRow,
   SectionHeaderItem,
+  SectionHeaderTitle,
   SectionHeaderItemLabel,
 } from 'ui/SectionHeader'
-import MultiSymbolSelector from 'ui/MultiSymbolSelector'
-import Loading from 'ui/Loading'
 import NoData from 'ui/NoData'
+import Loading from 'ui/Loading'
 import Chart from 'ui/Charts/Chart'
-import { parseLoanReportChartData } from 'ui/Charts/Charts.helpers'
-import TimeFrameSelector from 'ui/TimeFrameSelector'
+import TimeRange from 'ui/TimeRange'
 import QueryButton from 'ui/QueryButton'
 import RefreshButton from 'ui/RefreshButton'
-import TimeRange from 'ui/TimeRange'
+import TimeFrameSelector from 'ui/TimeFrameSelector'
+import MultiSymbolSelector from 'ui/MultiSymbolSelector'
+import { parseLoanReportChartData } from 'ui/Charts/Charts.helpers'
 import queryConstants from 'state/query/constants'
 import { checkFetch, checkInit, toggleSymbol } from 'state/utils'
 
@@ -53,14 +53,16 @@ class LoanReport extends PureComponent {
 
   render() {
     const {
-      currentFetchParams: { timeframe: currTimeframe },
-      entries,
-      targetSymbols,
-      params,
-      dataReceived,
-      pageLoading,
-      refresh,
       t,
+      params,
+      refresh,
+      entries,
+      pageLoading,
+      dataReceived,
+      targetSymbols,
+      currentFetchParams: {
+        timeframe: currTimeframe,
+      },
     } = this.props
     const { timeframe } = params
     const hasChanges = this.hasChanges()
@@ -85,9 +87,14 @@ class LoanReport extends PureComponent {
       )
     }
     return (
-      <Card elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
+      <Card
+        elevation={Elevation.ZERO}
+        className='col-lg-12 col-md-12 col-sm-12 col-xs-12'
+      >
         <SectionHeader>
-          <SectionHeaderTitle>{t('loanreport.title')}</SectionHeaderTitle>
+          <SectionHeaderTitle>
+            {t('loanreport.title')}
+          </SectionHeaderTitle>
           <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
             <SectionHeaderItem>
@@ -108,7 +115,6 @@ class LoanReport extends PureComponent {
                 onChange={this.handleTimeframeChange}
               />
             </SectionHeaderItem>
-
             <QueryButton
               disabled={!hasChanges}
               onClick={this.handleQuery}

--- a/src/components/LoanReport/index.js
+++ b/src/components/LoanReport/index.js
@@ -1,3 +1,1 @@
-import LoanReport from './LoanReport.container'
-
-export default LoanReport
+export { default } from './LoanReport.container'

--- a/src/state/winLoss/reducer.js
+++ b/src/state/winLoss/reducer.js
@@ -28,9 +28,11 @@ export function winLossReducer(state = initialState, action) {
         currentFetchParams: {
           timeframe: state.timeframe,
           isUnrealizedProfitExcluded: state.isUnrealizedProfitExcluded,
+          isVsAccountBalanceSelected: state.isVsAccountBalanceSelected,
         },
         timeframe: state.timeframe,
         isUnrealizedProfitExcluded: state.isUnrealizedProfitExcluded,
+        isVsAccountBalanceSelected: state.isVsAccountBalanceSelected,
       }
     case types.UPDATE_WIN_LOSS: {
       if (!payload) {

--- a/src/state/winLoss/reducer.js
+++ b/src/state/winLoss/reducer.js
@@ -1,6 +1,7 @@
 import authTypes from 'state/auth/constants'
 import timeRangeTypes from 'state/timeRange/constants'
 import timeframeConstants from 'ui/TimeFrameSelector/constants'
+import reportTypeConstants from 'ui/ReportTypeSelector/constants'
 import unrealizedProfitConstants from 'ui/UnrealizedProfitSelector/constants'
 
 import { fetchFail } from 'state/reducers.helper'
@@ -13,6 +14,7 @@ export const initialState = {
   dataReceived: false,
   currentFetchParams: {},
   timeframe: timeframeConstants.DAY,
+  isVsAccountBalanceSelected: reportTypeConstants.FALSE,
   isUnrealizedProfitExcluded: unrealizedProfitConstants.FALSE,
 }
 

--- a/src/state/winLoss/saga.js
+++ b/src/state/winLoss/saga.js
@@ -21,18 +21,36 @@ export const getReqWinLossVSAccountBalance = params => makeFetchCall('getWinLoss
 export function* fetchWinLoss() {
   try {
     const { start, end } = yield select(getTimeFrame)
-    const { timeframe, isUnrealizedProfitExcluded } = yield select(selectors.getParams)
-
-    const { result = [], error } = yield call(getReqWinLoss, {
-      start,
-      end,
+    const {
       timeframe,
       isUnrealizedProfitExcluded,
-    })
-    yield put(actions.updateWinLoss(result))
+      isVsAccountBalanceSelected,
+    } = yield select(selectors.getParams)
 
-    if (error) {
-      yield put(toggleErrorDialog(true, error.message))
+    if (isVsAccountBalanceSelected) {
+      const { result = [], error } = yield call(getReqWinLossVSAccountBalance, {
+        start,
+        end,
+        timeframe,
+        isUnrealizedProfitExcluded,
+      })
+      yield put(actions.updateWinLoss(result))
+
+      if (error) {
+        yield put(toggleErrorDialog(true, error.message))
+      }
+    } else {
+      const { result = [], error } = yield call(getReqWinLoss, {
+        start,
+        end,
+        timeframe,
+        isUnrealizedProfitExcluded,
+      })
+      yield put(actions.updateWinLoss(result))
+
+      if (error) {
+        yield put(toggleErrorDialog(true, error.message))
+      }
     }
   } catch (fail) {
     yield put(actions.fetchFail({

--- a/src/state/winLoss/saga.js
+++ b/src/state/winLoss/saga.js
@@ -15,6 +15,7 @@ import actions from './actions'
 import selectors from './selectors'
 
 export const getReqWinLoss = params => makeFetchCall('getWinLoss', params)
+export const getReqWinLossVSAccountBalance = params => makeFetchCall('getWinLossVSAccountBalance', params)
 
 /* eslint-disable-next-line consistent-return */
 export function* fetchWinLoss() {

--- a/src/state/winLoss/saga.js
+++ b/src/state/winLoss/saga.js
@@ -27,30 +27,18 @@ export function* fetchWinLoss() {
       isVsAccountBalanceSelected,
     } = yield select(selectors.getParams)
 
-    if (isVsAccountBalanceSelected) {
-      const { result = [], error } = yield call(getReqWinLossVSAccountBalance, {
-        start,
-        end,
-        timeframe,
-        isUnrealizedProfitExcluded,
-      })
-      yield put(actions.updateWinLoss(result))
+    const { result = [], error } = yield call((isVsAccountBalanceSelected
+      ? getReqWinLossVSAccountBalance
+      : getReqWinLoss), {
+      start,
+      end,
+      timeframe,
+      isUnrealizedProfitExcluded,
+    })
+    yield put(actions.updateWinLoss(result))
 
-      if (error) {
-        yield put(toggleErrorDialog(true, error.message))
-      }
-    } else {
-      const { result = [], error } = yield call(getReqWinLoss, {
-        start,
-        end,
-        timeframe,
-        isUnrealizedProfitExcluded,
-      })
-      yield put(actions.updateWinLoss(result))
-
-      if (error) {
-        yield put(toggleErrorDialog(true, error.message))
-      }
+    if (error) {
+      yield put(toggleErrorDialog(true, error.message))
     }
   } catch (fail) {
     yield put(actions.fetchFail({

--- a/src/state/winLoss/selectors.js
+++ b/src/state/winLoss/selectors.js
@@ -4,6 +4,7 @@ export const getCurrentFetchParams = state => getWinLoss(state).currentFetchPara
 export const getDataReceived = state => getWinLoss(state).dataReceived
 export const getEntries = state => getWinLoss(state).entries
 export const getIsUnrealizedProfitExcluded = state => getWinLoss(state).isUnrealizedProfitExcluded
+export const getIsVsAccountBalanceSelected = state => getWinLoss(state).isVsAccountBalanceSelected
 export const getPageLoading = state => getWinLoss(state).pageLoading
 export const getTimeframe = state => getWinLoss(state).timeframe
 export const getParams = (state) => {
@@ -22,6 +23,7 @@ export default {
   getDataReceived,
   getEntries,
   getIsUnrealizedProfitExcluded,
+  getIsVsAccountBalanceSelected,
   getPageLoading,
   getParams,
   getTimeframe,

--- a/src/state/winLoss/selectors.js
+++ b/src/state/winLoss/selectors.js
@@ -11,10 +11,12 @@ export const getParams = (state) => {
   const {
     timeframe,
     isUnrealizedProfitExcluded,
+    isVsAccountBalanceSelected,
   } = getWinLoss(state)
   return {
     timeframe,
     isUnrealizedProfitExcluded,
+    isVsAccountBalanceSelected,
   }
 }
 

--- a/src/ui/Charts/Chart/index.js
+++ b/src/ui/Charts/Chart/index.js
@@ -1,3 +1,1 @@
-import Chart from './Chart'
-
-export default Chart
+export { default } from './Chart'

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -27,7 +27,7 @@ const formatTimestamp = (timestamp, timeframe) => {
   }
 }
 
-const parseChartData = ({ data, timeframe }) => {
+export const parseChartData = ({ data, timeframe }) => {
   const chartData = data.map((entry) => {
     const { mts } = entry
 
@@ -49,8 +49,6 @@ export const parseVSAccBalanceChartData = ({ data, timeframe, t }) => {
 
     return {
       name: formatTimestamp(mts, timeframe),
-      [CURRENCY_USD]: formatValue(entry[CURRENCY_USD]),
-      cumulative: formatValue(entry.cumulative),
       perc: formatValue(entry.perc),
     }
   })

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -43,6 +43,26 @@ const parseChartData = ({ data, timeframe }) => {
   }
 }
 
+export const parseVSAccBalanceChartData = ({ data, timeframe, t }) => {
+  const chartData = data.map((entry) => {
+    const { mts } = entry
+
+    return {
+      name: formatTimestamp(mts, timeframe),
+      [CURRENCY_USD]: formatValue(entry[CURRENCY_USD]),
+      cumulative: formatValue(entry.cumulative),
+      perc: formatValue(entry.perc),
+    }
+  })
+
+  return {
+    chartData,
+    dataKeys: [
+      { key: 'perc', name: t('charts.percentage') },
+    ],
+  }
+}
+
 export const parseLoanReportChartData = ({ data, timeframe, t }) => {
   const chartData = data.map((entry) => {
     const { mts } = entry

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -78,7 +78,7 @@ export const parseLoanReportChartData = ({ data, timeframe, t }) => {
     dataKeys: [
       CURRENCY_USD,
       { key: 'cumulative', name: t('charts.cumulative') },
-      { key: 'perc', name: t('charts.percentage') },
+      { key: 'perc', name: t('charts.percent') },
     ],
   }
 }

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -56,7 +56,7 @@ export const parseVSAccBalanceChartData = ({ data, timeframe, t }) => {
   return {
     chartData,
     dataKeys: [
-      { key: 'perc', name: t('charts.percentage') },
+      { key: 'perc', name: t('charts.percent') },
     ],
   }
 }

--- a/src/ui/Charts/PieChart.js
+++ b/src/ui/Charts/PieChart.js
@@ -67,18 +67,23 @@ class PieChart extends PureComponent {
     const { data } = this.props
 
     return (
-      <SimplePieChart width={282} height={340}>
+      <SimplePieChart
+        width={282}
+        height={340}
+      >
         <Pie
           data={data}
           dataKey='value'
           labelLine={false}
-          label={renderCustomizedLabel}
           outerRadius={140}
-
+          label={renderCustomizedLabel}
         >
           {data.map((entry, index) => <Cell key={entry.name} fill={this.getColor(index)} />)}
         </Pie>
-        <Legend verticalAlign='top' wrapperStyle={{ paddingBottom: 15 }} />
+        <Legend
+          verticalAlign='top'
+          wrapperStyle={{ paddingBottom: 15 }}
+        />
       </SimplePieChart>
     )
   }

--- a/src/ui/ReportTypeSelector/ReportTypeSelector.js
+++ b/src/ui/ReportTypeSelector/ReportTypeSelector.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withTranslation } from 'react-i18next'
+
+import Select from 'ui/Select'
+
+import constants from './constants'
+
+const { TRUE, FALSE } = constants
+
+const ReportTypeSelector = ({ onChange, t, value }) => {
+  const items = [
+    { value: FALSE, label: t('selector.report-type.win_loss') },
+    { value: TRUE, label: t('selector.report-type.win_loss_vs_acc_balance') },
+  ]
+
+  return (
+    <Select
+      value={value}
+      items={items}
+      onChange={onChange}
+      className='bitfinex-select--report-type'
+      popoverClassName='bitfinex-select-menu--report-type'
+    />
+  )
+}
+
+ReportTypeSelector.propTypes = {
+  t: PropTypes.func.isRequired,
+  value: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+}
+
+export default withTranslation('translations')(ReportTypeSelector)

--- a/src/ui/ReportTypeSelector/constants.js
+++ b/src/ui/ReportTypeSelector/constants.js
@@ -1,0 +1,4 @@
+export default {
+  TRUE: true,
+  FALSE: false,
+}

--- a/src/ui/ReportTypeSelector/index.js
+++ b/src/ui/ReportTypeSelector/index.js
@@ -1,0 +1,1 @@
+export { default } from './ReportTypeSelector'

--- a/src/ui/Select/_Select.scss
+++ b/src/ui/Select/_Select.scss
@@ -18,6 +18,10 @@
     width: 160px;
   }
 
+  &--report-type .bp3-button {
+    width: 250px;
+  }
+
   &--timeframe .bp3-button {
     width: 100px;
   }
@@ -55,6 +59,14 @@
 
     &--unrealized-profit .bp3-popover-content {
       width: 160px;
+
+      .bp3-menu {
+        min-width: unset;
+      }
+    }
+
+    &--report-type .bp3-popover-content {
+      width: 250px;
 
       .bp3-menu {
         min-width: unset;


### PR DESCRIPTION
#### Task: [Add win/loss vs account balance UI section](https://app.asana.com/0/1163495710802945/1201243093611763/f) 

#### Description:
- Adds the possibility to select `Win/Loss vs Account Balance` report in the `Average Win/Loss` section 
- Updates corresponding logic to receive, handle and represent this report properly
- Optimizes HOCs composition and code readability improvements in several components
- Depends on [bfx-reports-frameworks #196](https://github.com/bitfinexcom/bfx-reports-framework/pull/196) 

#### Preview:
https://user-images.githubusercontent.com/41899906/140503793-06d04746-3c9a-46ed-af32-b7a7a7e1b57e.mov
