### PR TITLE
(improvement) Candles chart prices precisions

### DIFF
--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -28,6 +28,16 @@ const STYLES = {
 
 const SCROLL_THRESHOLD = 200
 
+const getPriceFormat = (candles) => {
+  const price = +candles[0]?.high
+  if (price >= 100) return { minMove: 0.01, precision: 2 }
+  if (price >= 10) return { minMove: 0.001, precision: 3 }
+  if (price >= 1) return { minMove: 0.0001, precision: 4 }
+  if (price < 0.0001) return { minMove: 0.0000001, precision: 7 }
+  if (price < 1) return { minMove: 0.00001, precision: 5 }
+  return { minMove: 0.01, precision: 2 }
+}
+
 class Candlestick extends React.PureComponent {
   state = {
     width: null,
@@ -125,11 +135,10 @@ class Candlestick extends React.PureComponent {
       },
     })
 
+    const priceFormat = getPriceFormat(candles)
+
     chart.addLineSeries({
-      priceFormat: {
-        minMove: 0.00001,
-        precision: 5,
-      },
+      priceFormat,
     })
 
     this.chart = chart

--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -6,10 +6,11 @@ import { createChart, CrosshairMode } from 'lightweight-charts'
 import _debounce from 'lodash/debounce'
 
 import { THEME_CLASSES } from 'utils/themes'
+import { getPriceFormat } from '../Charts.helpers'
 
+import Tooltip from './Tooltip'
 import CandleStats from './CandleStats'
 import TradesToggle from './TradesToggle'
-import Tooltip from './Tooltip'
 import TradingViewLink from './TradingViewLink'
 import { propTypes, defaultProps } from './Candlestick.props'
 
@@ -27,16 +28,6 @@ const STYLES = {
 }
 
 const SCROLL_THRESHOLD = 200
-
-const getPriceFormat = (candles) => {
-  const price = +candles[0]?.high
-  if (price >= 100) return { minMove: 0.01, precision: 2 }
-  if (price >= 10) return { minMove: 0.001, precision: 3 }
-  if (price >= 1) return { minMove: 0.0001, precision: 4 }
-  if (price < 0.0001) return { minMove: 0.0000001, precision: 7 }
-  if (price < 1) return { minMove: 0.00001, precision: 5 }
-  return { minMove: 0.01, precision: 2 }
-}
 
 class Candlestick extends React.PureComponent {
   state = {
@@ -137,9 +128,7 @@ class Candlestick extends React.PureComponent {
 
     const priceFormat = getPriceFormat(candles)
 
-    chart.addLineSeries({
-      priceFormat,
-    })
+    chart.addLineSeries({ priceFormat })
 
     this.chart = chart
 

--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -124,6 +124,14 @@ class Candlestick extends React.PureComponent {
         barSpacing: 15,
       },
     })
+
+    chart.addLineSeries({
+      priceFormat: {
+        minMove: 0.00001,
+        precision: 5,
+      },
+    })
+
     this.chart = chart
 
     chart.subscribeVisibleTimeRangeChange(this.onTimeRangeChange)

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -83,4 +83,14 @@ export const parseLoanReportChartData = ({ data, timeframe, t }) => {
   }
 }
 
+export const getPriceFormat = (candles) => {
+  const price = +candles[0]?.high
+  if (price >= 100) return { minMove: 0.01, precision: 2 }
+  if (price >= 10) return { minMove: 0.001, precision: 3 }
+  if (price >= 1) return { minMove: 0.0001, precision: 4 }
+  if (price < 0.0001) return { minMove: 0.0000001, precision: 7 }
+  if (price < 1) return { minMove: 0.00001, precision: 5 }
+  return { minMove: 0.01, precision: 2 }
+}
+
 export default parseChartData


### PR DESCRIPTION
#### Task: [Reports candle graph, display prices](https://app.asana.com/0/1163495710802945/1202166138093214/f) 
#### Description:
- [x] Implements dynamic price precision showing for different trading pairs on `Candles` chart
#### Before:
<img width="978" alt="chart-prec-before" src="https://user-images.githubusercontent.com/41899906/165482791-237acf95-e1c3-4e42-87ec-ef2452a0d77f.png">

#### After:
<img width="986" alt="chart-prec-after" src="https://user-images.githubusercontent.com/41899906/165482817-40e5a18e-95d2-4ec3-9cee-7ce9d8bb57f4.png">

