### PR TITLE
(fix) Trades tooltips

### DIFF
--- a/src/ui/Charts/Candlestick/Tooltip/Tooltip.js
+++ b/src/ui/Charts/Candlestick/Tooltip/Tooltip.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { withTranslation } from 'react-i18next'
 import _throttle from 'lodash/throttle'
 
@@ -99,7 +99,7 @@ class Tooltip extends React.PureComponent {
     } = trade
 
     return (
-      <Fragment>
+      <>
         {`Price: ${formatExecPrice(execPrice)}`}
         <br />
         {`${t('candles.amount')}: `}
@@ -113,7 +113,7 @@ class Tooltip extends React.PureComponent {
         <span className='bitfinex-show-soft'>
           {feeCurrency}
         </span>
-      </Fragment>
+      </>
     )
   }
 

--- a/src/ui/Charts/Candlestick/Tooltip/Tooltip.js
+++ b/src/ui/Charts/Candlestick/Tooltip/Tooltip.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import { withTranslation } from 'react-i18next'
 import _throttle from 'lodash/throttle'
 
-import { formatAmount } from 'ui/utils'
+import { formatAmount, formatExecPrice } from 'ui/utils'
 
 import { propTypes, defaultProps } from './Tooltip.props'
 
@@ -100,7 +100,7 @@ class Tooltip extends React.PureComponent {
 
     return (
       <Fragment>
-        {`Price: ${execPrice.toFixed(2)}`}
+        {`Price: ${formatExecPrice(execPrice)}`}
         <br />
         {`${t('candles.amount')}: `}
         {formatAmount(execAmount)}

--- a/src/ui/Charts/Candlestick/_Candlestick.scss
+++ b/src/ui/Charts/Candlestick/_Candlestick.scss
@@ -2,7 +2,7 @@
   position: relative;
 
   &-tooltip {
-    width: 150px;
+    width: 175px;
     height: 78px;
     position: absolute;
     display: none;

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import classNames from 'classnames'
 
 export const amountStyle = (amount) => {
@@ -43,11 +43,11 @@ export const formatFraction = (value, options = {}) => {
 export const formatAmount = (val, options = {}) => {
   if (!val) {
     return (
-      <Fragment>
+      <>
         <div className='bitfinex-amount'>
           {val}
         </div>
-      </Fragment>
+      </>
     )
   }
   const {
@@ -75,7 +75,7 @@ export const formatAmount = (val, options = {}) => {
   const [integer, fraction] = val.toString().split('.')
 
   return (
-    <Fragment>
+    <>
       <div className={classes}>
         <span>
           {dollarSign && '$'}
@@ -84,7 +84,7 @@ export const formatAmount = (val, options = {}) => {
         {'.'}
         <span className='bitfinex-amount-fraction'>{fraction}</span>
       </div>
-    </Fragment>
+    </>
   )
 }
 

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -104,11 +104,21 @@ export const formatColor = (value, color) => {
   )
 }
 
+export const formatExecPrice = (price) => {
+  if (price >= 100) return price.toFixed(2)
+  if (price >= 10) return price.toFixed(3)
+  if (price >= 1) return price.toFixed(4)
+  if (price < 0.0001) return price.toFixed(7)
+  if (price < 1) return price.toFixed(5)
+  return price.toFixed(2)
+}
+
 export default {
   fixedFloat,
   insertIf,
   formatAmount,
   formatColor,
+  formatExecPrice,
   formatFraction,
   formatThousands,
   amountStyle,


### PR DESCRIPTION
#### Task: [Trades tooltip: price precision, styling](https://app.asana.com/0/1163495710802945/1202195704419001/f) 
#### Description:
- [x] Fixes displayed trades execution price precision inconsistency
- [x] Fixes tooltips content overflowing issues
#### Before:
<img width="762" alt="trades_tooltip_before" src="https://user-images.githubusercontent.com/41899906/166204465-4c67eab0-6469-4db4-9750-648a89c43632.png">

#### After:
<img width="910" alt="trades_tooltip_after" src="https://user-images.githubusercontent.com/41899906/166204530-5cbabb5f-f883-421f-aa23-05d47aa99f7a.png">