### PR TITLE
(improvement) Similar trades

### DIFF
--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -186,7 +186,7 @@ class Candlestick extends React.PureComponent {
       open: trade,
     })))
 
-    this.tradeSeries.setMarkers(trades.map(trade => ({
+    this.tradeSeries.setMarkers(uniqueTrades.map(trade => ({
       time: trade.time,
       position: 'inBar',
       shape: 'circle',
@@ -269,7 +269,10 @@ class Candlestick extends React.PureComponent {
   }
 
   render() {
-    const { className, candles: { entries: candles } } = this.props
+    const {
+      className,
+      candles: { entries: candles },
+    } = this.props
     const {
       width,
       height,

--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -3,6 +3,8 @@ import { withTranslation } from 'react-i18next'
 import moment from 'moment'
 import classNames from 'classnames'
 import { createChart, CrosshairMode } from 'lightweight-charts'
+import _reduce from 'lodash/reduce'
+import _values from 'lodash/values'
 import _debounce from 'lodash/debounce'
 
 import { THEME_CLASSES } from 'utils/themes'
@@ -169,7 +171,17 @@ class Candlestick extends React.PureComponent {
       this.forceUpdate()
     }
 
-    this.tradeSeries.setData(trades.map(trade => ({
+    const uniqueTrades = _values(
+      _reduce(trades, (acc, trade) => {
+        if (!acc[trade.orderID]) acc[trade.orderID] = trade
+        if (acc[trade.orderID] && acc[trade.orderID].execPrice !== trade.execPrice) {
+          acc[trade.execPrice] = trade
+        }
+        return acc
+      }, {}),
+    )
+
+    this.tradeSeries.setData(uniqueTrades.map(trade => ({
       ...trade,
       open: trade,
     })))
@@ -178,7 +190,7 @@ class Candlestick extends React.PureComponent {
       time: trade.time,
       position: 'inBar',
       shape: 'circle',
-      color: trade.execAmount > 0 ? '#1eb150' : '#f0403f',
+      color: uniqueTrades.execAmount > 0 ? '#1eb150' : '#f0403f',
     })))
   }
 

--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -3,12 +3,10 @@ import { withTranslation } from 'react-i18next'
 import moment from 'moment'
 import classNames from 'classnames'
 import { createChart, CrosshairMode } from 'lightweight-charts'
-import _reduce from 'lodash/reduce'
-import _values from 'lodash/values'
 import _debounce from 'lodash/debounce'
 
 import { THEME_CLASSES } from 'utils/themes'
-import { getPriceFormat } from '../Charts.helpers'
+import { getPriceFormat, mergeSimilarTrades } from '../Charts.helpers'
 
 import Tooltip from './Tooltip'
 import CandleStats from './CandleStats'
@@ -171,22 +169,14 @@ class Candlestick extends React.PureComponent {
       this.forceUpdate()
     }
 
-    const uniqueTrades = _values(
-      _reduce(trades, (acc, trade) => {
-        if (!acc[trade.orderID]) acc[trade.orderID] = trade
-        if (acc[trade.orderID] && acc[trade.orderID].execPrice !== trade.execPrice) {
-          acc[trade.execPrice] = trade
-        }
-        return acc
-      }, {}),
-    )
+    const preparedTrades = mergeSimilarTrades(trades)
 
-    this.tradeSeries.setData(uniqueTrades.map(trade => ({
+    this.tradeSeries.setData(preparedTrades.map(trade => ({
       ...trade,
       open: trade,
     })))
 
-    this.tradeSeries.setMarkers(uniqueTrades.map(trade => ({
+    this.tradeSeries.setMarkers(preparedTrades.map(trade => ({
       time: trade.time,
       position: 'inBar',
       shape: 'circle',

--- a/src/ui/Charts/Candlestick/Candlestick.js
+++ b/src/ui/Charts/Candlestick/Candlestick.js
@@ -190,7 +190,7 @@ class Candlestick extends React.PureComponent {
       time: trade.time,
       position: 'inBar',
       shape: 'circle',
-      color: uniqueTrades.execAmount > 0 ? '#1eb150' : '#f0403f',
+      color: trade.execAmount > 0 ? '#1eb150' : '#f0403f',
     })))
   }
 

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -1,4 +1,6 @@
 import moment from 'moment-timezone'
+import _reduce from 'lodash/reduce'
+import _values from 'lodash/values'
 
 import timeframeConstants from 'ui/TimeFrameSelector/constants'
 
@@ -92,5 +94,15 @@ export const getPriceFormat = (candles) => {
   if (price < 1) return { minMove: 0.00001, precision: 5 }
   return { minMove: 0.01, precision: 2 }
 }
+
+export const mergeSimilarTrades = (trades) => _values(
+  _reduce(trades, (acc, trade) => {
+    if (!acc[trade.orderID]) acc[trade.orderID] = trade
+    if (acc[trade.orderID] && acc[trade.orderID].execPrice !== trade.execPrice) {
+      acc[trade.execPrice] = trade
+    }
+    return acc
+  }, {}),
+)
 
 export default parseChartData


### PR DESCRIPTION
#### Task: [Simplify the way trades are shown](https://app.asana.com/0/1163495710802945/1202166138093210/f) 
#### Description:
- [x] Adds logic for merging similar trades, with the same `orderId` and `execPrice`, to the one dot on the `Candles` chart for better representation and readability
#### Before:
https://user-images.githubusercontent.com/41899906/166453101-816bdf03-c451-43b3-b6de-16b976e64df4.mov
#### After:
https://user-images.githubusercontent.com/41899906/166453185-a92f0058-db92-4b12-9f91-04c3f7f9ac56.mov



