### PR TITLE
(feature) Notify users sync is being paused until connection is resumed

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -432,7 +432,8 @@
     },
     "signInFail": "Invalid credentials",
     "timeframe_update": "Time frame updated",
-    "signUpFail": "Invalid API Key or Secret"
+    "signUpFail": "Invalid API Key or Secret",
+    "netError": "Fetching data paused due broken internet connection"
   },
   "subaccounts": {
     "add_account": "Add Account",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -433,7 +433,8 @@
     "signInFail": "Invalid credentials",
     "timeframe_update": "Time frame updated",
     "signUpFail": "Invalid API Key or Secret",
-    "netError": "Fetching data paused due broken internet connection"
+    "netError": "Fetching data paused due broken internet connection",
+    "netResumed": "Internet connection restored fetching data resumed"
   },
   "subaccounts": {
     "add_account": "Add Account",

--- a/src/state/ws/constants.js
+++ b/src/state/ws/constants.js
@@ -1,4 +1,6 @@
 export default {
   WS_CONNECT: 'ws_connect',
   WS_RECONNECT: 'ws_reconnect',
+  WS_NET_ERROR: 'ws_emitENetError',
+  WS_NET_RESUMED: 'ws_emitENetResumed',
 }

--- a/src/state/ws/saga.js
+++ b/src/state/ws/saga.js
@@ -1,7 +1,7 @@
 import { call, put, takeLatest } from 'redux-saga/effects'
 
 import { updateSyncStatus } from 'state/sync/actions'
-import { updateWarningStatus } from 'state/status/actions'
+import { updateStatus, updateWarningStatus } from 'state/status/actions'
 
 import types from './constants'
 import login from './signIn'
@@ -18,7 +18,12 @@ function* notifyNetError() {
   yield put(updateWarningStatus({ id: 'status.netError' }))
 }
 
+function* notifyNetResumed() {
+  yield put(updateStatus({ id: 'status.netResumed' }))
+}
+
 export default function* wsSaga() {
   yield takeLatest(types.WS_RECONNECT, reconnect)
   yield takeLatest(types.WS_NET_ERROR, notifyNetError)
+  yield takeLatest(types.WS_NET_RESUMED, notifyNetResumed)
 }

--- a/src/state/ws/saga.js
+++ b/src/state/ws/saga.js
@@ -1,6 +1,7 @@
 import { call, put, takeLatest } from 'redux-saga/effects'
 
 import { updateSyncStatus } from 'state/sync/actions'
+import { updateWarningStatus } from 'state/status/actions'
 
 import types from './constants'
 import login from './signIn'
@@ -13,6 +14,11 @@ function* reconnect() {
   }
 }
 
+function* notifyNetError() {
+  yield put(updateWarningStatus({ id: 'status.netError' }))
+}
+
 export default function* wsSaga() {
   yield takeLatest(types.WS_RECONNECT, reconnect)
+  yield takeLatest(types.WS_NET_ERROR, notifyNetError)
 }


### PR DESCRIPTION
#### Task: [Notify users when fetching data from bfx_api_v2 is paused due broken internet connection](https://app.asana.com/0/1163495710802945/1202680154327657/f) 
#### Description:
- [x] Implements users notification when fetching data from `bfx_api_v2` is paused due broken internet connection and also when the connection is resumed
#### Preview:
<img width="891" alt="net_err" src="https://user-images.githubusercontent.com/41899906/183652400-fd38407c-0e43-4e43-9514-1f3718752454.png">

- Depends on [bfx-report #266](https://github.com/bitfinexcom/bfx-report/pull/266) and [bfx-reports-framework #230](https://github.com/bitfinexcom/bfx-reports-framework/pull/230)

