### PR TITLE
(improvements) Reports tables representation

### DIFF
--- a/src/components/AffiliatesEarnings/AffiliatesEarnings.js
+++ b/src/components/AffiliatesEarnings/AffiliatesEarnings.js
@@ -107,7 +107,7 @@ class AffiliatesEarnings extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -117,7 +117,7 @@ class AffiliatesEarnings extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
     return (

--- a/src/components/ChangeLogs/ChangeLogs.columns.js
+++ b/src/components/ChangeLogs/ChangeLogs.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import JSONFormat from 'ui/JSONFormat'
 import { getColumnWidth } from 'utils/columns'
@@ -22,9 +19,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsCreate)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },
@@ -38,9 +33,7 @@ export const getColumns = ({
       const { log } = filteredData[rowIndex]
       return (
         <Cell tooltip={log}>
-          <TruncatedFormat>
-            {log}
-          </TruncatedFormat>
+          {log}
         </Cell>
       )
     },

--- a/src/components/ChangeLogs/ChangeLogs.js
+++ b/src/components/ChangeLogs/ChangeLogs.js
@@ -75,7 +75,7 @@ class ChangeLogs extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             numRows={entries.length}
             tableColumns={tableColumns}
@@ -84,7 +84,7 @@ class ChangeLogs extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
     return (

--- a/src/components/Derivatives/Derivatives.columns.js
+++ b/src/components/Derivatives/Derivatives.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { formatAmount, fixedFloat } from 'ui/utils'
 import { getColumnWidth } from 'utils/columns'
@@ -129,9 +126,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].timestamp)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/FundingCreditHistory/FundingCreditHistory.columns.js
+++ b/src/components/FundingCreditHistory/FundingCreditHistory.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { getColumnWidth } from 'utils/columns'
 import { getSideMsg, getSideColor } from 'state/utils'
@@ -150,9 +147,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsOpening)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },
@@ -166,9 +161,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsLastPayout)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },
@@ -196,9 +189,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/FundingCreditHistory/FundingCreditHistory.js
+++ b/src/components/FundingCreditHistory/FundingCreditHistory.js
@@ -114,14 +114,14 @@ class FundingCreditHistory extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
             tableColumns={tableColumns}
           />
           <Pagination target={TYPE} loading={pageLoading} />
-        </>
+        </div>
       )
     }
 

--- a/src/components/FundingLoanHistory/FundingLoanHistory.columns.js
+++ b/src/components/FundingLoanHistory/FundingLoanHistory.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { getSideMsg, getSideColor } from 'state/utils'
 import { formatAmount, formatColor, fixedFloat } from 'ui/utils'
@@ -148,9 +145,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsOpening)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },
@@ -164,9 +159,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsLastPayout)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },
@@ -180,9 +173,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/FundingLoanHistory/FundingLoanHistory.js
+++ b/src/components/FundingLoanHistory/FundingLoanHistory.js
@@ -112,7 +112,7 @@ class FundingLoanHistory extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -122,7 +122,7 @@ class FundingLoanHistory extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/FundingOfferHistory/FundingOfferHistory.columns.js
+++ b/src/components/FundingOfferHistory/FundingOfferHistory.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { getColumnWidth } from 'utils/columns'
 import { formatAmount, fixedFloat } from 'ui/utils'
@@ -154,9 +151,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/FundingOfferHistory/FundingOfferHistory.js
+++ b/src/components/FundingOfferHistory/FundingOfferHistory.js
@@ -109,7 +109,7 @@ class FundingOfferHistory extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -119,7 +119,7 @@ class FundingOfferHistory extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/FundingPayment/FundingPayment.js
+++ b/src/components/FundingPayment/FundingPayment.js
@@ -109,7 +109,7 @@ class FundingPayment extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -119,7 +119,7 @@ class FundingPayment extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
     return (

--- a/src/components/Invoices/Invoices.columns.js
+++ b/src/components/Invoices/Invoices.columns.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Cell, TruncatedFormat } from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import JSONFormat from 'ui/JSONFormat'
 import { getColumnWidth } from 'utils/columns'
