### PR TITLE
(fix) Auth via WebSockets

### DIFF
--- a/src/state/ws/index.js
+++ b/src/state/ws/index.js
@@ -15,8 +15,8 @@ const getAuth = () => {
 // initial auth with /login requires email/password even if token already present
 const getLoginAuth = () => {
   const state = store.getState()
-  const { email, password } = getAuthData(state)
-  return { email, password }
+  const { email, password, isSubAccount } = getAuthData(state)
+  return { email, password, isSubAccount }
 }
 
 class WS {
@@ -87,11 +87,11 @@ class WS {
   }
 
   signIn = (auth = getLoginAuth()) => {
-    const { email, password } = auth
+    const { email, password, isSubAccount } = auth
     this.send('signIn', {}, {
       email,
       password,
-      isSubAccount: false,
+      isSubAccount,
     })
   }
 


### PR DESCRIPTION
#### Task: [Wrong auth via WebSockets](https://app.asana.com/0/1163495710802945/1203283175870077/f) 
#### Description:
- [x] Fixes incorrect `isSubAccount` flag providing during auth via `WebSockets` in the framework mode
#### Before:
<img width="1261" alt="ws-auth-before" src="https://user-images.githubusercontent.com/41899906/199943938-b9575d62-07db-4557-9305-6f0b07b00960.png">

#### After:
<img width="1183" alt="ws-auth-after" src="https://user-images.githubusercontent.com/41899906/199944013-a134abf3-326d-4f15-939c-d1dbe8dde0f8.png">
