### PR TITLE
(improvement) Weighted averages limit note

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -699,11 +699,10 @@
   "weightedaverages": {
     "title": "Weighted Averages",
     "limitNote":{
-      "displayDate": "Display date: ",
-      "note1": "Note that the selected dates are not the same as the display dates. This is because the web version is limited to displaying 2,000 transactions at a time.",
-      "note2": "In case a bigger period of time is intended, can try by just selecting one symbol or by downloading ",
-      "link": "our software",
-      "note3": " that does not have this limit."
+      "displayDate": "Displaying transactions for period: ",
+      "note1": "Your request exceeds the limit of 2000 transactions to display.",
+      "link": "Download the Reports App",
+      "note2": " to display more or change your filters."
     }
   },
   "withdrawals": {

--- a/src/components/WeightedAverages/WeightedAverages.note.js
+++ b/src/components/WeightedAverages/WeightedAverages.note.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
+import Icon from 'icons'
 import { formatDate } from 'state/utils'
 import { getTimezone } from 'state/base/selectors'
 
@@ -13,22 +14,27 @@ const LimitNote = ({ start, end }) => {
   const timezone = useSelector(getTimezone)
   return (
     <div className='limit-note'>
-      <p className='limit-note--header'>
-        {t('weightedaverages.limitNote.displayDate')}
-        {`${formatDate(start, timezone)} - ${formatDate(end, timezone)}`}
-      </p>
-      <div className='limit-note--body'>
-        {t('weightedaverages.limitNote.note1')}
-        <br />
-        <a
-          target='_blank'
-          href={REPORTS_LINK}
-          rel='noopener noreferrer'
-          className='limit-note--body-link'
-        >
-          {t('weightedaverages.limitNote.link')}
-        </a>
-        {t('weightedaverages.limitNote.note2')}
+      <div className='limit-note--icon'>
+        <Icon.INFO_CIRCLE />
+      </div>
+      <div className='limit-note--text'>
+        <p className='limit-note--header'>
+          {t('weightedaverages.limitNote.displayDate')}
+          {`${formatDate(start, timezone)} - ${formatDate(end, timezone)}`}
+        </p>
+        <div className='limit-note--body'>
+          {t('weightedaverages.limitNote.note1')}
+          <br />
+          <a
+            target='_blank'
+            href={REPORTS_LINK}
+            rel='noopener noreferrer'
+            className='limit-note--body-link'
+          >
+            {t('weightedaverages.limitNote.link')}
+          </a>
+          {t('weightedaverages.limitNote.note2')}
+        </div>
       </div>
     </div>
   )

--- a/src/components/WeightedAverages/WeightedAverages.note.js
+++ b/src/components/WeightedAverages/WeightedAverages.note.js
@@ -20,15 +20,15 @@ const LimitNote = ({ start, end }) => {
       <div className='limit-note--body'>
         {t('weightedaverages.limitNote.note1')}
         <br />
-        {t('weightedaverages.limitNote.note2')}
         <a
           target='_blank'
           href={REPORTS_LINK}
           rel='noopener noreferrer'
+          className='limit-note--body-link'
         >
           {t('weightedaverages.limitNote.link')}
         </a>
-        {t('weightedaverages.limitNote.note3')}
+        {t('weightedaverages.limitNote.note2')}
       </div>
     </div>
   )

--- a/src/components/WeightedAverages/WeightedAverages.note.js
+++ b/src/components/WeightedAverages/WeightedAverages.note.js
@@ -15,7 +15,7 @@ const LimitNote = ({ start, end }) => {
     <div className='limit-note'>
       <p className='limit-note--header'>
         {t('weightedaverages.limitNote.displayDate')}
-        {`${formatDate(start, timezone)} - ${formatDate(end, timezone)} *`}
+        {`${formatDate(start, timezone)} - ${formatDate(end, timezone)}`}
       </p>
       <div className='limit-note--body'>
         {t('weightedaverages.limitNote.note1')}

--- a/src/components/WeightedAverages/_WeightedAverages.scss
+++ b/src/components/WeightedAverages/_WeightedAverages.scss
@@ -4,14 +4,19 @@
     margin-bottom: 25px;
     background-color: var(--bgColor);
     border-radius: 4px;
-    font-size: 12px;
+    font-size: 13px;
     
     &--header {
       color: var(--activeColor)
     }
 
     &--body {
-      color: var(--color2)
+      color: var(--color2);
+
+      &-link {
+        color: var(--color2);
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/src/components/WeightedAverages/_WeightedAverages.scss
+++ b/src/components/WeightedAverages/_WeightedAverages.scss
@@ -1,9 +1,13 @@
 .weighted-averages {
   .limit-note {
+    padding: 15px 20px;
     margin-bottom: 25px;
+    background-color: var(--bgColor);
+    border-radius: 4px;
+    font-size: 12px;
     
     &--header {
-      color: var(--validationErrorColor)
+      color: var(--activeColor)
     }
 
     &--body {

--- a/src/components/WeightedAverages/_WeightedAverages.scss
+++ b/src/components/WeightedAverages/_WeightedAverages.scss
@@ -1,13 +1,26 @@
 .weighted-averages {
   .limit-note {
-    padding: 15px 20px;
-    margin-bottom: 25px;
-    background-color: var(--bgColor);
-    border-radius: 4px;
     font-size: 13px;
+    max-width: 1006px;
+    padding: 20px;
+    margin-bottom: 25px;
+    border-radius: 4px;
+    background-color: var(--bgColor);
+    display: flex;
+
+    &--icon {
+      margin-right: 12px;
+
+      svg {
+        .icon--info-circle {
+          fill: var(--activeColor);
+        }
+      }
+    }
+    
     
     &--header {
-      color: var(--activeColor)
+      color: var(--activeColor);
     }
 
     &--body {


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204569805902093/f

#### Description:
- [x] Improves `Weighted Averages` web version limit note representation according to the latest design updates

#### Before: 
<img width="1373" alt="wegted-avgs-limit-nitice-before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/7a4e7907-d8be-441e-ad17-30b7b3c38ce1">

#### After: 
<img width="1378" alt="wegted-avgs-limit-nitice-after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/a793544e-4526-49e0-a519-04c743193bcb">
