### PR TITLE
(fix) Wrong symbol param for getPublicTrades request

### DIFF
--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -6,7 +6,7 @@ import {
 } from 'redux-saga/effects'
 
 import { makeFetchCall } from 'state/utils'
-import { formatRawSymbols, mapRequestPairs } from 'state/symbols/utils'
+import { formatRawSymbols, deformatPair } from 'state/symbols/utils'
 import { getTimeFrame } from 'state/timeRange/selectors'
 import { getFilterQuery } from 'state/filters/selectors'
 import { refreshPagination, updatePagination } from 'state/pagination/actions'
@@ -33,8 +33,9 @@ function getReqPublicTrades({
     end,
     filter,
     limit: getQueryLimit(TYPE),
-    symbol: formatRawSymbols(mapRequestPairs(targetPair, true)),
+    symbol: formatRawSymbols(deformatPair(targetPair)),
   }
+
   return makeFetchCall('getPublicTrades', params)
 }
 

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -1,3 +1,5 @@
+import _map from 'lodash/map'
+
 import authTypes from 'state/auth/constants'
 import { formatPair, mapPair, mapSymbol } from 'state/symbols/utils'
 
@@ -67,8 +69,8 @@ export function symbolsReducer(state = initialState, action) {
       SymbolMap.setSymbols(symbolMapping)
       SymbolMap.setPairs(pairMapping)
 
+      const formattedPairs = _map(pairs, formatPair).sort()
       const formattedInactiveCurrencies = inactiveCurrencies.map(mapSymbol).sort()
-      const formattedPairs = pairs.map(formatPair).map(mapPair).sort()
       const formattedInactivePairs = inactiveSymbols.map(formatPair).map(mapPair).sort()
 
       return {

--- a/src/state/symbols/utils/index.js
+++ b/src/state/symbols/utils/index.js
@@ -8,7 +8,7 @@ export * from './mapping'
 // BTCUSD -> tBTCUSD
 // BTCF0:USDF0 -> tBTCF0:USDF0
 // USD -> fUSD
-const addPrefix = (symbol = '', isFunding = false) => (
+export const addPrefix = (symbol = '', isFunding = false) => (
   (isFunding || symbol.length < 6) ? `f${symbol}` : `t${symbol}`
 )
 
@@ -61,7 +61,7 @@ export const getSymbolsURL = (symbols) => {
 
 // BTC:USD -> BTCUSD
 // BTCF0:USTF0 -> BTCF0:USTF0
-const deformatPair = pair => ((pair.length === 7) ? pair.replace(':', '') : pair)
+export const deformatPair = pair => ((pair.length === 7) ? pair.replace(':', '') : pair)
 
 // BTCUSD -> tBTCUSD
 // ['BTCUSD'] -> 'tBTCUSD'
@@ -80,7 +80,9 @@ export const formatRawSymbols = (symbols, isFunding) => {
 }
 
 export default {
+  addPrefix,
   formatPair,
+  deformatPair,
   formatRawSymbols,
   getMappedSymbolsFromUrl,
   getSymbolsURL,

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -179,7 +179,7 @@ export const checkInit = (props, type) => {
       if (!dataReceived && !pageLoading) {
         const pair = (match.params && match.params.pair) || ''
         if (pair) {
-          setTargetPair(getMappedSymbolsFromUrl(pair)[0])
+          setTargetPair(pair)
         }
         fetchData()
       }
@@ -327,7 +327,7 @@ export function setPair(type, props, pair) {
 
   if (targetPair !== pair) {
     setTargetPair(pair)
-    history.push(generateUrl(type, window.location.search, demapPairs(pair)))
+    history.push(generateUrl(type, window.location.search, [pair]))
   }
 }
 

--- a/src/ui/Select/_Select.scss
+++ b/src/ui/Select/_Select.scss
@@ -1,6 +1,7 @@
 .bitfinex-select {
   .bp3-button {
-    width: 180px;
+    min-width: 180px;
+    width: fit-content;
     height: 40px;
     padding-right: 8px;
     background-color: var(--multiBg);


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204298582161856/f
#### Description:
- [x] Fixes issues with incorrect pairs formatting and providing a `symbol` param for the `getPublicTrades` request in some cases
- [x] Adjusts `Symbol Filter` width to fit better for all available pairs
#### Before:
<img width="1134" alt="fix_symbol_before" src="https://user-images.githubusercontent.com/41899906/228871455-ff9f8b69-7831-4824-b213-1354c1af7034.png">

#### After:
<img width="1371" alt="fix_symbol_after" src="https://user-images.githubusercontent.com/41899906/228871519-2be8b5f2-344c-4c2d-a7b9-c6a98dbdc9c4.png">
