### PR TITLE
(improvements) Error messages

### DIFF
--- a/src/state/accountBalance/saga.js
+++ b/src/state/accountBalance/saga.js
@@ -29,7 +29,6 @@ export function* fetchAccountBalance() {
       isUnrealizedProfitExcluded,
     }
     const { result = [], error } = yield call(getReqBalance, params)
-
     yield put(actions.updateBalance(result))
 
     if (error) {

--- a/src/state/accountBalance/saga.js
+++ b/src/state/accountBalance/saga.js
@@ -29,6 +29,7 @@ export function* fetchAccountBalance() {
       isUnrealizedProfitExcluded,
     }
     const { result = [], error } = yield call(getReqBalance, params)
+
     yield put(actions.updateBalance(result))
 
     if (error) {

--- a/src/state/accountSummary/saga.js
+++ b/src/state/accountSummary/saga.js
@@ -21,7 +21,7 @@ export function* fetchAccountSummary() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'accountsummary.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/affiliatesEarnings/saga.js
+++ b/src/state/affiliatesEarnings/saga.js
@@ -61,7 +61,7 @@ function* fetchAffiliatesEarnings() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'affiliatesearnings.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/audit/saga.js
+++ b/src/state/audit/saga.js
@@ -57,7 +57,7 @@ function* fetchPositionsAudit() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'paudit.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -140,7 +140,7 @@ function* signUp({ payload }) {
         yield put(updateErrorStatus({
           id: 'status.fail',
           topic: 'auth.auth',
-          detail: JSON.stringify(error),
+          detail: error?.message ?? JSON.stringify(error),
         }))
       }
     }
@@ -254,7 +254,7 @@ function* signIn({ payload }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'auth.auth',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {
@@ -327,7 +327,7 @@ function* removeUser() {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'auth.auth',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {
@@ -396,7 +396,7 @@ function* recoverPassword({ payload }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'auth.auth',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {
@@ -473,7 +473,7 @@ function* deleteAccount({ payload }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'auth.auth',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/candles/saga.js
+++ b/src/state/candles/saga.js
@@ -60,7 +60,7 @@ function* fetchData(section, data, method) {
     yield put(actions.fetchFail({
       id: 'status.fail',
       topic: 'candles.title',
-      detail: JSON.stringify(error),
+      detail: error?.message ?? JSON.stringify(error),
     }))
   }
 }

--- a/src/state/changeLogs/saga.js
+++ b/src/state/changeLogs/saga.js
@@ -52,7 +52,7 @@ function* fetchChangeLogs() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'changelogs.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/derivatives/saga.js
+++ b/src/state/derivatives/saga.js
@@ -40,7 +40,7 @@ function* fetchDerivatives() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'derivatives.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/fundingCreditHistory/saga.js
+++ b/src/state/fundingCreditHistory/saga.js
@@ -58,7 +58,7 @@ function* fetchFCredit() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'fcredit.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/fundingLoanHistory/saga.js
+++ b/src/state/fundingLoanHistory/saga.js
@@ -58,7 +58,7 @@ function* fetchFLoan() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'floan.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/fundingOfferHistory/saga.js
+++ b/src/state/fundingOfferHistory/saga.js
@@ -58,7 +58,7 @@ function* fetchFOffer() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'foffer.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/invoices/saga.js
+++ b/src/state/invoices/saga.js
@@ -70,7 +70,7 @@ function* fetchInvoices() {
         yield put(actions.fetchFail({
           id: 'status.fail',
           topic: 'invoices.title',
-          detail: JSON.stringify(error),
+          detail: error?.message ?? JSON.stringify(error),
         }))
       }
     }

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -62,7 +62,7 @@ function* fetchLedgers() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'ledgers.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/logins/saga.js
+++ b/src/state/logins/saga.js
@@ -52,7 +52,7 @@ function* fetchLogins() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'logins.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/movements/saga.js
+++ b/src/state/movements/saga.js
@@ -58,7 +58,7 @@ function* fetchMovements() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'movements.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/orderTrades/saga.js
+++ b/src/state/orderTrades/saga.js
@@ -32,7 +32,7 @@ function* fetchOrderTrades() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'ordertrades.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/orders/saga.js
+++ b/src/state/orders/saga.js
@@ -57,7 +57,7 @@ function* fetchOrders() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'orders.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/positions/saga.js
+++ b/src/state/positions/saga.js
@@ -60,7 +60,7 @@ function* fetchPositions() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'positions.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/positionsActive/saga.js
+++ b/src/state/positionsActive/saga.js
@@ -17,7 +17,7 @@ function* fetchActivePositions() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'positions.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/publicFunding/saga.js
+++ b/src/state/publicFunding/saga.js
@@ -59,7 +59,7 @@ function* fetchPublicFunding() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'publicfunding.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/publicTrades/saga.js
+++ b/src/state/publicTrades/saga.js
@@ -57,7 +57,7 @@ function* fetchPublicTrades() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'publictrades.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -455,7 +455,7 @@ function* exportCSV({ payload: targets }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'download.export',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/subAccounts/saga.js
+++ b/src/state/subAccounts/saga.js
@@ -75,7 +75,7 @@ export function* createSubAccount({ payload }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'subaccounts.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {
@@ -125,7 +125,7 @@ export function* removeSubAccount({ payload }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'subaccounts.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {
@@ -180,7 +180,7 @@ export function* updateSubAccount({ payload }) {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'subaccounts.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {
@@ -217,7 +217,7 @@ export function* updateLocalUsername({ payload }) {
         yield put(updateErrorStatus({
           id: 'status.fail',
           topic: 'subaccounts.title',
-          detail: JSON.stringify(error),
+          detail: error?.message ?? JSON.stringify(error),
         }))
       }
     }

--- a/src/state/symbols/saga.js
+++ b/src/state/symbols/saga.js
@@ -18,7 +18,7 @@ function* fetchSymbols() {
       yield put(updateErrorStatus({
         id: 'status.fail',
         topic: 'symbols.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/tickers/saga.js
+++ b/src/state/tickers/saga.js
@@ -58,7 +58,7 @@ function* fetchTickers() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'tickers.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/trades/saga.js
+++ b/src/state/trades/saga.js
@@ -57,7 +57,7 @@ function* fetchTrades() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'trades.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {

--- a/src/state/weightedAverages/saga.js
+++ b/src/state/weightedAverages/saga.js
@@ -40,7 +40,7 @@ function* fetchWeightedAverages() {
       yield put(actions.fetchFail({
         id: 'status.fail',
         topic: 'weightedaverages.title',
-        detail: JSON.stringify(error),
+        detail: error?.message ?? JSON.stringify(error),
       }))
     }
   } catch (fail) {


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205274879478196/f

#### Description:
- [x] Enhances the error notifications: for all the `json rpc` requests shows only error `messages` if available instead of the whole error object for representation

#### Before:
<img width="531" alt="err_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/92a09172-821c-44f4-8d47-e28a85dc0b7e">

#### After:
<img width="337" alt="err_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/b8673a4d-ade2-4495-874f-b0e32eece33b">

#### Depends on: 
- [bfx-report #327](https://github.com/bitfinexcom/bfx-report/pull/327)
