### PR TITLE
(improvement) Account summary values

### DIFF
--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
+import _round from 'lodash/round'
 
 export const amountStyle = (amount) => {
   const val = parseFloat(amount)
@@ -58,21 +59,22 @@ export const formatAmount = (val, options = {}) => {
     formatThousands: shouldFormatThousands = false,
     dollarSign = false,
   } = options
+  let roundedValue = _round(val, 8)
 
   const classes = classNames('bitfinex-amount', {
-    'bitfinex-green-text': color ? color === 'green' : val > 0,
-    'bitfinex-red-text': color ? color === 'red' : val < 0,
+    'bitfinex-green-text': color ? color === 'green' : roundedValue > 0,
+    'bitfinex-red-text': color ? color === 'red' : roundedValue < 0,
   })
 
   if (fixFraction) {
-    val = formatFraction(val, { digits, minDigits }) // eslint-disable-line no-param-reassign
+    roundedValue = formatFraction(roundedValue, { digits, minDigits }) // eslint-disable-line no-param-reassign
   }
 
   if (shouldFormatThousands) {
-    val = formatThousands(val) // eslint-disable-line no-param-reassign
+    roundedValue = formatThousands(roundedValue) // eslint-disable-line no-param-reassign
   }
 
-  const [integer, fraction] = val.toString().split('.')
+  const [integer, fraction] = roundedValue.toString().split('.')
 
   return (
     <>

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -67,11 +67,11 @@ export const formatAmount = (val, options = {}) => {
   })
 
   if (fixFraction) {
-    roundedValue = formatFraction(roundedValue, { digits, minDigits }) // eslint-disable-line no-param-reassign
+    roundedValue = formatFraction(roundedValue, { digits, minDigits })
   }
 
   if (shouldFormatThousands) {
-    roundedValue = formatThousands(roundedValue) // eslint-disable-line no-param-reassign
+    roundedValue = formatThousands(roundedValue)
   }
 
   const [integer, fraction] = roundedValue.toString().split('.')


### PR DESCRIPTION
#### Task: [Round summary display](https://app.asana.com/0/1163495710802945/1202695629271501/f) 
#### Description:
- [x] Rounds `Account Summary` displayed values for better representation

#### Before:
<img width="1036" alt="acc-summary-vals-before" src="https://user-images.githubusercontent.com/41899906/182120108-b11b6161-f0c3-4943-9f52-120be794b281.png">

#### After:
<img width="1041" alt="acc-summary-vals-after" src="https://user-images.githubusercontent.com/41899906/182120183-2df597bd-391f-4447-9550-2eac9a5b8e40.png">