### PR TITLE
(feature) Ability to name multiple accounts

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -571,7 +571,9 @@
     "api_secret": "API Secret",
     "password": "Password",
     "remove": "Remove Sub Account",
-    "login": "Login To Sub Account"
+    "login": "Login To Sub Account",
+    "name_label": "Name",
+    "name_placeholder": "Accounts Group Name (optional)"
   },
   "symbols": {
     "title": "Get symbols",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -573,7 +573,7 @@
     "remove": "Remove Sub Account",
     "login": "Login To Sub Account",
     "name_label": "Name",
-    "name_placeholder": "Accounts Group Name (optional)"
+    "name_placeholder": "Accounts group name (optional)"
   },
   "symbols": {
     "title": "Get symbols",

--- a/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
+++ b/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
@@ -120,9 +120,10 @@ class RegisterSubAccounts extends PureComponent {
           />
           <>
             <SubAccount
-              authData={authData}
               users={users}
+              authData={authData}
               allowedUsers={preparedUsers}
+              localUsername={localUsername}
               masterAccount={masterAccEmail}
               isMultipleAccsSelected={isMultipleAccsSelected}
             />

--- a/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
+++ b/src/components/Auth/RegisterSubAccounts/RegisterSubAccounts.js
@@ -10,6 +10,7 @@ import config from 'config'
 import PlatformLogo from 'ui/PlatformLogo'
 import SubAccount from 'components/SubAccounts/SubAccount'
 
+import InputKey from '../InputKey'
 import { AUTH_TYPES, MODES } from '../Auth'
 import SelectedUserItem from '../SignIn/SignIn.item'
 
@@ -46,6 +47,7 @@ class RegisterSubAccounts extends PureComponent {
 
     const { masterAccount } = props
     this.state = {
+      localUsername: null,
       masterAccEmail: masterAccount,
     }
   }
@@ -70,6 +72,11 @@ class RegisterSubAccounts extends PureComponent {
     this.clearMasterAccEmail()
   }
 
+  handleInputChange = (e) => {
+    const { name, value } = e.target
+    this.setState({ [name]: value })
+  }
+
   render() {
     const {
       t,
@@ -78,7 +85,7 @@ class RegisterSubAccounts extends PureComponent {
       masterAccount,
       isMultipleAccsSelected,
     } = this.props
-    const { masterAccEmail } = this.state
+    const { masterAccEmail, localUsername } = this.state
     const preparedUsers = filterRestrictedUsers(users)
     const classes = classNames(
       'bitfinex-auth',
@@ -102,6 +109,14 @@ class RegisterSubAccounts extends PureComponent {
             user={masterAccount}
             title={'auth.addAccountsTo'}
             backToUsersList={this.handleBackToSignIn}
+          />
+          <InputKey
+            type='text'
+            name='localUsername'
+            value={localUsername}
+            label='subaccounts.name_label'
+            onChange={this.handleInputChange}
+            placeholder={t('subaccounts.name_placeholder')}
           />
           <>
             <SubAccount

--- a/src/components/Auth/RegisterSubAccounts/_RegisterSubAccounts.scss
+++ b/src/components/Auth/RegisterSubAccounts/_RegisterSubAccounts.scss
@@ -6,6 +6,15 @@
     color: var(--activeColor);
   }
 
+  .bp3-dialog-body {
+    .bitfinex-auth-form-input {
+      .bp3-form-group {
+        margin-left: 1px;
+        margin-bottom: 2px;
+      }
+    }
+  }
+
   .sub-account {
     &-controls {
       margin-bottom: 20px;

--- a/src/components/Auth/SignIn/SignIn.js
+++ b/src/components/Auth/SignIn/SignIn.js
@@ -85,7 +85,6 @@ class SignIn extends PureComponent {
       switchMode,
       isUsersLoaded,
       authData: { email },
-      isMultipleAccsSelected,
     } = this.props
 
     if (!prevProps.isUsersLoaded && isUsersLoaded) {
@@ -98,15 +97,6 @@ class SignIn extends PureComponent {
       } else {
         switchMode(MODES.SIGN_UP)
       }
-    }
-
-    if (!prevProps.isMultipleAccsSelected && isMultipleAccsSelected) {
-      const multiAccsUsers = getPreparedUsers(users, isMultipleAccsSelected)
-      const updatedEmail = multiAccsUsers[0]
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        email: updatedEmail || '',
-      })
     }
 
     this.handleSubAccounts()

--- a/src/components/Auth/SignIn/SignIn.js
+++ b/src/components/Auth/SignIn/SignIn.js
@@ -144,14 +144,6 @@ class SignIn extends PureComponent {
     })
   }
 
-  onEmailChange = (email) => {
-    const { authData: { email: preservedEmail, password } } = this.props
-    this.setState({
-      email,
-      password: email === preservedEmail ? password : undefined,
-    })
-  }
-
   handle2FACancel = () => {
     const { showOtpLogin } = this.props
     this.setState({ otp: '' })

--- a/src/components/Header/AccountMenu/AccountMenu.container.js
+++ b/src/components/Header/AccountMenu/AccountMenu.container.js
@@ -4,7 +4,12 @@ import { withRouter } from 'react-router-dom'
 import { withTranslation } from 'react-i18next'
 
 import { logout } from 'state/auth/actions'
-import { getAuthStatus, getEmail, getIsSubAccsAvailable } from 'state/auth/selectors'
+import {
+  getEmail,
+  getAuthStatus,
+  getLocalUsername,
+  getIsSubAccsAvailable,
+} from 'state/auth/selectors'
 import { toggleExportDialog, togglePreferencesDialog } from 'state/ui/actions'
 
 import AccountMenu from './AccountMenu'
@@ -12,6 +17,7 @@ import AccountMenu from './AccountMenu'
 const mapStateToProps = state => ({
   email: getEmail(state),
   authStatus: getAuthStatus(state),
+  localUsername: getLocalUsername(state),
   isSubAccsAvailable: getIsSubAccsAvailable(state),
 })
 

--- a/src/components/Header/AccountMenu/AccountMenu.js
+++ b/src/components/Header/AccountMenu/AccountMenu.js
@@ -7,7 +7,9 @@ import {
   Popover,
   Position,
 } from '@blueprintjs/core'
+import _isNull from 'lodash/isNull'
 import _isString from 'lodash/isString'
+import _toString from 'lodash/toString'
 
 import Icon from 'icons'
 import config from 'config'
@@ -21,7 +23,10 @@ import { openHelp } from '../utils'
 const { showFrameworkMode } = config
 const { MENU_LOGINS, MENU_SUB_ACCOUNTS, MENU_CHANGE_LOGS } = queryConstants
 
-const formatUsername = (email = '') => {
+const formatUsername = (email = '', localUsername) => {
+  if (!_isNull(localUsername)) {
+    return _toString(localUsername)
+  }
   if (!_isString(email)) {
     return ''
   }
@@ -34,6 +39,7 @@ const AccountMenu = ({
   logout,
   history,
   authStatus,
+  localUsername,
   togglePrefDialog,
   toggleExportDialog,
   isSubAccsAvailable,
@@ -114,7 +120,7 @@ const AccountMenu = ({
           <div className='account-menu-target'>
             <Icon.USER_CIRCLE />
             <span className='account-menu-username'>
-              {authStatus ? formatUsername(email) : ''}
+              {authStatus ? formatUsername(email, localUsername) : ''}
             </span>
             <Icon.CHEVRON_DOWN />
             <Icon.CHEVRON_UP />
@@ -140,6 +146,11 @@ AccountMenu.propTypes = {
       search: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  localUsername: PropTypes.string,
+}
+
+AccountMenu.defaultProps = {
+  localUsername: null,
 }
 
 export default memo(AccountMenu)

--- a/src/components/SubAccounts/SubAccount/SubAccount.js
+++ b/src/components/SubAccounts/SubAccount/SubAccount.js
@@ -88,13 +88,14 @@ class SubAccount extends PureComponent {
   }
 
   updateSubAccount = () => {
-    const { masterAccount, updateSubAccount } = this.props
+    const { masterAccount, updateSubAccount, localUsername } = this.props
     const { accounts, subUsersToRemove } = this.state
 
     const filledAccounts = getFilledAccounts(accounts)
     if (filledAccounts.length || subUsersToRemove.length) {
       updateSubAccount({
         masterAccount,
+        localUsername,
         addedSubUsers: filledAccounts,
         removedSubUsers: subUsersToRemove,
       })

--- a/src/components/SubAccounts/SubAccount/SubAccount.js
+++ b/src/components/SubAccounts/SubAccount/SubAccount.js
@@ -23,6 +23,7 @@ class SubAccount extends PureComponent {
     isSubAccountsLoading: PropTypes.bool,
     isMultipleAccsSelected: PropTypes.bool,
     masterAccount: PropTypes.string,
+    localUsername: PropTypes.string,
     updateSubAccount: PropTypes.func.isRequired,
     users: PropTypes.arrayOf(PropTypes.shape({
       email: PropTypes.string.isRequired,
@@ -38,6 +39,7 @@ class SubAccount extends PureComponent {
   static defaultProps = {
     allowedUsers: [],
     isSyncing: false,
+    localUsername: null,
     masterAccount: undefined,
     isSubAccountsLoading: false,
     isMultipleAccsSelected: false,
@@ -49,7 +51,7 @@ class SubAccount extends PureComponent {
   }
 
   createSubAccount = () => {
-    const { addSubAccount, masterAccount } = this.props
+    const { addSubAccount, masterAccount, localUsername } = this.props
     const { accounts } = this.state
 
     const preparedAccountData = getFilledAccounts(accounts).map((account) => {
@@ -65,7 +67,7 @@ class SubAccount extends PureComponent {
         : { apiKey, apiSecret }
     })
 
-    addSubAccount({ preparedAccountData, masterAccount })
+    addSubAccount({ preparedAccountData, masterAccount, localUsername })
 
     this.setState({
       accounts: [EMPTY_ACCOUNT],

--- a/src/state/auth/selectors.js
+++ b/src/state/auth/selectors.js
@@ -20,7 +20,7 @@ export const getUserShouldReLogin = state => getAuth(state)?.userShouldReLogin ?
 export const getIsSubAccsAvailable = state => _first(
   _filter(getUsers(state), user => _isEqual(user?.email, getEmail(state))),
 )?.isApiKeysAuth ?? true
-export const getLocalUsername = state => getAuth(state)?.localUsername ?? false
+export const getLocalUsername = state => getAuth(state)?.localUsername ?? null
 
 export const getAuthData = state => {
   const {

--- a/src/state/auth/selectors.js
+++ b/src/state/auth/selectors.js
@@ -20,6 +20,7 @@ export const getUserShouldReLogin = state => getAuth(state)?.userShouldReLogin ?
 export const getIsSubAccsAvailable = state => _first(
   _filter(getUsers(state), user => _isEqual(user?.email, getEmail(state))),
 )?.isApiKeysAuth ?? true
+export const getLocalUsername = state => getAuth(state)?.localUsername ?? false
 
 export const getAuthData = state => {
   const {
@@ -104,4 +105,5 @@ export default {
   getLoginToken,
   getUserShouldReLogin,
   getIsSubAccsAvailable,
+  getLocalUsername,
 }

--- a/src/state/subAccounts/saga.js
+++ b/src/state/subAccounts/saga.js
@@ -52,11 +52,9 @@ const getReqUpdateSubAccount = (params, auth) => {
 export function* createSubAccount({ payload }) {
   const { preparedAccountData, masterAccount, localUsername } = payload
   const params = { subAccountApiKeys: preparedAccountData, masterAccount, localUsername }
-  console.log('+++createSubAccount1', payload)
   try {
     yield put(setSubAccountLoadingStatus(true))
     const { result, error } = yield call(getReqCreateSubAccount, params)
-    console.log('+++createSubAccount2', result)
     if (result) {
       yield put(setSubAccountLoadingStatus(false))
       yield put(fetchUsers())
@@ -129,7 +127,9 @@ export function* removeSubAccount({ payload: masterAccount }) {
 
 export function* updateSubAccount({ payload }) {
   try {
-    const { addedSubUsers, removedSubUsers, masterAccount } = payload
+    const {
+      addedSubUsers, removedSubUsers, masterAccount, localUsername,
+    } = payload
 
     let auth
     if (masterAccount) {
@@ -149,6 +149,7 @@ export function* updateSubAccount({ payload }) {
       params.removingSubUsersByEmails = removedSubUsers.map(subUserEmail => ({ email: subUserEmail }))
     }
     yield put(setSubAccountLoadingStatus(true))
+    yield makeFetchCall('updateUser', { localUsername }, auth)
     const { result, error } = yield call(getReqUpdateSubAccount, params, auth)
     if (result) {
       yield put(setSubAccountLoadingStatus(false))

--- a/src/state/subAccounts/saga.js
+++ b/src/state/subAccounts/saga.js
@@ -17,6 +17,7 @@ import { setSubAccountLoadingStatus } from './actions'
 const getReqCreateSubAccount = ({
   masterAccount,
   subAccountApiKeys,
+  localUsername,
 }) => {
   if (masterAccount) {
     const auth = {
@@ -25,10 +26,12 @@ const getReqCreateSubAccount = ({
     }
     return makeFetchCall('createSubAccount', {
       subAccountApiKeys,
+      localUsername,
     }, auth)
   }
   return makeFetchCall('createSubAccount', {
     subAccountApiKeys,
+    localUsername,
   })
 }
 
@@ -47,11 +50,13 @@ const getReqUpdateSubAccount = (params, auth) => {
 }
 
 export function* createSubAccount({ payload }) {
-  const { preparedAccountData, masterAccount } = payload
-  const params = { subAccountApiKeys: preparedAccountData, masterAccount }
+  const { preparedAccountData, masterAccount, localUsername } = payload
+  const params = { subAccountApiKeys: preparedAccountData, masterAccount, localUsername }
+  console.log('+++createSubAccount1', payload)
   try {
     yield put(setSubAccountLoadingStatus(true))
     const { result, error } = yield call(getReqCreateSubAccount, params)
+    console.log('+++createSubAccount2', result)
     if (result) {
       yield put(setSubAccountLoadingStatus(false))
       yield put(fetchUsers())


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204388320575679/f

#### Description:
- [x] Implements the possibility of optional naming for multiple accounts during creating or updating
- [x] Implements displaying optional `localUsername` (if available) instead of the account email

#### Preview: 
https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/ef63781a-78ec-46ef-9dbd-18d780351ba8


#### Depends on: 
- [bfx-reports-framework #271](https://github.com/bitfinexcom/bfx-reports-framework/pull/271)

