### PR TITLE
(fix) Time frame params providing

### DIFF
--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -5,6 +5,7 @@ import {
   takeLatest,
 } from 'redux-saga/effects'
 import queryString from 'query-string'
+import _assign from 'lodash/assign'
 import _includes from 'lodash/includes'
 
 import { LANGUAGES } from 'locales/i18n'
@@ -56,10 +57,15 @@ import { getEmail } from 'state/auth/selectors'
 import { getTimeFrame } from 'state/timeRange/selectors'
 import config from 'config'
 
-import { getExportEmail } from './selectors'
 import actions from './actions'
-import { getQueryLimit, NO_QUERY_LIMIT_TARGETS } from './utils'
 import types from './constants'
+import { getExportEmail } from './selectors'
+import {
+  getQueryLimit,
+  NO_TIME_FRAME_TARGETS,
+  NO_QUERY_LIMIT_TARGETS,
+} from './utils'
+
 
 const { showFrameworkMode } = config
 const {
@@ -221,9 +227,11 @@ function formatSymbol(target, symbols) {
 
 function* getOptions({ target }) {
   const options = {}
-  if (!_includes(NO_QUERY_LIMIT_TARGETS, target)) {
+  if (!_includes(NO_TIME_FRAME_TARGETS, target)) {
     const timeFrame = yield select(getTimeFrame)
-    Object.assign(options, timeFrame)
+    _assign(options, timeFrame)
+  }
+  if (!_includes(NO_QUERY_LIMIT_TARGETS, target)) {
     options.limit = getQueryLimit(target)
   }
   options.timezone = yield select(getTimezone)

--- a/src/state/query/utils.js
+++ b/src/state/query/utils.js
@@ -200,6 +200,12 @@ export const NO_QUERY_LIMIT_TARGETS = [
   MENU_WIN_LOSS,
 ]
 
+export const NO_TIME_FRAME_TARGETS = [
+  MENU_DERIVATIVES,
+  MENU_WALLETS,
+  MENU_SNAPSHOTS,
+]
+
 export function isValidTimeStamp(n) {
   return (`${n}`).length === 13
     && (new Date(n)).getTime() === n


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203402965926244/f
#### Description:
- [x] Fixes missed time frame start/end params provided during exporting in CSV for `Average Win/Loss`, `Traded Volume`, `Account Balance`, `Loan` and `Fees` reports
#### Preview:
<img width="1460" alt="start_end_export_csv_params" src="https://user-images.githubusercontent.com/41899906/203302049-330b0fb9-e783-4b46-a1de-59f88d894687.png">
