### PR TITLE
(improvement) Show trades id column by default

### DIFF
--- a/src/ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns.js
+++ b/src/ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns.js
@@ -84,7 +84,7 @@ const SECTION_COLUMNS = {
   [MENU_INVOICES]: INVOICES_COLUMNS,
 
   [MENU_TRADES]: [
-    { id: 'id', name: 'id', type: INTEGER, filter: true, hidden: true },
+    { id: 'id', name: 'id', type: INTEGER, filter: true },
     { id: 'orderID', name: 'orderid', type: INTEGER, filter: true },
     { id: 'pair', name: 'pair' },
     { id: 'execAmount', name: 'amount', type: NUMBER, filter: true },


### PR DESCRIPTION
#### Task: [Show trades id column by default](https://app.asana.com/0/1198734617779736/1202719539675791/f) 
#### Description:
- [x] Updates columns filter configuration to show trades `id` column by default in `Trades` report 
#### Preview:
<img width="1011" alt="trades_id_default" src="https://user-images.githubusercontent.com/41899906/182861572-2fc1ae88-7aef-4130-98b1-6251e0c52753.png">

