### PR TITLE
(improvement) Reports representation on mobile

### DIFF
--- a/src/ui/CollapsedTable/_CollapsedTable.scss
+++ b/src/ui/CollapsedTable/_CollapsedTable.scss
@@ -13,6 +13,24 @@
     & > div {
       display: table-row;
 
+      .bitfinex-green-text, .bitfinex-green-text > div {
+        color: var(--tableAmountPosColor);
+      }
+    
+      .bitfinex-red-text, .bitfinex-red-text > div {
+        color: var(--tableAmountNegColor);
+      }
+    
+      .bitfinex-amount {
+        &.bitfinex-green-text > .bitfinex-amount-fraction {
+          color: var(--tableAmountFractionPosColor);
+        }
+    
+        &.bitfinex-red-text > .bitfinex-amount-fraction {
+          color: var(--tableAmountFractionNegColor);
+        }
+      }
+
       &:nth-child(odd) {
         background-color: var(--bgColor);
       }


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205282820751447/f

#### Description:
- [x] Implements colored displaying on mobiles `amounts`, `volumes`, etc, the same way as on the desktop for better readability

#### Before:
<img width="290" alt="reports_on_mobile_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/f33171e7-d86e-40cc-baa7-60b8541a60c4">

#### After:
<img width="290" alt="reports_on_mobile_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/84f047e6-b208-4292-a617-708e8150f3cd">
