### PR TITLE
Fix copy-paste table data issue

### DIFF
--- a/src/ui/DataTable/DataTable.js
+++ b/src/ui/DataTable/DataTable.js
@@ -75,7 +75,18 @@ class DataTable extends PureComponent {
         cur += 1
       }
 
-      navigator.clipboard.writeText(`${columnHeaders.join('\t')}\n${text}`)
+      const newLineChar = columnHeaders.length > 0
+        ? '\n'
+        : ''
+      const headersText = `${columnHeaders.join('\t')}${newLineChar}`
+
+      navigator.clipboard.writeText(`${headersText}${text}`).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(err)
+      })
+    }).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(err)
     })
   }
 


### PR DESCRIPTION
This PR fixes the copy/paste table data issue: there inserts a redundant new line character at the start of every copy (single cell or multi-cell)

To operate with the clipboard there is using WebAPI `Navigator.clipboard` interface
https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard
  - the requests for the ability to monitor the user's clipboard will stay anyway
  - we can't implement different behavior as ` Permissions.query()` and `Permissions.request()` methods are not stable at the moment https://developer.mozilla.org/en-US/docs/Web/API/Permissions https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API
  - the `Clipboard.readText()` and `Clipboard.writeText()` may throw an error when permition is deny. This feature is available only in secure contexts (HTTPS). https://developer.mozilla.org/en-US/docs/Web/API/Clipboard In this case adds some `catch()` -> `console.error()`