### PR TITLE
(improvement) Charts prices representation

### DIFF
--- a/src/ui/Charts/Chart/Chart.js
+++ b/src/ui/Charts/Chart/Chart.js
@@ -12,6 +12,8 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 
+import { formatChartData } from '../Charts.helpers'
+
 import { propTypes, defaultProps } from './Chart.props'
 
 const COLORS = [
@@ -82,7 +84,6 @@ class Chart extends React.PureComponent {
     }
 
     const classes = classNames('line-chart', className)
-    const dataFormatter = value => new Intl.NumberFormat('en').format(value)
 
     return (
       <div className={classes}>
@@ -100,11 +101,11 @@ class Chart extends React.PureComponent {
             <YAxis
               width={90}
               stroke='#9e9494'
-              tickFormatter={dataFormatter}
+              tickFormatter={formatChartData}
             />
             <Tooltip
               isAnimationActive={false}
-              formatter={value => new Intl.NumberFormat('en').format(value)}
+              formatter={formatChartData}
             />
             <CartesianGrid
               stroke='#57636b'

--- a/src/ui/Charts/Chart/Chart.js
+++ b/src/ui/Charts/Chart/Chart.js
@@ -97,7 +97,10 @@ class Chart extends React.PureComponent {
               stroke='#9e9494'
             />
             <YAxis stroke='#9e9494' />
-            <Tooltip isAnimationActive={false} />
+            <Tooltip
+              isAnimationActive={false}
+              formatter={value => new Intl.NumberFormat('en').format(value)}
+            />
             <CartesianGrid
               stroke='#57636b'
               strokeDasharray='3 3'

--- a/src/ui/Charts/Chart/Chart.js
+++ b/src/ui/Charts/Chart/Chart.js
@@ -13,7 +13,6 @@ import {
 } from 'recharts'
 
 import { formatChartData } from '../Charts.helpers'
-
 import { propTypes, defaultProps } from './Chart.props'
 
 const COLORS = [

--- a/src/ui/Charts/Chart/Chart.js
+++ b/src/ui/Charts/Chart/Chart.js
@@ -98,6 +98,7 @@ class Chart extends React.PureComponent {
               stroke='#9e9494'
             />
             <YAxis
+              width={90}
               stroke='#9e9494'
               tickFormatter={dataFormatter}
             />

--- a/src/ui/Charts/Chart/Chart.js
+++ b/src/ui/Charts/Chart/Chart.js
@@ -82,6 +82,7 @@ class Chart extends React.PureComponent {
     }
 
     const classes = classNames('line-chart', className)
+    const dataFormatter = value => new Intl.NumberFormat('en').format(value)
 
     return (
       <div className={classes}>
@@ -96,7 +97,10 @@ class Chart extends React.PureComponent {
               dataKey='name'
               stroke='#9e9494'
             />
-            <YAxis stroke='#9e9494' />
+            <YAxis
+              stroke='#9e9494'
+              tickFormatter={dataFormatter}
+            />
             <Tooltip
               isAnimationActive={false}
               formatter={value => new Intl.NumberFormat('en').format(value)}

--- a/src/ui/Charts/Charts.helpers.js
+++ b/src/ui/Charts/Charts.helpers.js
@@ -105,4 +105,7 @@ export const mergeSimilarTrades = (trades) => _values(
   }, {}),
 )
 
+// Formatting: 1000000 ---> 1,000,000
+export const formatChartData = value => new Intl.NumberFormat('en').format(value)
+
 export default parseChartData


### PR DESCRIPTION
#### Task: [Add comas to money in graphs](https://app.asana.com/0/1163495710802945/1202351379929639/f) 
#### Description:
- [x] Improves `Charts` and `Tooltips` prices formatting for better readability
#### Before:
<img width="913" alt="charts_data_before" src="https://user-images.githubusercontent.com/41899906/171402874-49616430-4cf8-44bf-b0b4-1e1b307004b9.png">

#### After:
<img width="912" alt="charts_data_after" src="https://user-images.githubusercontent.com/41899906/171402955-626f0e12-da7e-45de-8dc0-45b651fd9432.png">
