### PR TITLE
(fix) Wallets section active state

### DIFF
--- a/src/ui/NavMenu/NavMenu.helpers.js
+++ b/src/ui/NavMenu/NavMenu.helpers.js
@@ -8,6 +8,7 @@ import {
   GENERAL_TARGETS,
   FUNDING_TARGETS,
   EARNINGS_TARGETS,
+  WALLETS_TARGETS,
 } from 'ui/SectionSwitch/SectionSwitch.helpers'
 
 import constants from './NavMenu.constants'
@@ -65,7 +66,7 @@ export const getSections = (menuType, isTurkishSite) => {
         [MENU_LEDGERS, 'navItems.myHistory.ledgersTrading', false, GENERAL_TARGETS],
         [MENU_FOFFER, 'navItems.myHistory.funding', isTurkishSite, FUNDING_TARGETS],
         [MENU_FPAYMENT, 'navItems.myHistory.earnings', isTurkishSite, EARNINGS_TARGETS],
-        [MENU_WALLETS, 'wallets.title'],
+        [MENU_WALLETS, 'wallets.title', false, WALLETS_TARGETS],
       ]
     case MENU_MERCHANT_HISTORY:
       return [


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204861291049130/f

#### Description:
- [x] Fixes the issue with the active state losing in the `Wallets` section when switching to the `Movements` tab
- [x] Syncs `beta` with the latest `master`
#### Before: 
<img width="1216" alt="wallets_active_state_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/b8d6fdd9-0bb0-4953-96aa-b57d08748442">

#### After: 
<img width="1213" alt="wallets_active_state_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/1e588a9a-e0d6-4f15-a69a-604ac9f97ab5">
