### PR TITLE
(improvement) Rework getUsers request

### DIFF
--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -14,7 +14,7 @@ import WS from 'state/ws'
 import wsTypes from 'state/ws/constants'
 import wsSignIn from 'state/ws/signIn'
 import { selectAuth } from 'state/auth/selectors'
-import { formatAuthDate, makeFetchCall } from 'state/utils'
+import { formatAuthDate, makeFetchCall, postJsonFetch } from 'state/utils'
 import tokenRefreshSaga from 'state/auth/tokenRefresh/saga'
 import { togglePreferencesDialog } from 'state/ui/actions'
 import { updateErrorStatus, updateSuccessStatus } from 'state/status/actions'
@@ -179,7 +179,8 @@ function* signIn({ payload }) {
 
 function* fetchUsers() {
   try {
-    const { result: users } = yield call(makeFetchCall, 'getUsers')
+    const { result: users } = yield call(postJsonFetch,
+      `${config.API_URL}/json-rpc`, { method: 'getUsers' })
 
     if (users) {
       yield put(actions.setUsers(users))

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -54,7 +54,7 @@ export const getAuthFromStore = () => {
 // turned off for firefox
 export const getDefaultTableScrollSetting = () => config.isElectronApp || !navigator.userAgent.includes('Firefox')
 
-export function postJsonfetch(url, bodyJson) {
+export function postJsonFetch(url, bodyJson) {
   return fetch(url, {
     method: 'POST',
     headers: {
@@ -69,7 +69,7 @@ export function postJsonfetch(url, bodyJson) {
 }
 
 export function makeFetchCall(method, params = undefined, auth = getAuthFromStore()) {
-  return postJsonfetch(`${config.API_URL}/json-rpc`, {
+  return postJsonFetch(`${config.API_URL}/json-rpc`, {
     auth,
     method,
     params: params || undefined,
@@ -510,7 +510,7 @@ export default {
   isValidateType,
   momentFormatter,
   momentFormatterDays,
-  postJsonfetch,
+  postJsonFetch,
   removeUrlParams,
   getFrameworkPositionsEntries,
   getFrameworkPositionsTickersEntries,


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1203668664168006/f
#### Description:
- [x] Reworks `getUsers` call without `auth` params that are redundant for this public endpoint
#### Before:
<img width="1288" alt="get_users_before" src="https://user-images.githubusercontent.com/41899906/223399688-a77ff17e-4602-4792-babe-49aaa32df3ab.png">

#### After:
<img width="1087" alt="get_users_after" src="https://user-images.githubusercontent.com/41899906/223399769-423c3177-5c45-4e20-9124-194d52658aee.png">

