### PR TITLE
(fix) Issue with change logs

### DIFF
--- a/src/state/changeLogs/reducer.js
+++ b/src/state/changeLogs/reducer.js
@@ -4,6 +4,7 @@ import _get from 'lodash/get'
 import authTypes from 'state/auth/constants'
 import timeRangeTypes from 'state/timeRange/constants'
 import { fetch, fetchFail } from 'state/reducers.helper'
+import _isString from 'lodash/isString'
 
 import types from './constants'
 
@@ -37,12 +38,16 @@ export function changeLogsReducer(state = initialState, action) {
           userAgent,
         } = entry
 
+        const preparedUserAgent = _isString(userAgent)
+          ? userAgent
+          : userAgent?.raw
+
         return {
           ip,
           log,
           mtsCreate,
           subUserId,
-          userAgent,
+          userAgent: preparedUserAgent,
         }
       })
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205273935454916/f

#### Description:
- [x] Fixes issue with crashing `Change Logs` report when users remove the 2FA option from their account

#### Before:
![change_logs_before](https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/92b1da79-8883-4438-91a6-8ed66d6faaf2)

#### After: 
<img width="1357" alt="change_logs_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/3c0d5a04-4931-4260-970d-67a755e44663">