@@ -213,9 +213,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mts)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/Invoices/Invoices.js
+++ b/src/components/Invoices/Invoices.js
@@ -132,7 +132,7 @@ class Invoices extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -142,7 +142,7 @@ class Invoices extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/Ledgers/Ledgers.columns.js
+++ b/src/components/Ledgers/Ledgers.columns.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Cell, TruncatedFormat } from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { insertIf, fixedFloat, formatAmount } from 'ui/utils'
 import queryConstants from 'state/query/constants'
@@ -151,9 +151,7 @@ export default function getColumns(props) {
         const timestamp = getFullTime(filteredData[rowIndex].mts)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },

--- a/src/components/Ledgers/Ledgers.js
+++ b/src/components/Ledgers/Ledgers.js
@@ -125,7 +125,7 @@ class Ledgers extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -135,7 +135,7 @@ class Ledgers extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/Logins/Logins.columns.js
+++ b/src/components/Logins/Logins.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import JSONFormat from 'ui/JSONFormat'
 import { getColumnWidth } from 'utils/columns'
@@ -36,9 +33,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].time)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/Logins/Logins.js
+++ b/src/components/Logins/Logins.js
@@ -88,7 +88,7 @@ class Logins extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -98,7 +98,7 @@ class Logins extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
     return (

--- a/src/components/Movements/Movements.columns.js
+++ b/src/components/Movements/Movements.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { formatAmount, fixedFloat, insertIf } from 'ui/utils'
 import Explorer from 'ui/Explorer'
@@ -38,9 +35,7 @@ const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsUpdated)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/Movements/Movements.js
+++ b/src/components/Movements/Movements.js
@@ -116,7 +116,7 @@ class Movements extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -126,7 +126,7 @@ class Movements extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
     return (

--- a/src/components/Orders/Orders.columns.js
+++ b/src/components/Orders/Orders.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import JSONFormat from 'ui/JSONFormat'
 import { formatAmount, fixedFloat } from 'ui/utils'
@@ -147,9 +144,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsCreate)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },
@@ -163,9 +158,7 @@ export const getColumns = ({
       const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
       return (
         <Cell tooltip={timestamp}>
-          <TruncatedFormat>
-            {timestamp}
-          </TruncatedFormat>
+          {timestamp}
         </Cell>
       )
     },

--- a/src/components/Orders/Orders.js
+++ b/src/components/Orders/Orders.js
@@ -138,7 +138,7 @@ class Orders extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -148,7 +148,7 @@ class Orders extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/Positions/Positions.columns.js
+++ b/src/components/Positions/Positions.columns.js
@@ -1,10 +1,7 @@
 import React from 'react'
 import _endsWith from 'lodash/endsWith'
 
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import queryConstants from 'state/query/constants'
 import JSONFormat from 'ui/JSONFormat'
@@ -264,9 +261,7 @@ export default function getColumns(props) {
         const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },

--- a/src/components/Positions/Positions.js
+++ b/src/components/Positions/Positions.js
@@ -119,7 +119,7 @@ class Positions extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -129,7 +129,7 @@ class Positions extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/PositionsAudit/PositionsAudit.js
+++ b/src/components/PositionsAudit/PositionsAudit.js
@@ -82,7 +82,7 @@ class PositionsAudit extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             numRows={entries.length}
             tableColumns={tableColumns}
@@ -91,7 +91,7 @@ class PositionsAudit extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
 

--- a/src/components/PublicFunding/PublicFunding.columns.js
+++ b/src/components/PublicFunding/PublicFunding.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { fixedFloat, formatAmount } from 'ui/utils'
 import { getColumnWidth } from 'utils/columns'
@@ -40,9 +37,7 @@ export default function getColumns(props) {
         const timestamp = getFullTime(filteredData[rowIndex].mts)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },

--- a/src/components/PublicFunding/PublicFunding.js
+++ b/src/components/PublicFunding/PublicFunding.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import { withTranslation } from 'react-i18next'
 import { Card, Elevation } from '@blueprintjs/core'
 
@@ -75,14 +75,14 @@ class PublicFunding extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <Fragment>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
             tableColumns={tableColumns}
           />
           <Pagination target={TYPE} loading={pageLoading} />
-        </Fragment>
+        </div>
       )
     }
 

