### PR TITLE
(fix) Redirection after adding a sub-account

### DIFF
--- a/src/components/Auth/Auth.js
+++ b/src/components/Auth/Auth.js
@@ -53,11 +53,11 @@ class Auth extends PureComponent {
 
   componentDidUpdate(prevProps) {
     const { authType } = this.state
-    const { isUsersLoaded, users, authData: { isSubAccount } } = this.props
+    const { isUsersLoaded, users } = this.props
     const isMultipleAccsSelected = authType === AUTH_TYPES.MULTIPLE_ACCOUNTS
     if (config.showFrameworkMode && !prevProps.isUsersLoaded && isUsersLoaded && users.length) {
       // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ mode: isMultipleAccsSelected && !isSubAccount ? MODES.SIGN_UP : MODES.SIGN_IN })
+      this.setState({ mode: isMultipleAccsSelected ? MODES.SIGN_UP : MODES.SIGN_IN })
     }
   }
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203361820459953/f

#### Description:
- [x] Prevents redirection to the `Sign In` screen after the successful adding a sub-account for improving UX if the user wants to add several sub-accounts in a row
#### Before:

https://user-images.githubusercontent.com/41899906/201895168-6c90910e-e366-495b-85f9-94c73841f593.mov

#### After:

https://user-images.githubusercontent.com/41899906/201895280-03fbd423-b367-4ee5-8a69-2a2bd09e8d22.mov

