### PR TITLE
(fix) haveCollsBeenSyncedAtLeastOnce request on the sign in

### DIFF
--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -159,6 +159,7 @@ export function* initSync() {
   const { result: syncProgress } = yield call(fetchSyncProgress)
   if (syncProgress === types.SYNC_NOT_STARTED) {
     yield put(actions.setIsSyncing(false))
+    yield call(startSyncing)
   } else {
     yield put(actions.setIsSyncing(true))
     const isSyncing = Number.isInteger(syncProgress) && syncProgress !== 100


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203493040915772/f
#### Description:
- [x] Fixes issue with missed `haveCollsBeenSyncedAtLeastOnce` request after signing in
#### Preview:
<img width="1356" alt="haveCollsBeenSyncedAtLeastOnce_after_sign_in" src="https://user-images.githubusercontent.com/41899906/206494705-9d777252-fa5e-4f99-8891-6844e7756e43.png">