--- a/src/components/PublicTrades/PublicTrades.columns.js
+++ b/src/components/PublicTrades/PublicTrades.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { formatAmount, fixedFloat, amountStyle } from 'ui/utils'
 import { formatPair } from 'state/symbols/utils'
@@ -41,9 +38,7 @@ export default function getColumns(props) {
         const timestamp = getFullTime(filteredData[rowIndex].mts)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },

--- a/src/components/PublicTrades/PublicTrades.js
+++ b/src/components/PublicTrades/PublicTrades.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import { withTranslation } from 'react-i18next'
 import { Card, Elevation } from '@blueprintjs/core'
 
@@ -67,14 +67,14 @@ class PublicTrades extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <Fragment>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
             tableColumns={tableColumns}
           />
           <Pagination target={TYPE} loading={pageLoading} />
-        </Fragment>
+        </div>
       )
     }
 

--- a/src/components/StakingPayments/StakingPayments.js
+++ b/src/components/StakingPayments/StakingPayments.js
@@ -111,7 +111,7 @@ class StakingPayments extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -121,7 +121,7 @@ class StakingPayments extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </>
+        </div>
       )
     }
     return (

--- a/src/components/Tickers/Tickers.columns.js
+++ b/src/components/Tickers/Tickers.columns.js
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  Cell,
-  TruncatedFormat,
-} from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { fixedFloat } from 'ui/utils'
 import { getColumnWidth } from 'utils/columns'
@@ -77,9 +74,7 @@ export default function getColumns(props) {
         const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },

--- a/src/components/Tickers/Tickers.js
+++ b/src/components/Tickers/Tickers.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import { withTranslation } from 'react-i18next'
 import { Card, Elevation } from '@blueprintjs/core'
 
@@ -82,14 +82,14 @@ class Tickers extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <Fragment>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
             tableColumns={tableColumns}
           />
           <Pagination target={TYPE} loading={pageLoading} />
-        </Fragment>
+        </div>
       )
     }
 

--- a/src/components/Trades/Trades.columns.js
+++ b/src/components/Trades/Trades.columns.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import { Cell, TruncatedFormat } from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { formatAmount, fixedFloat } from 'ui/utils'
 import { demapPairs, demapSymbols } from 'state/symbols/utils'
@@ -170,9 +170,7 @@ export default function getColumns(props) {
         const timestamp = getFullTime(filteredData[rowIndex].mtsCreate)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },

