### PR TITLE
(fix) Password input on the default screen

### DIFF
--- a/src/components/Auth/SignIn/SignIn.js
+++ b/src/components/Auth/SignIn/SignIn.js
@@ -220,7 +220,7 @@ class SignIn extends PureComponent {
     const isSignInDisabled = !email || (isElectronApp && !isElectronBackendLoaded)
       || (!isNotProtected && !password)
     const isEmailSelected = !_isEmpty(email)
-    const isCurrentUserShouldReLogin = isEmailSelected && _isEqual(email, userShouldReLogin)
+    const isCurrentUserShouldReLogin = isEmailSelected && _isEqual(email, userShouldReLogin) && !showUsersList
     const showSelectedUser = !showUsersList && isEmailSelected
     const showInputPassword = !isNotProtected && !showUsersList && isEmailSelected && users.length > 0
     const showSignInActions = !isOtpLoginShown && !showUsersList


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204646424446474/f
#### Description:
- [x] Fixes the issue with the `Password` input availability on the main registered users list screen in some specific cases:
<img width="570" alt="pwd-field-on-users-list" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/d1be3b3a-7a06-4106-a37c-b7656dca2207">
