### PR TITLE
(fix) Public Funding rate filter param

### DIFF
--- a/src/ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns.js
+++ b/src/ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns.js
@@ -201,7 +201,7 @@ const SECTION_COLUMNS = {
     { id: 'id', name: 'id', type: INTEGER, filter: true, hidden: true },
     { id: 'mts', name: 'time', type: DATE, filter: true },
     { id: 'amount', name: 'amount', type: NUMBER, filter: true },
-    { id: 'rate', name: 'rate', type: NUMBER, filter: true, transform: TRANSFORMS.PERCENTAGE },
+    { id: 'rate', name: 'rate', type: NUMBER, filter: true },
     { id: 'period', name: 'period', type: INTEGER, filter: true },
     { id: 'currency', name: 'currency', hidden: true },
   ],


### PR DESCRIPTION
#### Task: [Fix passing "rate" filter param for "Public Funding"](https://app.asana.com/0/1163495710802945/1202936277388285/f) 
#### Description:
- [x] Fixes incorrect `rate` filter param type and value passing from `Public Funding` report
#### Before:
<img width="1242" alt="pub_fub_rate_filter_before" src="https://user-images.githubusercontent.com/41899906/193549900-0251274c-ab7d-4166-ad66-bd5bc6265a57.png">

#### After:
<img width="1274" alt="pub_fub_rate_filter_after" src="https://user-images.githubusercontent.com/41899906/193550005-108bcbd0-0712-47a3-9143-7ae619372d89.png">
