### PR TITLE
(fix) Estimated sync time representation

### DIFF
--- a/src/components/Header/SyncMode/SyncMode.helpers.js
+++ b/src/components/Header/SyncMode/SyncMode.helpers.js
@@ -3,7 +3,7 @@ import { Spinner } from '@blueprintjs/core'
 import _isNull from 'lodash/isNull'
 
 import Icon from 'icons'
-import { getFormattedTime } from 'utils/dates'
+import { getFormattedTime, getFormattedDuration } from 'utils/dates'
 
 const getEstimatedSyncTime = ({
   leftTime = null,
@@ -16,11 +16,11 @@ const getEstimatedSyncTime = ({
 
   const spent = _isNull(spentTime)
     ? t('sync.estimated_time.estimating')
-    : getFormattedTime(spentTime, 'mm:ss')
+    : getFormattedDuration(spentTime)
 
   const left = _isNull(leftTime)
     ? t('sync.estimated_time.estimating')
-    : getFormattedTime(leftTime, 'mm:ss')
+    : getFormattedDuration(leftTime)
 
   return {
     start,

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,8 @@
 import moment from 'moment'
+import _join from 'lodash/join'
+import _floor from 'lodash/floor'
+import _toString from 'lodash/toString'
+import _padStart from 'lodash/padStart'
 
 export const getFormattedDate = time => moment(time).format('MMMM DD, YYYY HH:mm')
 
@@ -10,8 +14,21 @@ export const makeDate = (action) => {
 
 export const getFormattedTime = (time, format) => moment(time).format(format)
 
+export const getFormattedDuration = (milliseconds) => {
+  const seconds = _floor((milliseconds / 1000) % 60)
+  const minutes = _floor((milliseconds / 1000 / 60) % 60)
+  const hours = _floor((milliseconds / 1000 / 60 / 60) % 24)
+
+  return _join([
+    _padStart(_toString(hours), 2, '0'),
+    _padStart(_toString(minutes), 2, '0'),
+    _padStart(_toString(seconds), 2, '0'),
+  ], ':')
+}
+
 export default {
   getFormattedDate,
   getFormattedTime,
+  getFormattedDuration,
   makeDate,
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205063274561710/f

#### Description:
- [x] Fixes issues with the incorrect synchronization estimation time conversion and representation

#### Preview:
![est_time_prev](https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/81e89257-5690-4319-8f35-78c9db61c2a9)
