### PR TITLE
(improvements) Update weighted averages limit note

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -716,7 +716,7 @@
     "title": "Weighted Averages",
     "limitNote":{
       "title": "Not all transactions could be displayed",
-      "note1": "Your request exceeds the limit of 50k transactions.",
+      "note1": "Your request exceeds the limit of 100k transactions.",
       "link": "Download the Reports App",
       "note2": " to display more or change your date range."
     }


### PR DESCRIPTION
Task: https://bitfinex.slack.com/archives/GAVNZP4RF/p1688539176006499

#### Description:
- [x] Updates limit to `100k` in the `Weighted Averages` limit note description