### PR TITLE
(fix) Exchange chinese translations

### DIFF
--- a/public/locales/zh-CN/translations.json
+++ b/public/locales/zh-CN/translations.json
@@ -246,7 +246,7 @@
   "ledgers": {
     "title": "分类账",
     "categories": {
-      "exchange": "现货",
+      "exchange": "兌換",
       "position_modified": "仓位调整、关闭或清算",
       "position_claim": "仓位赎回",
       "position_transfer": "仓位转移",
@@ -503,7 +503,7 @@
   "wallets": {
     "title": "钱包",
     "header": {
-      "exchange": "交易所",
+      "exchange": "兌換",
       "margin": "保证金",
       "funding": "融资",
       "token-sales": "通证发布"


### PR DESCRIPTION
#### Task: [Reports - Change Exchange translation](https://app.asana.com/0/1163495710802945/1202204457720636/f) 
#### Description:
- [x] Fixes `Exchange` chinese translations in the `Ledgers` categories and `Wallets` section
#### Before:
<img width="953" alt="cn_ledgers_exchange_before" src="https://user-images.githubusercontent.com/41899906/166667598-be5a5fa7-1496-4d9a-a214-a89236d25652.png">
<img width="877" alt="cn_wallets_exchange_before" src="https://user-images.githubusercontent.com/41899906/166667707-0d2be2d9-c901-424d-abf8-cb41f92bc613.png">

#### After:
<img width="915" alt="cn_ledgers_exchange_after" src="https://user-images.githubusercontent.com/41899906/166667789-3ecd4902-ca97-4cb2-b801-9405d8202bd8.png">
<img width="878" alt="cn_wallets_exchange_after" src="https://user-images.githubusercontent.com/41899906/166667804-0649719c-9603-4973-83e6-439662317a6a.png">

