### PR TITLE
(fix) Logins metadata preview

### DIFF
--- a/src/ui/JSONFormat/_JSONFormat.scss
+++ b/src/ui/JSONFormat/_JSONFormat.scss
@@ -1,7 +1,6 @@
 .json-format {
-  width: 100%;
+  width: #{"max(500px, 40vw);"};
   overflow: hidden;
   white-space: pre-wrap;
   word-break: break-all;
-  max-width: calc(85vh - 20px);
 }


### PR DESCRIPTION
#### Task: [Logins Metadata mouseover falls off the page](https://app.asana.com/0/1163495710802945/1201505127866884/f) 

#### Description:
- Fixes `Logins` metadata preview displaying issues

#### Before:
![metadata-before](https://user-images.githubusercontent.com/41899906/145826581-7d6cdf09-b719-410d-89e7-3350d6e509f6.png)
#### After:
![metadata-after](https://user-images.githubusercontent.com/41899906/145826653-390da176-86df-4682-ab19-cb9d6f434856.png)