### PR TITLE
(internal) Actualize redux libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2804,9 +2804,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -2815,24 +2815,13 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
-      "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.8.tgz",
+      "integrity": "sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-redux": {
-      "version": "7.1.18",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.18.tgz",
-      "integrity": "sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==",
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
       }
     },
     "@types/resize-observer-browser": {
@@ -2888,6 +2877,11 @@
           "dev": true
         }
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/webpack": {
       "version": "4.41.31",
@@ -5813,9 +5807,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -14965,16 +14959,23 @@
       }
     },
     "react-redux": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
-      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.1.tgz",
+      "integrity": "sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==",
       "requires": {
         "@babel/runtime": "^7.12.1",
-        "@types/react-redux": "^7.1.16",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.13.1"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
+        }
       }
     },
     "react-refresh": {
@@ -17919,6 +17920,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ=="
     },
     "util": {
       "version": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15306,12 +15306,11 @@
       }
     },
     "redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-logger": {
@@ -17197,11 +17196,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15323,9 +15323,9 @@
       }
     },
     "redux-persist": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.10.0.tgz",
-      "integrity": "sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
     },
     "redux-saga": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "recharts": "^2.1.4",
     "redux": "4.2.0",
     "redux-logger": "3.0.6",
-    "redux-persist": "5.10.0",
+    "redux-persist": "6.0.0",
     "redux-saga": "0.16.2",
     "shelljs": "^0.8.5"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.8.6",
     "react-i18next": "10.5.2",
-    "react-redux": "^7.2.1",
+    "react-redux": "8.0.1",
     "react-router-dom": "^5.0.0",
     "react-swipeable": "^5.5.1",
     "react-transition-group": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-swipeable": "^5.5.1",
     "react-transition-group": "^2.6.1",
     "recharts": "^2.1.4",
-    "redux": "4.0.5",
+    "redux": "4.2.0",
     "redux-logger": "3.0.6",
     "redux-persist": "5.10.0",
     "redux-saga": "0.16.2",


### PR DESCRIPTION
#### Task: [Actualize dependencies](https://app.asana.com/0/1198734617779736/1202092498069641/f) 

#### Description:
- Bumps [redux](https://www.npmjs.com/package/redux) from 4.0.5 to 4.20.0
- Bumps [react-redux](https://www.npmjs.com/package/react-redux) from 7.2.1 to 8.0.1
- Bumps [redux-persist](https://www.npmjs.com/package/redux-persist) from 5.10.0 to 6.0.0