### PR TITLE
(improvement) Sub-accounts selection

### DIFF
--- a/src/components/SubAccounts/SubAccount/SubAccount.js
+++ b/src/components/SubAccounts/SubAccount/SubAccount.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Button, Intent } from '@blueprintjs/core'
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
+import _differenceBy from 'lodash/differenceBy'
 
 import Loading from 'ui/Loading'
 
@@ -113,6 +114,7 @@ class SubAccount extends PureComponent {
     const subUsers = _get(subAccountData, 'subUsers', [])
     const hasFilledAccounts = getFilledAccounts(accounts).length > 0
     const hasSubAccount = !!users.find(user => user.email === masterAccountEmail && user.isSubAccount)
+    const preparedUsers = _differenceBy(users, subUsers, 'email')
     let showContent
     if (isSubAccountsLoading) {
       showContent = <Loading />
@@ -134,9 +136,9 @@ class SubAccount extends PureComponent {
           {(masterAccount || (isSubAccount || !hasSubAccount)) && (
             <>
               <SubUsersAdd
-                users={users}
                 accounts={accounts}
                 authData={authData}
+                users={preparedUsers}
                 onChange={this.onSubUsersChange}
                 masterAccount={masterAccount}
                 addMultipleAccsEnabled={addMultipleAccsEnabled}


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203425507382730/f
#### Description:
- [x] Prevents the possibility for already created `sub-accounts` to being selected for the creation of new one
#### Before:
<img width="556" alt="create-sub-acc-selection-before" src="https://user-images.githubusercontent.com/41899906/203512963-b2da83e6-a94e-46bb-bc33-3f834363e459.png">

#### After:
<img width="534" alt="create-sub-acc-selection-after" src="https://user-images.githubusercontent.com/41899906/203513009-4108cd44-cf49-4340-8e41-cd760f2553c2.png">
