### PR TITLE
(fix) Adjust symbol filter

### DIFF
--- a/src/ui/Select/_Select.scss
+++ b/src/ui/Select/_Select.scss
@@ -59,7 +59,8 @@
 
     &--symbol, &--pair {
       .bp3-popover-content {
-        width: 180px;
+        min-width: 180px;
+        width: fit-content;
       }
     }
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204059893810965/f
#### Description:
- [x] Fixes issues with some symbols representation in the `Symbol Filter` dropdown list
#### Before:
<img width="555" alt="symbol-select-before" src="https://user-images.githubusercontent.com/41899906/222405897-1deafcf9-0ae4-4ce3-8fd9-6eafc4613efb.png">

#### After:
<img width="548" alt="symbol-select-after" src="https://user-images.githubusercontent.com/41899906/222405986-8e066c81-2141-4d20-8b81-fd1b0a6fd6d3.png">
