### PR TITLE
(fix) Selection restricted users for multi accounts

### DIFF
--- a/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
+++ b/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
@@ -49,10 +49,10 @@ class RegisterSubAccounts extends PureComponent {
   constructor(props) {
     super()
 
-    const { authData: { email }, users } = props
-    const { email: firstUserEmail } = filterRestrictedUsers(users)[0] || {}
+    const { users } = props
+    const { email } = filterRestrictedUsers(users)[0] || {}
     this.state = {
-      masterAccEmail: email || firstUserEmail,
+      masterAccEmail: email,
     }
   }
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204435653795721/f

#### Description:
- [x] Fixes issues with the availability to the selection of restricted users with `isRestrictedToBeAddedToSubAccount` flag for `Multiple Accounts` in some specific  cases

#### Before: 
<img width="1204" alt="restricted_for_sub_accs_before" src="https://user-images.githubusercontent.com/41899906/233598004-8a5341ff-9022-4e8c-9157-2199b0e93ce5.png">

#### After: 
<img width="1173" alt="restricted_for_sub_accs_after" src="https://user-images.githubusercontent.com/41899906/233598563-30ab529f-bf6b-45ec-80be-4e2010b4c494.png">

#### Depends on: 
- [bfx-reports-framework #260](https://github.com/bitfinexcom/bfx-reports-framework/pull/260)
