### PR TITLE
(fix) Menu options availability

### DIFF
--- a/src/components/Header/AccountMenu/AccountMenu.js
+++ b/src/components/Header/AccountMenu/AccountMenu.js
@@ -96,11 +96,13 @@ const AccountMenu = ({
                 icon={<Icon.INFO_CIRCLE />}
                 text={t('header.help')}
               />
-              <MenuItem
-                className='account-menu-sync'
-                shouldDismissPopover={false}
-                text={<SyncMode />}
-              />
+              {showFrameworkMode && (
+                <MenuItem
+                  className='account-menu-sync'
+                  shouldDismissPopover={false}
+                  text={<SyncMode />}
+                />
+              )}
               <MenuItem
                 className='account-menu-query'
                 shouldDismissPopover={false}

--- a/src/components/Header/TopNavigation/TopNavigation.container.js
+++ b/src/components/Header/TopNavigation/TopNavigation.container.js
@@ -8,7 +8,7 @@ import {
   getIsSubAccsAvailable,
 } from 'state/auth/selectors'
 import { getWindowWidth } from 'state/ui/selectors'
-import { togglePreferencesDialog } from 'state/ui/actions'
+import { toggleExportDialog, togglePreferencesDialog } from 'state/ui/actions'
 import { logout } from 'state/auth/actions'
 
 import TopNavigation from './TopNavigation'
@@ -22,6 +22,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   logout,
+  toggleExportDialog,
   togglePrefDialog: togglePreferencesDialog,
 }
 

--- a/src/components/Header/TopNavigation/TopNavigation.js
+++ b/src/components/Header/TopNavigation/TopNavigation.js
@@ -42,6 +42,7 @@ const TopNavigation = ({
   history,
   localUsername,
   togglePrefDialog,
+  toggleExportDialog,
   isSubAccsAvailable,
 }) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -112,6 +113,12 @@ const TopNavigation = ({
                 text={t('navItems.loginHistory')}
                 onClick={() => switchSection(MENU_LOGINS)}
               />
+              <MenuItem
+                className='account-menu-export'
+                onClick={toggleExportDialog}
+                icon={<Icon.FILE_EXPORT />}
+                text={t('download.export')}
+              />
               {showSubAccounts && (
                 <MenuItem
                   icon={<Icon.USER_CIRCLE />}
@@ -154,6 +161,7 @@ TopNavigation.propTypes = {
   logout: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
   togglePrefDialog: PropTypes.func.isRequired,
+  toggleExportDialog: PropTypes.func.isRequired,
   isSubAccsAvailable: PropTypes.bool.isRequired,
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1204922857120776/f

#### Description:
- [x] Fixes the `Export` option unavailability in the top navigation menu
- [x] Shows `Start Sync` only in the framework mode

#### Before: 
<img width="834" alt="top_nav_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/fa669385-27d4-40e4-afa4-88fea510f74b">

#### After: 
<img width="831" alt="top_nav_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/b4eb5e3b-a6b9-41f0-88ed-36304295fad2">
