### PR TITLE
(improvement) Selected timezone usage in date inputs

### DIFF
--- a/src/ui/DateInput/DateInput.container.js
+++ b/src/ui/DateInput/DateInput.container.js
@@ -1,0 +1,16 @@
+import { compose } from 'redux'
+import { connect } from 'react-redux'
+import { withTranslation } from 'react-i18next'
+
+import { getTimezone } from 'state/base/selectors'
+
+import DateInput from './DateInput'
+
+const mapStateToProps = (state) => ({
+  timezone: getTimezone(state),
+})
+
+export default compose(
+  withTranslation('translations'),
+  connect(mapStateToProps),
+)(DateInput)

--- a/src/ui/DateInput/DateInput.js
+++ b/src/ui/DateInput/DateInput.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react'
-import { withTranslation } from 'react-i18next'
 import moment from 'moment-timezone'
 import { Position } from '@blueprintjs/core'
 import { DateInput as BptDateInput, TimePrecision } from '@blueprintjs/datetime'
@@ -10,8 +9,6 @@ import {
 } from 'state/utils'
 
 import { propTypes, defaultProps } from './DateInput.props'
-
-const currentTimezone = moment.tz.guess()
 
 class DateInput extends PureComponent {
   state = {
@@ -42,13 +39,14 @@ class DateInput extends PureComponent {
       daysOnly,
       defaultValue,
       t,
+      timezone,
       value,
     } = this.props
     const { isOpen } = this.state
 
     const { formatDate, parseDate } = daysOnly
       ? momentFormatterDays()
-      : momentFormatter(DEFAULT_DATETIME_FORMAT, currentTimezone)
+      : momentFormatter(DEFAULT_DATETIME_FORMAT, timezone)
 
     const timePrecision = !daysOnly ? TimePrecision.SECOND : undefined
     const icon = isOpen
@@ -83,4 +81,4 @@ class DateInput extends PureComponent {
 DateInput.propTypes = propTypes
 DateInput.defaultProps = defaultProps
 
-export default withTranslation('translations')(DateInput)
+export default DateInput

--- a/src/ui/DateInput/DateInput.props.js
+++ b/src/ui/DateInput/DateInput.props.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import moment from 'moment-timezone'
 
 export const propTypes = {
   className: PropTypes.string,
@@ -6,10 +7,12 @@ export const propTypes = {
   onChange: PropTypes.func.isRequired,
   daysOnly: PropTypes.bool,
   t: PropTypes.func.isRequired,
+  timezone: PropTypes.string,
 }
 
 export const defaultProps = {
   className: '',
   defaultValue: null,
   daysOnly: false,
+  timezone: moment.tz.guess(), // current timezone
 }

--- a/src/ui/DateInput/index.js
+++ b/src/ui/DateInput/index.js
@@ -1,1 +1,1 @@
-export { default } from './DateInput'
+export { default } from './DateInput.container'


### PR DESCRIPTION
#### Task: [Changes in calendar](https://app.asana.com/0/1163495710802945/1202559462625166/f) 
#### Description:
- [x] Adds selected in `Preferences` timezone usage to the date inputs
#### Preview:
![Timezone_select](https://user-images.githubusercontent.com/41899906/177530632-9c9d0d56-c14e-40ab-975c-7f726769c36d.png)
![Date_input](https://user-images.githubusercontent.com/41899906/177530672-69895a5d-6fe5-4d0a-8da6-31ab5f47a7f0.png)


