### PR TITLE
(improvement) Trades fee percent precision

### DIFF
--- a/src/components/Trades/Trades.columns.js
+++ b/src/components/Trades/Trades.columns.js
@@ -25,7 +25,7 @@ const getFeePercent = (entry) => {
     val = fee / (execAmount * execPrice)
   }
   if (val) {
-    return `${fixedFloat(Math.abs(val) * 100, 2)}%`
+    return `${fixedFloat(Math.abs(val) * 100, 3)}%`
   }
   return '-'
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203157338507327/f

#### Description:
- [x] Increases `Fee Perc` precision in the `Trades` report to 3 decimals for better representation

#### Preview:
<img width="940" alt="trades_fee_perc_round_3dec" src="https://user-images.githubusercontent.com/41899906/201329521-a2906f91-027c-4d5a-b9d7-6a0db12b8604.png">
