### PR TITLE
(fix) USDt symbols and pairs parsing

### DIFF
--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -39,7 +39,12 @@ export function symbolsReducer(state = initialState, action) {
           if (id.includes('F0')) {
             symbol = `${symbol} (deriv)`
           }
-          symbolMapping[id] = symbol
+          if (symbol === 'USDt') {
+            symbolMapping.UST = symbol
+          } else {
+            symbolMapping[id] = symbol
+          }
+
           explorersDict[symbol] = explorer
           dict[symbol] = name
           coins.push(symbol)

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -51,6 +51,8 @@ export function symbolsReducer(state = initialState, action) {
         coins.push(id)
       })
 
+      const preparedCoins = [...new Set(coins)].sort()
+
       const pairMapping = mapSymbols.reduce((acc, symbol) => {
         const [from, to] = symbol
         acc[from] = to
@@ -66,7 +68,7 @@ export function symbolsReducer(state = initialState, action) {
 
       return {
         ...state,
-        coins: coins.sort(),
+        coins: preparedCoins,
         currencies: dict,
         explorers: explorersDict,
         inactiveCurrencies: formattedInactiveCurrencies,


### PR DESCRIPTION
Tasks: 
- https://app.asana.com/0/1163495710802945/1203481440422500/f
- https://app.asana.com/0/1163495710802945/1203483745286385/f
#### Description:
- [x] Fixes issue with incorrect parsing `USDt` pairs,  `XXX:USX` instead of `XXX:UST`
- [x] Fixes issue with `USDt (tron)` repeated symbols 
#### Pairs before:
<img width="1258" alt="udst-pairs-before" src="https://user-images.githubusercontent.com/41899906/205480144-0a35bf85-2e6b-4fc1-94fc-8b4c39ffde00.png">

#### Pairs after:
<img width="1384" alt="udst-pairs-after" src="https://user-images.githubusercontent.com/41899906/205480158-56b107c3-9e0c-4cc8-8a7f-3a936352d70e.png">

#### Symbols before:
<img width="876" alt="usdt-tron-before" src="https://user-images.githubusercontent.com/41899906/205480173-672feaf3-09ec-4f4e-91f8-658c567d8034.png">

#### Symbols after:
<img width="878" alt="udt-tron-after" src="https://user-images.githubusercontent.com/41899906/205480189-3e855db3-b5a9-4f8f-9071-71ad1ad6dee9.png">

