### PR TITLE
(fix) Staled master account

### DIFF
--- a/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
+++ b/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import _filter from 'lodash/filter'
+import _isEmpty from 'lodash/isEmpty'
 import { Classes, Dialog } from '@blueprintjs/core'
 
 import Icon from 'icons'
@@ -43,9 +44,22 @@ class RegisterSubAccounts extends PureComponent {
     }
   }
 
+  componentDidUpdate() {
+    const { users } = this.props
+    if (_isEmpty(users)) {
+      this.clearMasterAccEmail()
+    }
+  }
+
   onEmailChange = (email) => {
     this.setState({
       masterAccEmail: email,
+    })
+  }
+
+  clearMasterAccEmail = () => {
+    this.setState({
+      masterAccEmail: undefined,
     })
   }
 

--- a/src/components/SubAccounts/SubAccount/SubAccount.js
+++ b/src/components/SubAccounts/SubAccount/SubAccount.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Button, Intent } from '@blueprintjs/core'
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
+import _differenceBy from 'lodash/differenceBy'
 
 import Loading from 'ui/Loading'
 
@@ -113,6 +114,7 @@ class SubAccount extends PureComponent {
     const subUsers = _get(subAccountData, 'subUsers', [])
     const hasFilledAccounts = getFilledAccounts(accounts).length > 0
     const hasSubAccount = !!users.find(user => user.email === masterAccountEmail && user.isSubAccount)
+    const preparedUsers = _differenceBy(users, subUsers, 'email')
     let showContent
     if (isSubAccountsLoading) {
       showContent = <Loading />
@@ -134,9 +136,9 @@ class SubAccount extends PureComponent {
           {(masterAccount || (isSubAccount || !hasSubAccount)) && (
             <>
               <SubUsersAdd
-                users={users}
                 accounts={accounts}
                 authData={authData}
+                users={preparedUsers}
                 onChange={this.onSubUsersChange}
                 masterAccount={masterAccount}
                 addMultipleAccsEnabled={addMultipleAccsEnabled}


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203425677147878/f
#### Description:
- [x] Fixes issue with the staled `Master Account` still selected after the dropping database, restarting the backend and reloading the app
#### Before:
<img width="1264" alt="master-acc-before" src="https://user-images.githubusercontent.com/41899906/203860557-028ad16f-b536-4903-aa69-8d9e525e25af.png">

#### After:
<img width="1391" alt="master-acc-after" src="https://user-images.githubusercontent.com/41899906/203861516-d7446e13-aeeb-4ec3-be9d-d05e8ed15bcd.png">

- Depends on #576 