### PR TITLE
(fix) Accounts registration type

### DIFF
--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -119,6 +119,7 @@ function* signUp({ payload }) {
       }
       yield put(actions.addUser(newUser))
       yield put(actions.showOtpLogin(false))
+      yield put(actions.fetchUsers())
       return
     }
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204814230933799/f

#### Description:
- [x] Fixes issues with the incorrect accounts registration type detection during the following scenario:
```
- register a new account via API key/secret
- after the first sign-in ---> logout
- the incorrect type Login instead of API key will be shown once, before the first page refreshing
```

#### Before: 
<img width="671" alt="registration_type_before_1" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/84da57a6-4ee8-4aef-8316-c6aa193a9c8f">
<img width="646" alt="registration_type_before_2" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/0cd95a49-ff21-41d9-b8c0-2a5f0406be15">


#### After: 

https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/a7b9d22e-6143-4834-8ef4-d953a36e11dd


