### PR TITLE
(improvements) Navigation adjustments

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -370,7 +370,7 @@
       "title": "My Account",
       "summary": "Summary",
       "balance": "Balance",
-      "analysisStat": "Analysis/Statistics",
+      "analysisStat": "Analysis & Statistics",
       "analysisStatTabs": {
         "weightedAvgs": "Weighted Averages",
         "volume": "Volume",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -403,7 +403,11 @@
         "staking": "Staking",
         "affiliates": "Affiliates"
       },
-      "wallets": "Wallets" 
+      "wallets": "Wallets",
+      "walletsTabs": {
+        "balances": "Balances",
+        "movements": "Movements"
+      }
     },
     "merchantHistory": {
       "title": "Merchant History",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -383,7 +383,7 @@
     },
     "myHistory": {
       "title": "My History",
-      "general": "General",
+      "ledgersTrading": "Ledgers & Trading",
       "generalTabs": {
         "ledgers": "Ledgers",
         "trades": "Trades",

--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -103,7 +103,7 @@ class Wallets extends PureComponent {
       >
         <SectionHeader>
           <SectionHeaderTitle>
-            {t('wallets.title')}
+            {t('navItems.myHistory.walletsTabs.balances')}
           </SectionHeaderTitle>
           <SectionSwitch target={TYPE} />
           {isFrameworkMode && (

--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -17,6 +17,7 @@ import {
 } from 'ui/SectionHeader'
 import QueryButton from 'ui/QueryButton'
 import RefreshButton from 'ui/RefreshButton'
+import SectionSwitch from 'ui/SectionSwitch'
 import { isValidTimeStamp } from 'state/query/utils'
 import queryConstants from 'state/query/constants'
 
@@ -104,6 +105,7 @@ class Wallets extends PureComponent {
           <SectionHeaderTitle>
             {t('wallets.title')}
           </SectionHeaderTitle>
+          <SectionSwitch target={TYPE} />
           {isFrameworkMode && (
             <SectionHeaderRow>
               <SectionHeaderItem>

--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -3,6 +3,7 @@ import { withTranslation } from 'react-i18next'
 import { Card, Elevation } from '@blueprintjs/core'
 import _isEmpty from 'lodash/isEmpty'
 
+import config from 'config'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DateInput from 'ui/DateInput'
@@ -17,12 +18,13 @@ import {
 import QueryButton from 'ui/QueryButton'
 import RefreshButton from 'ui/RefreshButton'
 import { isValidTimeStamp } from 'state/query/utils'
-import config from 'config'
+import queryConstants from 'state/query/constants'
 
 import WalletsData from './Wallets.data'
 import { propTypes, defaultProps } from './Wallets.props'
 
 const isFrameworkMode = config.showFrameworkMode
+const TYPE = queryConstants.MENU_WALLETS
 
 class Wallets extends PureComponent {
   constructor(props) {

--- a/src/ui/NavMenu/NavMenu.helpers.js
+++ b/src/ui/NavMenu/NavMenu.helpers.js
@@ -62,7 +62,7 @@ export const getSections = (menuType, isTurkishSite) => {
       ]
     case MENU_MY_HISTORY:
       return [
-        [MENU_LEDGERS, 'navItems.myHistory.general', false, GENERAL_TARGETS],
+        [MENU_LEDGERS, 'navItems.myHistory.ledgersTrading', false, GENERAL_TARGETS],
         [MENU_FOFFER, 'navItems.myHistory.funding', isTurkishSite, FUNDING_TARGETS],
         [MENU_FPAYMENT, 'navItems.myHistory.earnings', isTurkishSite, EARNINGS_TARGETS],
         [MENU_WALLETS, 'wallets.title'],

--- a/src/ui/NavMenu/NavMenu.js
+++ b/src/ui/NavMenu/NavMenu.js
@@ -31,8 +31,8 @@ const NavMenu = ({
   className,
   isTurkishSite,
 }) => {
-  const [isMyAccountOpen, setIsMyAccountOpen] = useState(false)
-  const [isMyHistoryOpen, setIsMyHistoryOpen] = useState(false)
+  const [isMyAccountOpen, setIsMyAccountOpen] = useState(true)
+  const [isMyHistoryOpen, setIsMyHistoryOpen] = useState(true)
   const [isMarketHistoryOpen, setIsMarketHistoryOpen] = useState(false)
   const [isMerchantHistoryOpen, setIsMerchantHistoryOpen] = useState(false)
 

--- a/src/ui/SectionSwitch/SectionSwitch.helpers.js
+++ b/src/ui/SectionSwitch/SectionSwitch.helpers.js
@@ -25,7 +25,6 @@ export const GENERAL_TARGETS = [
   queryConstants.MENU_LEDGERS,
   queryConstants.MENU_TRADES,
   queryConstants.MENU_ORDERS,
-  queryConstants.MENU_MOVEMENTS,
   queryConstants.MENU_POSITIONS,
 ]
 
@@ -39,6 +38,11 @@ export const EARNINGS_TARGETS = [
   queryConstants.MENU_FPAYMENT,
   queryConstants.MENU_SPAYMENTS,
   queryConstants.MENU_AFFILIATES_EARNINGS,
+]
+
+export const WALLETS_TARGETS = [
+  queryConstants.MENU_WALLETS,
+  queryConstants.MENU_MOVEMENTS,
 ]
 
 

--- a/src/ui/SectionSwitch/SectionSwitch.helpers.js
+++ b/src/ui/SectionSwitch/SectionSwitch.helpers.js
@@ -87,10 +87,6 @@ export const GENERAL_SECTIONS = [
     description: 'navItems.myHistory.generalTabs.orders',
   },
   {
-    targetSection: queryConstants.MENU_MOVEMENTS,
-    description: 'navItems.myHistory.generalTabs.movements',
-  },
-  {
     targetSection: queryConstants.MENU_POSITIONS,
     description: 'navItems.myHistory.generalTabs.positions',
   },

--- a/src/ui/SectionSwitch/SectionSwitch.helpers.js
+++ b/src/ui/SectionSwitch/SectionSwitch.helpers.js
@@ -166,6 +166,7 @@ export const getSections = (target, hasSubSections) => {
   if (_includes(GENERAL_TARGETS, target)) return GENERAL_SECTIONS
   if (_includes(FUNDING_TARGETS, target)) return FUNDING_SECTIONS
   if (_includes(EARNINGS_TARGETS, target)) return EARNINGS_SECTIONS
+  if (_includes(WALLETS_TARGETS, target)) return WALLETS_SECTIONS
 
   return []
 }

--- a/src/ui/SectionSwitch/SectionSwitch.helpers.js
+++ b/src/ui/SectionSwitch/SectionSwitch.helpers.js
@@ -148,6 +148,17 @@ export const POSITIONS_SECTIONS = [
   },
 ]
 
+export const WALLETS_SECTIONS = [
+  {
+    targetSection: queryConstants.MENU_WALLETS,
+    description: 'navItems.myHistory.walletsTabs.balances',
+  },
+  {
+    targetSection: queryConstants.MENU_MOVEMENTS,
+    description: 'navItems.myHistory.walletsTabs.movements',
+  },
+]
+
 export const getSections = (target, hasSubSections) => {
   if (_includes(TRADES_TARGETS, target) && hasSubSections) return TRADES_SECTIONS
   if (_includes(POSITIONS_TARGETS, target) && hasSubSections) return POSITIONS_SECTIONS


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204647018050040/f

#### Description:
- [x] Implements navigation via tabs between `Balances` and `Movements` reports in the `Wallets` sub-section
- [x] Expands `My Account` and `My History` sections by default for better UX
- [x] Actualizes several sub-sections naming

#### Preview: 
<img width="1199" alt="nav-improvements" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/946ce5b3-3753-4106-b53d-1829e07699a3">