--- a/src/components/Trades/Trades.js
+++ b/src/components/Trades/Trades.js
@@ -63,7 +63,7 @@ class Trades extends PureComponent {
       showContent = <NoData />
     } else {
       showContent = (
-        <Fragment>
+        <div className='data-table-wrapper'>
           <DataTable
             section={TYPE}
             numRows={entries.length}
@@ -73,7 +73,7 @@ class Trades extends PureComponent {
             target={TYPE}
             loading={pageLoading}
           />
-        </Fragment>
+        </div>
       )
     }
 

--- a/src/components/Trades/Trades.js
+++ b/src/components/Trades/Trades.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import { withTranslation } from 'react-i18next'
 import { Card, Elevation } from '@blueprintjs/core'
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -100,6 +100,10 @@ html {
   overflow: hidden;
 }
 
+.data-table-wrapper {
+  max-width: fit-content;
+}
+
 .color--active {
   color: var(--activeColor);
 }

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -53,7 +53,7 @@
   --thBg: #0B1923;
   --thBgHover: #19354a;
   --tableColor: #f5f8fa;
-  --tableBorder: #19354a;
+  --tableBorder: #334A59;
   --tableOddBg: #0B1923;
   --tableEvenBg: #0B1923;
   --tableScrollBg: #0c1a25;

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -54,8 +54,8 @@
   --thBgHover: #19354a;
   --tableColor: #f5f8fa;
   --tableBorder: #19354a;
-  --tableOddBg: #172d3e;
-  --tableEvenBg: #102331;
+  --tableOddBg: #0B1923;
+  --tableEvenBg: #0B1923;
   --tableScrollBg: #0c1a25;
   --tableScrollThumbBg: #2A3F4D;
   --tableAmountPosColor: #00a27c;

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -57,7 +57,7 @@
   --tableOddBg: #172d3e;
   --tableEvenBg: #102331;
   --tableScrollBg: #0c1a25;
-  --tableScrollThumbBg: #5ebefa;
+  --tableScrollThumbBg: #2A3F4D;
   --tableAmountPosColor: #00a27c;
   --tableAmountNegColor: #f05359;
   --tableAmountFractionPosColor: #03ca9b;

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -50,7 +50,7 @@
 
   // tables
   --thColor: #82baf6;
-  --thBg: #172d3e;
+  --thBg: #0B1923;
   --thBgHover: #19354a;
   --tableColor: #f5f8fa;
   --tableBorder: #19354a;

--- a/src/ui/CollapsedTable/_CollapsedTable.scss
+++ b/src/ui/CollapsedTable/_CollapsedTable.scss
@@ -4,9 +4,11 @@
   &-item {
     display: table;
     width: 100%;
+    padding: 16px;
+    border-radius: 6px;
     margin-bottom: 10px;
-    border: 1px solid var(--borderColor);
-    border-radius: 2px;
+    background-color: var(--bgColor);
+    border: 1px solid var(--bgColor);
 
     &:last-child {
       margin-bottom: 0;
@@ -16,11 +18,11 @@
       display: table-row;
 
       &:nth-child(odd) {
-        background-color: var(--tableOddBg);
+        background-color: var(--bgColor);
       }
 
       &:nth-child(even) {
-        background-color: var(--tableEvenBg);
+        background-color: var(--bgColor);
       }
 
       & > div {
@@ -32,7 +34,6 @@
         &:first-child {
           width: 45%;
           color: var(--activeColor);
-          border-right: 1px solid var(--borderColor);
         }
 
         &:last-child {

--- a/src/ui/CollapsedTable/_CollapsedTable.scss
+++ b/src/ui/CollapsedTable/_CollapsedTable.scss
@@ -28,12 +28,12 @@
       & > div {
         display: table-cell;
         min-height: 24px;
-        padding: 4px 11px;
+        padding: 12px 11px;
         vertical-align: middle;
+        border-bottom: 1px solid var(--tableBorder);
 
         &:first-child {
           width: 45%;
-          color: var(--activeColor);
         }
 
         &:last-child {

--- a/src/ui/CollapsedTable/_CollapsedTable.scss
+++ b/src/ui/CollapsedTable/_CollapsedTable.scss
@@ -10,10 +10,6 @@
     background-color: var(--bgColor);
     border: 1px solid var(--bgColor);
 
-    &:last-child {
-      margin-bottom: 0;
-    }
-
     & > div {
       display: table-row;
 
@@ -41,7 +37,14 @@
           word-break: break-word;
         }
       }
+
+      &:last-child {
+        & > div {
+          border-bottom: none;
+        }
+      }      
     }
+    
   }
 
   .bp3-table-truncated-format-text {

--- a/src/ui/CollapsedTable/_CollapsedTable.scss
+++ b/src/ui/CollapsedTable/_CollapsedTable.scss
@@ -42,9 +42,8 @@
         & > div {
           border-bottom: none;
         }
-      }      
+      }
     }
-    
   }
 
   .bp3-table-truncated-format-text {

--- a/src/ui/DataTable/DataTable.js
+++ b/src/ui/DataTable/DataTable.js
@@ -179,6 +179,7 @@ class DataTable extends PureComponent {
         getCellClipboardData={this.getCellClipboardData}
         onCopy={this.onCopy}
         bodyContextMenuRenderer={this.renderBodyContextMenu}
+        defaultRowHeight={50}
       >
         {tableColumns.map(column => (
           <Column

--- a/src/ui/DataTable/_DataTable.scss
+++ b/src/ui/DataTable/_DataTable.scss
@@ -88,6 +88,13 @@
     &-name {
       font-size: 14px;
       color: var(--thColor);
+
+      &-text {
+        min-height: 50px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+      }
     }
   }
 

--- a/src/ui/DataTable/_DataTable.scss
+++ b/src/ui/DataTable/_DataTable.scss
@@ -5,6 +5,7 @@
   max-height: 517px;
   margin-left: 1px;
   flex: 0 1 auto;
+  border-top: 1px solid var(--tableBorder);
 
   &-full-height {
     max-height: unset;

--- a/src/ui/DataTable/_DataTable.scss
+++ b/src/ui/DataTable/_DataTable.scss
@@ -86,7 +86,7 @@
     }
 
     &-name {
-      font-size: 13px;
+      font-size: 14px;
       color: var(--thColor);
     }
   }

--- a/src/ui/DataTable/_DataTable.scss
+++ b/src/ui/DataTable/_DataTable.scss
@@ -56,22 +56,12 @@
 
 .bp3-table {
   &-container {
-    box-shadow: 0 0 0 1px var(--tableBorder);
-
-    .bp3-table-last-in-column {
-      box-shadow: inset -1px 0 0 var(--tableBorder);
-    }
-
     .bp3-table-last-in-row {
       box-shadow: inset 0 -1px 0 var(--tableBorder);
 
       &.bp3-table-header {
         box-shadow: 0 1px 0 var(--tableBorder);
       }
-    }
-
-    .bp3-table-last-in-column.bp3-table-last-in-row {
-      box-shadow: none;
     }
   }
 
@@ -81,7 +71,7 @@
       color: inherit;
 
       .bp3-table-header {
-        box-shadow: 0 1px 0 var(--tableBorder), inset -1px 0 0 var(--tableBorder);
+        box-shadow: 0 1px 0 var(--tableBorder);
       }
     }
 
@@ -112,7 +102,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    box-shadow: inset 0 -1px 0 var(--tableBorder), inset -1px 0 0 var(--tableBorder);
+    box-shadow: inset 0 -1px 0 var(--tableBorder);
 
     &-ledger {
       &-even {

--- a/src/ui/DataTable/_DataTable.scss
+++ b/src/ui/DataTable/_DataTable.scss
@@ -100,8 +100,11 @@
   }
 
   &-cell {
-    font-size: 13px;
+    font-size: 14px;
     color: var(--tableColor);
+    display: flex;
+    align-items: center;
+    justify-content: center;
     box-shadow: inset 0 -1px 0 var(--tableBorder), inset -1px 0 0 var(--tableBorder);
 
     &-ledger {

--- a/src/ui/DataTable/_DataTable.scss
+++ b/src/ui/DataTable/_DataTable.scss
@@ -104,7 +104,7 @@
     color: var(--tableColor);
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     box-shadow: inset 0 -1px 0 var(--tableBorder), inset -1px 0 0 var(--tableBorder);
 
     &-ledger {

--- a/src/ui/Pagination/Pagination.js
+++ b/src/ui/Pagination/Pagination.js
@@ -116,13 +116,13 @@ class Pagination extends PureComponent {
     return (
       <Swipeable className='pagination' onSwiped={this.onSwiped} delta={50}>
         <div className='pagination-group'>
-          <span className='pagination-icon'>
+          <span className='pagination-icon-wrapper'>
             <Icon.CHEVRON_DOUBLE_LEFT
               className={classNames('pagination-icon', { 'pagination-icon--disabled': page === 1 || loading })}
               onClick={this.jumpToFirstPage}
             />
           </span>
-          <span className='pagination-icon'>
+          <span className='pagination-icon-wrapper'>
             <Icon.CHEVRON_LEFT
               className={classNames('pagination-icon', { 'pagination-icon--disabled': page === 1 || loading })}
               onClick={this.backward}
@@ -143,13 +143,13 @@ class Pagination extends PureComponent {
             {pageLen}
             {renderRestDots}
           </span>
-          <span className='pagination-icon'>
+          <span className='pagination-icon-wrapper'>
             <Icon.CHEVRON_RIGHT
               className={classNames('pagination-icon', { 'pagination-icon--disabled': page === pageLen || loading })}
               onClick={this.forward}
             />
           </span>
-          <span className='pagination-icon'>
+          <span className='pagination-icon-wrapper'>
             <Icon.CHEVRON_DOUBLE_RIGHT
               className={classNames('pagination-icon', { 'pagination-icon--disabled': !nextPage || loading })}
               onClick={this.fetchNext}

--- a/src/ui/Pagination/Pagination.js
+++ b/src/ui/Pagination/Pagination.js
@@ -116,14 +116,18 @@ class Pagination extends PureComponent {
     return (
       <Swipeable className='pagination' onSwiped={this.onSwiped} delta={50}>
         <div className='pagination-group'>
-          <Icon.CHEVRON_DOUBLE_LEFT
-            className={classNames('pagination-icon', { 'pagination-icon--disabled': page === 1 || loading })}
-            onClick={this.jumpToFirstPage}
-          />
-          <Icon.CHEVRON_LEFT
-            className={classNames('pagination-icon', { 'pagination-icon--disabled': page === 1 || loading })}
-            onClick={this.backward}
-          />
+          <span className='pagination-icon'>
+            <Icon.CHEVRON_DOUBLE_LEFT
+              className={classNames('pagination-icon', { 'pagination-icon--disabled': page === 1 || loading })}
+              onClick={this.jumpToFirstPage}
+            />
+          </span>
+          <span className='pagination-icon'>
+            <Icon.CHEVRON_LEFT
+              className={classNames('pagination-icon', { 'pagination-icon--disabled': page === 1 || loading })}
+              onClick={this.backward}
+            />
+          </span>
           <span className='pagination-page'>
             {t('pagination.page')}
             <input
@@ -139,14 +143,18 @@ class Pagination extends PureComponent {
             {pageLen}
             {renderRestDots}
           </span>
-          <Icon.CHEVRON_RIGHT
-            className={classNames('pagination-icon', { 'pagination-icon--disabled': page === pageLen || loading })}
-            onClick={this.forward}
-          />
-          <Icon.CHEVRON_DOUBLE_RIGHT
-            className={classNames('pagination-icon', { 'pagination-icon--disabled': !nextPage || loading })}
-            onClick={this.fetchNext}
-          />
+          <span className='pagination-icon'>
+            <Icon.CHEVRON_RIGHT
+              className={classNames('pagination-icon', { 'pagination-icon--disabled': page === pageLen || loading })}
+              onClick={this.forward}
+            />
+          </span>
+          <span className='pagination-icon'>
+            <Icon.CHEVRON_DOUBLE_RIGHT
+              className={classNames('pagination-icon', { 'pagination-icon--disabled': !nextPage || loading })}
+              onClick={this.fetchNext}
+            />
+          </span>
           {renderLoading}
         </div>
       </Swipeable>

--- a/src/ui/Pagination/_Pagination.scss
+++ b/src/ui/Pagination/_Pagination.scss
@@ -16,18 +16,19 @@
     height: 40px;
     align-items: center;
     justify-content: center;
-  }
 
-  &-icon {
-    margin: 0 2px;
-    vertical-align: middle;
-    cursor: pointer;
-
-    &--disabled {
-      pointer-events: none;
+    .pagination-icon {
+      margin: 0 2px;
+      cursor: pointer;
+      vertical-align: middle;
+      transform: scale(1.3);
 
       path {
-        fill: var(--timeRangeColor);
+        fill: var(--color2);
+      }
+  
+      &--disabled {
+        pointer-events: none;
       }
     }
   }

--- a/src/ui/Pagination/_Pagination.scss
+++ b/src/ui/Pagination/_Pagination.scss
@@ -4,6 +4,20 @@
   align-items: center;
   justify-content: center;
 
+  &-group {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &-icon-wrapper {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+  }
+
   &-icon {
     margin: 0 2px;
     vertical-align: middle;

--- a/src/ui/Pagination/_Pagination.scss
+++ b/src/ui/Pagination/_Pagination.scss
@@ -11,11 +11,14 @@
   }
 
   &-icon-wrapper {
+    width: 39px;
+    height: 39px;
+    margin: 0 5px;
     display: inline-flex;
-    width: 40px;
-    height: 40px;
     align-items: center;
     justify-content: center;
+    border: 1px solid var(--color2);
+    border-radius: 4px;
 
     .pagination-icon {
       margin: 0 2px;

--- a/src/ui/Pagination/_Pagination.scss
+++ b/src/ui/Pagination/_Pagination.scss
@@ -30,6 +30,10 @@
     background-color: var(--bgColor);
     border: 1px solid var(--borderColor);
     color: var(--color);
+
+    &::placeholder {
+      color: var(--color);
+    }
   }
 
   &-loading {

--- a/src/ui/Pagination/_Pagination.scss
+++ b/src/ui/Pagination/_Pagination.scss
@@ -23,13 +23,14 @@
   }
 
   &-input {
-    width: 45px;
-    height: 22px;
-    margin: 0 3px;
+    width: 40px;
+    height: 40px;
+    margin: 0 7px;
     text-align: center;
     background-color: var(--bgColor);
-    border: 1px solid var(--borderColor);
     color: var(--color);
+    border: none;
+    border-radius: 4px;
 
     &::placeholder {
       color: var(--color);

--- a/src/ui/Pagination/_Pagination.scss
+++ b/src/ui/Pagination/_Pagination.scss
@@ -1,5 +1,8 @@
 .pagination {
   margin: 25px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &-icon {
     margin: 0 2px;

--- a/src/ui/SectionHeader/_SectionHeader.scss
+++ b/src/ui/SectionHeader/_SectionHeader.scss
@@ -4,7 +4,7 @@
   &-title {
     font-size: 30px;
     margin-bottom: 20px;
-    color: var(--activeColor);
+    color: var(--color);
     position: relative;
 
     .bp3-popover-wrapper {

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -52,7 +52,6 @@ export const formatAmount = (val, options = {}) => {
     )
   }
   const {
-    color,
     digits = 8,
     minDigits = false,
     fixFraction = true,
@@ -60,11 +59,6 @@ export const formatAmount = (val, options = {}) => {
     dollarSign = false,
   } = options
   let roundedValue = _round(val, 8)
-
-  const classes = classNames('bitfinex-amount', {
-    'bitfinex-green-text': color ? color === 'green' : roundedValue > 0,
-    'bitfinex-red-text': color ? color === 'red' : roundedValue < 0,
-  })
 
   if (fixFraction) {
     roundedValue = formatFraction(roundedValue, { digits, minDigits })
@@ -78,7 +72,7 @@ export const formatAmount = (val, options = {}) => {
 
   return (
     <>
-      <div className={classes}>
+      <div className='bitfinex-amount'>
         <span>
           {dollarSign && '$'}
           {integer}

--- a/src/utils/columns.js
+++ b/src/utils/columns.js
@@ -6,7 +6,7 @@ import _pick from 'lodash/pick'
 import _filter from 'lodash/filter'
 import _isEqual from 'lodash/isEqual'
 
-import { Cell, TruncatedFormat } from '@blueprintjs/table'
+import { Cell } from '@blueprintjs/table'
 
 import { formatAmount, fixedFloat } from 'ui/utils'
 
@@ -404,9 +404,7 @@ export const getFrameworkPositionsColumns = (props) => {
         const timestamp = getFullTime(filteredData[rowIndex].mtsUpdate)
         return (
           <Cell tooltip={timestamp}>
-            <TruncatedFormat>
-              {timestamp}
-            </TruncatedFormat>
+            {timestamp}
           </Cell>
         )
       },


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204694685398770/f

#### Description:
- [x] Enhances `Reports` tables representation according to the latest design updates
#### Before: 
<img width="989" alt="reports_tables_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/65e80d89-a5b0-4940-b778-cc1dcab1e29b">

#### After: 
<img width="978" alt="reports_tables_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/5390b56a-7813-48ad-bdcb-1f256423f819">
