### PR TITLE
(improvement) Dates range preserving

### DIFF
--- a/src/state/timeRange/reducer.js
+++ b/src/state/timeRange/reducer.js
@@ -1,6 +1,8 @@
 import { REHYDRATE } from 'redux-persist'
 import _get from 'lodash/get'
 
+import authTypes from 'state/auth/constants'
+
 import types from './constants'
 
 const initialState = {
@@ -40,6 +42,8 @@ export function timeRangeReducer(state = initialState, action) {
         ...state,
         isTimeRangePreserved: !state.isTimeRangePreserved,
       }
+    case authTypes.LOGOUT:
+      return state.isTimeRangePreserved ? state : initialState
     default:
       return state
   }

--- a/src/state/timeRange/reducer.js
+++ b/src/state/timeRange/reducer.js
@@ -7,7 +7,7 @@ const initialState = {
   range: types.DEFAULT_RANGE,
   start: undefined,
   end: undefined,
-  isTimeRangePreserved: true,
+  isTimeRangePreserved: false,
 }
 
 export function timeRangeReducer(state = initialState, action) {


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204559203795582/f

#### Description:
- [x] Prevents selected dates range preserving by default between login sessions, the default range `Last 2 Weeks` will be set from the start until the `Preserve Timeframe` option won't be turned on in the `Preferences` menu

#### Preview: 

https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/a9c61e5f-fcb5-48a5-b056-5a3feae5960a

