### PR TITLE
(fix) Derivatives: dropping selected pairs on refresh

### DIFF
--- a/src/state/derivatives/reducer.js
+++ b/src/state/derivatives/reducer.js
@@ -11,6 +11,7 @@ import {
   fetch,
   fetchFail,
   removePair,
+  refresh,
   setPairs,
 } from 'state/reducers.helper'
 import { formatPair, mapPair } from 'state/symbols/utils'
@@ -81,6 +82,7 @@ export function derivativesReducer(state = initialState, action) {
     case types.CLEAR_PAIRS:
       return clearPairs(state, initialState)
     case types.REFRESH:
+      return refresh(TYPE, state, initialState)
     case authTypes.LOGOUT:
       return initialState
     default: {

--- a/src/state/derivatives/reducer.js
+++ b/src/state/derivatives/reducer.js
@@ -3,6 +3,7 @@ import _get from 'lodash/get'
 import _sortBy from 'lodash/sortBy'
 
 import authTypes from 'state/auth/constants'
+import queryTypes from 'state/query/constants'
 import {
   addPair,
   basePairState,
@@ -19,6 +20,8 @@ import types from './constants'
 const initialState = {
   ...basePairState,
 }
+
+const TYPE = queryTypes.MENU_DERIVATIVES
 
 export function derivativesReducer(state = initialState, action) {
   const { type: actionType, payload } = action


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203800205087029/f
#### Description:
- [x] Fixes issue with dropping selected pairs on `Derivatives` refreshing
#### Before:
https://user-images.githubusercontent.com/41899906/214562439-6f00bfe8-a57f-4c08-abfd-e74f5393e177.mov

#### After:
https://user-images.githubusercontent.com/41899906/214562510-15d8f6ca-68b6-4635-afa2-8b488db4fc01.mov

