### PR TITLE
(fix) URL to get API keys

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ const { REACT_APP_ENV } = process.env
 const environments = {
   development: {
     API_URL: 'http://localhost:31339/api',
-    KEY_URL: 'https://www.bitfinex.com',
+    KEY_URL: 'https://setting.bitfinex.com/api',
     HOME_URL: 'http://localhost:3000',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: true,
@@ -15,7 +15,7 @@ const environments = {
   },
   testing: {
     API_URL: 'https://bfx-report-ui.staging.bitfinex.com/api',
-    KEY_URL: 'https://www.staging.bitfinex.com',
+    KEY_URL: 'https://bfx-ui-settings.staging.bitfinex.com/api',
     HOME_URL: 'https://staging.bitfinex.com',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: false,
@@ -25,7 +25,7 @@ const environments = {
   },
   staging: {
     API_URL: 'https://bfx-report-ui.staging.bitfinex.com/api',
-    KEY_URL: 'https://www.staging.bitfinex.com',
+    KEY_URL: 'https://bfx-ui-settings.staging.bitfinex.com/api',
     HOME_URL: 'https://staging.bitfinex.com',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: false,
@@ -35,7 +35,7 @@ const environments = {
   },
   production: {
     API_URL: 'https://report.bitfinex.com/api',
-    KEY_URL: 'https://www.bitfinex.com',
+    KEY_URL: 'https://setting.bitfinex.com/api',
     HOME_URL: 'https://www.bitfinex.com/t',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: false,

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ const { REACT_APP_ENV } = process.env
 const environments = {
   development: {
     API_URL: 'http://localhost:31339/api',
-    KEY_URL: 'https://www.bitfinex.com/api',
+    KEY_URL: 'https://www.bitfinex.com',
     HOME_URL: 'http://localhost:3000',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: true,
@@ -15,7 +15,7 @@ const environments = {
   },
   testing: {
     API_URL: 'https://bfx-report-ui.staging.bitfinex.com/api',
-    KEY_URL: 'https://staging.bitfinex.com/api',
+    KEY_URL: 'https://www.staging.bitfinex.com',
     HOME_URL: 'https://staging.bitfinex.com',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: false,
@@ -25,7 +25,7 @@ const environments = {
   },
   staging: {
     API_URL: 'https://bfx-report-ui.staging.bitfinex.com/api',
-    KEY_URL: 'https://staging.bitfinex.com/api',
+    KEY_URL: 'https://www.staging.bitfinex.com',
     HOME_URL: 'https://staging.bitfinex.com',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: false,
@@ -35,7 +35,7 @@ const environments = {
   },
   production: {
     API_URL: 'https://report.bitfinex.com/api',
-    KEY_URL: 'https://www.bitfinex.com/api',
+    KEY_URL: 'https://www.bitfinex.com',
     HOME_URL: 'https://www.bitfinex.com/t',
     WS_ADDRESS: 'ws://127.0.0.1:31339/ws',
     localExport: false,


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203497198591291/f
#### Description:
- [x] Actualizes URLs for getting `API` keys 
#### Preview:
<img width="585" alt="api-key-url" src="https://user-images.githubusercontent.com/41899906/205918969-12c6766c-cf9d-4289-b9ad-f57ce12434a4.png">

Related to [bfx-report-electron #172](https://github.com/bitfinexcom/bfx-report-electron/pull/172)