### PR TITLE
(internal) Actualize timezone libraries 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,31 +1475,66 @@
       }
     },
     "@blueprintjs/timezone": {
-      "version": "3.9.14",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/timezone/-/timezone-3.9.14.tgz",
-      "integrity": "sha512-EW7dEyTywK/3gLwBophR5P491H2l3rWnnY7wpcl9J67eLe29IPced0Rp4Dj0NjinoeH+Yf8vFuXHOmE9OQomMQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/timezone/-/timezone-3.10.1.tgz",
+      "integrity": "sha512-uVf28kENhkwiwCCyGTQBxRsz/Z/KEy3RyQXoeCv/ZDryjEFNVpHCjYlf2QMt4DP7ADEwWH3SfLebjtXdRjFb+g==",
       "requires": {
-        "@blueprintjs/core": "^3.50.4",
-        "@blueprintjs/select": "^3.18.6",
+        "@blueprintjs/core": "^3.54.0",
+        "@blueprintjs/select": "^3.19.1",
         "classnames": "^2.2",
         "moment": "^2.29.0",
         "moment-timezone": "^0.5.31",
         "react-lifecycles-compat": "^3.0.4",
-        "tslib": "~1.13.0"
+        "tslib": "~2.3.1"
       },
       "dependencies": {
-        "moment": {
-          "version": "2.29.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        "@blueprintjs/colors": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.3.tgz",
+          "integrity": "sha512-ANRQZT5h9+zC8B/y0S9B+SqEpicL0XRT4drAhiPFHBrOStRZWzOh3bPrwNSPqr7tdShxYtMyxbH+fkHMetZaxg=="
         },
-        "moment-timezone": {
-          "version": "0.5.33",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-          "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+        "@blueprintjs/core": {
+          "version": "3.54.0",
+          "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.54.0.tgz",
+          "integrity": "sha512-u2c1s6MNn0ocxhnC6CuiG5g3KV6b4cKUvSobznepA9SC3/AL1s3XOvT7DLWoHRv2B/vBOHFYEDzLw2/vlcGGZg==",
           "requires": {
-            "moment": ">= 2.9.0"
+            "@blueprintjs/colors": "^4.0.0-alpha.3",
+            "@blueprintjs/icons": "^3.33.0",
+            "@juggle/resize-observer": "^3.3.1",
+            "@types/dom4": "^2.0.1",
+            "classnames": "^2.2",
+            "dom4": "^2.1.5",
+            "normalize.css": "^8.0.1",
+            "popper.js": "^1.16.1",
+            "react-lifecycles-compat": "^3.0.4",
+            "react-popper": "^1.3.7",
+            "react-transition-group": "^2.9.0",
+            "tslib": "~2.3.1"
           }
+        },
+        "@blueprintjs/icons": {
+          "version": "3.33.0",
+          "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.33.0.tgz",
+          "integrity": "sha512-Q6qoSDIm0kRYQZISm59UUcDCpV3oeHulkLuh3bSlw0HhcSjvEQh2PSYbtaifM60Q4aK4PCd6bwJHg7lvF1x5fQ==",
+          "requires": {
+            "classnames": "^2.2",
+            "tslib": "~2.3.1"
+          }
+        },
+        "@blueprintjs/select": {
+          "version": "3.19.1",
+          "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.19.1.tgz",
+          "integrity": "sha512-8UJIZMaWXRMQHr14wbmzJc/CklcSKxOU5JUux0xXKQz/hDW/g1a650tlwJmnxufvRdShbGinlVfHupCs0EL6sw==",
+          "requires": {
+            "@blueprintjs/core": "^3.54.0",
+            "classnames": "^2.2",
+            "tslib": "~2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -2254,6 +2289,11 @@
           }
         }
       }
+    },
+    "@juggle/resize-observer": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
+      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12342,9 +12342,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "moment-timezone": {
       "version": "0.5.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12347,9 +12347,9 @@
       "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "moment-timezone": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
-      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "4.17.21",
     "memoize-one": "^5.0.2",
     "moment": "2.29.3",
-    "moment-timezone": "0.5.23",
+    "moment-timezone": "0.5.34",
     "sass": "1.50.0",
     "normalize.css": "8.0.1",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lightweight-charts": "^1.2.1",
     "lodash": "4.17.21",
     "memoize-one": "^5.0.2",
-    "moment": "2.29.2",
+    "moment": "2.29.3",
     "moment-timezone": "0.5.23",
     "sass": "1.50.0",
     "normalize.css": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@blueprintjs/icons": "^3.7.0",
     "@blueprintjs/select": "^3.8.0",
     "@blueprintjs/table": "3.5.0",
-    "@blueprintjs/timezone": "^3.4.0",
+    "@blueprintjs/timezone": "3.10.1",
     "classnames": "2.2.6",
     "connected-react-router": "^6.6.0",
     "flexboxgrid2": "7.2.1",


### PR DESCRIPTION
#### Task: [Actualize dependencies](https://app.asana.com/0/1198734617779736/1202092498069641/f) 

#### Description:
- Bumps [moment](https://www.npmjs.com/package/moment/v/2.29.3) from 2.29.2 to 2.29.3
- Bumps [moment-timezone](https://www.npmjs.com/package/moment-timezone/v/0.5.34) from 0.5.23 to 0.5.34
- Bumps [@blueprintjs/timezone](https://www.npmjs.com/package/@blueprintjs/timezone/v/3.10.1) from 3.4.0 to 3.10.1