### PR TITLE
(fix) Refresh auth token when user re-login via WebSockets

### DIFF
--- a/src/state/ws/signIn.js
+++ b/src/state/ws/signIn.js
@@ -1,8 +1,14 @@
-import { call, take, race } from 'redux-saga/effects'
+import {
+  call,
+  put,
+  take,
+  race,
+} from 'redux-saga/effects'
 import { delay } from 'redux-saga'
 
 import WS from 'state/ws'
 import types from 'state/auth/constants'
+import actions from 'state/auth/actions'
 
 const RETRIES = 6
 
@@ -16,6 +22,11 @@ function* wsSignIn(retryCount = 0) {
 
   if (timeout && retryCount < RETRIES) {
     return yield call(wsSignIn, retryCount + 1)
+  }
+
+  if (wsAuth) {
+    const { payload: { result } } = wsAuth
+    yield put(actions.updateAuth(result))
   }
 
   return !!wsAuth


### PR DESCRIPTION
#### Task: [Refresh auth token when user re-login via WebSockets](https://app.asana.com/0/1163495710802945/1202065980063155/f) 
#### Description:
- [x] Adds auth refreshing on re-login via `WebSockets` and fixes issues with broken `HTTP` requests due to the staled token from the previous authorization

#### Before:
<img width="752" alt="ws_signin_before_1" src="https://user-images.githubusercontent.com/41899906/180997795-78f6b30a-d605-483c-920d-730292217bfa.png">
<img width="752" alt="ws_signin_before_2" src="https://user-images.githubusercontent.com/41899906/180997931-e5fd4716-2a45-417a-93a9-d0cbbfedd719.png">

#### After:
<img width="747" alt="ws_signin_after_1" src="https://user-images.githubusercontent.com/41899906/180998085-cd88d301-a356-415d-ac5d-dbb2d0192e15.png">
<img width="750" alt="ws_signin_after_2" src="https://user-images.githubusercontent.com/41899906/180998113-3a4514db-5c6c-4369-904a-e96f7cf31b38.png">

