### PR TITLE
(improvements) Filter panels representation

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -519,9 +519,11 @@
       "exact": "Exact"
     },
     "filter": {
-      "symbol": "Symbol Filter",
+      "symbol": "Symbol",
       "pair": "Pair Filter",
-      "category": "Category Filter"
+      "category": "Category Filter",
+      "columns": "Columns",
+      "date": "Date"
     },
     "report-type": {
       "title": "Select Report Type",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -220,7 +220,7 @@
     "webhook": "Webhook"
   },
   "columnsfilter": {
-    "title": "Filter Columns",
+    "title": "Filter",
     "clear": "Clear",
     "cancel": "Cancel",
     "apply": "Apply",

--- a/src/components/AccountBalance/AccountBalance.js
+++ b/src/components/AccountBalance/AccountBalance.js
@@ -125,8 +125,13 @@ class AccountBalance extends PureComponent {
           <SectionHeaderTitle>
             {t('accountbalance.title')}
           </SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.select')}

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -175,8 +175,13 @@ class AverageWinLoss extends PureComponent {
             {t('averagewinloss.title')}
           </SectionHeaderTitle>
           <SectionSwitch target={TYPE} />
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.select')}

--- a/src/components/Candles/Candles.js
+++ b/src/components/Candles/Candles.js
@@ -138,8 +138,13 @@ class Candles extends PureComponent {
           <SectionHeaderTitle>
             {t('candles.title')}
           </SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/Derivatives/Derivatives.js
+++ b/src/components/Derivatives/Derivatives.js
@@ -157,7 +157,12 @@ class Derivatives extends PureComponent {
               />
             </SectionHeaderItem>
             <ClearFiltersButton onClick={this.clearPairs} />
-            <ColumnsFilter target={TYPE} />
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.columns')}
+              </SectionHeaderItemLabel>
+              <ColumnsFilter target={TYPE} />
+            </SectionHeaderItem>
             <RefreshButton onClick={refresh} />
             <DerivativesSyncPref />
           </SectionHeaderRow>

--- a/src/components/FeesReport/FeesReport.js
+++ b/src/components/FeesReport/FeesReport.js
@@ -148,8 +148,13 @@ class FeesReport extends PureComponent {
             {t('feesreport.title')}
           </SectionHeaderTitle>
           <SectionSwitch target={TYPE} />
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/Invoices/Invoices.js
+++ b/src/components/Invoices/Invoices.js
@@ -171,7 +171,12 @@ class Invoices extends PureComponent {
               />
             </SectionHeaderItem>
             <ClearFiltersButton onClick={this.clearSymbols} />
-            <ColumnsFilter target={TYPE} />
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.columns')}
+              </SectionHeaderItemLabel>
+              <ColumnsFilter target={TYPE} />
+            </SectionHeaderItem>
             <RefreshButton onClick={refresh} />
           </SectionHeaderRow>
         </SectionHeader>

--- a/src/components/Invoices/Invoices.js
+++ b/src/components/Invoices/Invoices.js
@@ -153,8 +153,13 @@ class Invoices extends PureComponent {
       >
         <SectionHeader>
           <SectionHeaderTitle>{t('invoices.title')}</SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/Ledgers/Ledgers.js
+++ b/src/components/Ledgers/Ledgers.js
@@ -145,8 +145,13 @@ class Ledgers extends PureComponent {
       >
         <SectionHeader>
           <SectionHeaderTitle>{t('ledgers.title')}</SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/Ledgers/Ledgers.js
+++ b/src/components/Ledgers/Ledgers.js
@@ -172,7 +172,12 @@ class Ledgers extends PureComponent {
                 onChange={this.onCategoryChange}
               />
             </SectionHeaderItem>
-            <ColumnsFilter target={TYPE} />
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.columns')}
+              </SectionHeaderItemLabel>
+              <ColumnsFilter target={TYPE} />
+            </SectionHeaderItem>
             <RefreshButton onClick={refresh} />
           </SectionHeaderRow>
         </SectionHeader>

--- a/src/components/LoanReport/LoanReport.js
+++ b/src/components/LoanReport/LoanReport.js
@@ -133,8 +133,13 @@ class LoanReport extends PureComponent {
             {t('loanreport.title')}
           </SectionHeaderTitle>
           <SectionSwitch target={TYPE} />
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/PublicFunding/PublicFunding.js
+++ b/src/components/PublicFunding/PublicFunding.js
@@ -90,8 +90,13 @@ class PublicFunding extends PureComponent {
       <Card elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
         <SectionHeader>
           <SectionHeaderTitle>{t('publicfunding.title')}</SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/PublicFunding/PublicFunding.js
+++ b/src/components/PublicFunding/PublicFunding.js
@@ -107,7 +107,12 @@ class PublicFunding extends PureComponent {
                 onSymbolSelect={this.onSymbolSelect}
               />
             </SectionHeaderItem>
-            <ColumnsFilter target={TYPE} />
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.columns')}
+              </SectionHeaderItemLabel>
+              <ColumnsFilter target={TYPE} />
+            </SectionHeaderItem>
             <RefreshButton onClick={refresh} />
             <SyncSymbolPrefButton />
           </SectionHeaderRow>

--- a/src/components/PublicTrades/PublicTrades.columns.js
+++ b/src/components/PublicTrades/PublicTrades.columns.js
@@ -55,11 +55,10 @@ export default function getColumns(props) {
         const { type, amount } = filteredData[rowIndex]
         const classes = amountStyle(amount)
         return (
-          <Cell
-            className={classes}
-            tooltip={getTooltipContent(type, t)}
-          >
-            {type}
+          <Cell tooltip={getTooltipContent(type, t)}>
+            <span className={classes}>
+              {type}
+            </span>
           </Cell>
         )
       },

--- a/src/components/PublicTrades/PublicTrades.js
+++ b/src/components/PublicTrades/PublicTrades.js
@@ -82,8 +82,13 @@ class PublicTrades extends PureComponent {
       <Card elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
         <SectionHeader>
           <SectionHeaderTitle>{t('publictrades.title')}</SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.symbol')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/PublicTrades/PublicTrades.js
+++ b/src/components/PublicTrades/PublicTrades.js
@@ -85,7 +85,7 @@ class PublicTrades extends PureComponent {
           <SectionHeaderRow>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
-                {t('selector.filter.symbol')}
+                {t('selector.filter.date')}
               </SectionHeaderItemLabel>
               <TimeRange className='section-header-time-range' />
             </SectionHeaderItem>
@@ -98,7 +98,12 @@ class PublicTrades extends PureComponent {
                 onPairSelect={this.onPairSelect}
               />
             </SectionHeaderItem>
-            <ColumnsFilter target={TYPE} />
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.columns')}
+              </SectionHeaderItemLabel>
+              <ColumnsFilter target={TYPE} />
+            </SectionHeaderItem>
             <RefreshButton onClick={refresh} />
             <SyncPrefButton sectionType={TYPE} />
           </SectionHeaderRow>

--- a/src/components/SubAccounts/SubAccount/SubUsersAdd/_SubUsersAdd.scss
+++ b/src/components/SubAccounts/SubAccount/SubUsersAdd/_SubUsersAdd.scss
@@ -27,6 +27,12 @@
         }
       }
 
+      .bitfinex-select {
+        .bp3-button {
+          height: 40px;
+        }     
+      }
+
       .input-group {
         display: inline-block;
 

--- a/src/components/Tickers/Tickers.js
+++ b/src/components/Tickers/Tickers.js
@@ -97,8 +97,13 @@ class Tickers extends PureComponent {
       <Card elevation={Elevation.ZERO} className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
         <SectionHeader>
           <SectionHeaderTitle>{t('tickers.spot')}</SectionHeaderTitle>
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/Tickers/Tickers.js
+++ b/src/components/Tickers/Tickers.js
@@ -115,7 +115,12 @@ class Tickers extends PureComponent {
               />
             </SectionHeaderItem>
             <ClearFiltersButton onClick={this.clearPairs} />
-            <ColumnsFilter target={TYPE} />
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.columns')}
+              </SectionHeaderItemLabel>
+              <ColumnsFilter target={TYPE} />
+            </SectionHeaderItem>
             <RefreshButton onClick={refresh} />
             <SyncPrefButton sectionType={TYPE} />
           </SectionHeaderRow>

--- a/src/components/TradedVolume/TradedVolume.js
+++ b/src/components/TradedVolume/TradedVolume.js
@@ -101,8 +101,13 @@ class TradedVolume extends PureComponent {
             {t('tradedvolume.title')}
           </SectionHeaderTitle>
           <SectionSwitch target={TYPE} />
-          <TimeRange className='section-header-time-range' />
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/WeightedAverages/WeightedAverages.js
+++ b/src/components/WeightedAverages/WeightedAverages.js
@@ -16,7 +16,6 @@ import {
 } from 'ui/SectionHeader'
 import TimeRange from 'ui/TimeRange'
 import RefreshButton from 'ui/RefreshButton'
-import SectionSwitch from 'ui/SectionSwitch'
 import PairSelector from 'ui/PairSelector'
 
 import {
@@ -29,7 +28,6 @@ import queryConstants from 'state/query/constants'
 import LimitNote from './WeightedAverages.note'
 import { getColumns } from './WeightedAverages.columns'
 
-const { showFrameworkMode } = config
 const TYPE = queryConstants.MENU_WEIGHTED_AVERAGES
 
 class WeightedAverages extends PureComponent {
@@ -131,12 +129,14 @@ class WeightedAverages extends PureComponent {
           <SectionHeaderTitle>
             {t('weightedaverages.title')}
           </SectionHeaderTitle>
-          {showFrameworkMode && (
-            <SectionSwitch target={TYPE} />
-          )}
-          <TimeRange className='section-header-time-range' />
           {nextPage && <LimitNote />}
           <SectionHeaderRow>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.filter.date')}
+              </SectionHeaderItemLabel>
+              <TimeRange className='section-header-time-range' />
+            </SectionHeaderItem>
             <SectionHeaderItem>
               <SectionHeaderItemLabel>
                 {t('selector.filter.symbol')}

--- a/src/components/WeightedAverages/WeightedAverages.js
+++ b/src/components/WeightedAverages/WeightedAverages.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { Card, Elevation } from '@blueprintjs/core'
 import _size from 'lodash/size'
 
-import config from 'config'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DataTable from 'ui/DataTable'

--- a/src/components/WeightedAverages/WeightedAverages.js
+++ b/src/components/WeightedAverages/WeightedAverages.js
@@ -16,7 +16,7 @@ import {
 import TimeRange from 'ui/TimeRange'
 import RefreshButton from 'ui/RefreshButton'
 import PairSelector from 'ui/PairSelector'
-
+import SectionSwitch from 'ui/SectionSwitch'
 import {
   checkInit,
   checkFetch,
@@ -128,6 +128,7 @@ class WeightedAverages extends PureComponent {
           <SectionHeaderTitle>
             {t('weightedaverages.title')}
           </SectionHeaderTitle>
+          <SectionSwitch target={TYPE} />
           {nextPage && <LimitNote />}
           <SectionHeaderRow>
             <SectionHeaderItem>

--- a/src/components/WeightedAverages/WeightedAverages.js
+++ b/src/components/WeightedAverages/WeightedAverages.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Card, Elevation } from '@blueprintjs/core'
 import _size from 'lodash/size'
 
+import config from 'config'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DataTable from 'ui/DataTable'
@@ -27,6 +28,7 @@ import queryConstants from 'state/query/constants'
 import LimitNote from './WeightedAverages.note'
 import { getColumns } from './WeightedAverages.columns'
 
+const { showFrameworkMode } = config
 const TYPE = queryConstants.MENU_WEIGHTED_AVERAGES
 
 class WeightedAverages extends PureComponent {
@@ -79,7 +81,6 @@ class WeightedAverages extends PureComponent {
 
   onPairSelect = pair => setPair(TYPE, this.props, pair)
 
-
   render() {
     const {
       t,
@@ -128,7 +129,9 @@ class WeightedAverages extends PureComponent {
           <SectionHeaderTitle>
             {t('weightedaverages.title')}
           </SectionHeaderTitle>
-          <SectionSwitch target={TYPE} />
+          {showFrameworkMode && (
+            <SectionSwitch target={TYPE} />
+          )}
           {nextPage && <LimitNote />}
           <SectionHeaderRow>
             <SectionHeaderItem>

--- a/src/ui/ClearFiltersButton/_ClearFiltersButton.scss
+++ b/src/ui/ClearFiltersButton/_ClearFiltersButton.scss
@@ -1,6 +1,5 @@
 .clear-filters-button {
   height: 20px;
-  margin-bottom: 8px;
   cursor: pointer;
 }
 

--- a/src/ui/CollapsedTable/_CollapsedTable.scss
+++ b/src/ui/CollapsedTable/_CollapsedTable.scss
@@ -13,6 +13,24 @@
     & > div {
       display: table-row;
 
+      .bitfinex-green-text, .bitfinex-green-text > div {
+        color: var(--tableAmountPosColor);
+      }
+    
+      .bitfinex-red-text, .bitfinex-red-text > div {
+        color: var(--tableAmountNegColor);
+      }
+    
+      .bitfinex-amount {
+        &.bitfinex-green-text > .bitfinex-amount-fraction {
+          color: var(--tableAmountFractionPosColor);
+        }
+    
+        &.bitfinex-red-text > .bitfinex-amount-fraction {
+          color: var(--tableAmountFractionNegColor);
+        }
+      }
+
       &:nth-child(odd) {
         background-color: var(--bgColor);
       }

--- a/src/ui/ColumnsFilter/ColumnsFilter.js
+++ b/src/ui/ColumnsFilter/ColumnsFilter.js
@@ -209,7 +209,7 @@ class ColumnsFilter extends PureComponent {
           <Button
             onClick={this.toggleDialog}
             className={buttonClasses}
-            intent={Intent.PRIMARY}
+            intent={Intent.SUCCESS}
           >
             {t('columnsfilter.title')}
           </Button>

--- a/src/ui/ColumnsFilter/ColumnsFilter.js
+++ b/src/ui/ColumnsFilter/ColumnsFilter.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react'
+import React, { PureComponent } from 'react'
 import { withTranslation } from 'react-i18next'
 import classNames from 'classnames'
 import {
@@ -204,7 +204,7 @@ class ColumnsFilter extends PureComponent {
     const buttonClasses = classNames('button--large', { 'columns-filter--active': hasAppliedFilters })
 
     return (
-      <Fragment>
+      <>
         <div className='columns-filter-wrapper'>
           <Button
             onClick={this.toggleDialog}
@@ -277,7 +277,7 @@ class ColumnsFilter extends PureComponent {
             </div>
           </div>
         </ColumnsFilterDialog>
-      </Fragment>
+      </>
     )
   }
 }

--- a/src/ui/ColumnsFilter/_ColumnsFilter.scss
+++ b/src/ui/ColumnsFilter/_ColumnsFilter.scss
@@ -2,6 +2,12 @@
   &-wrapper {
     display: inline-block;
     position: relative;
+
+    .bp3-button {
+      height: 34px;
+      min-width: 95px;
+      font-size: 14px;
+    }
   }
 
   &-dialog {

--- a/src/ui/DateInput/_DateInput.scss
+++ b/src/ui/DateInput/_DateInput.scss
@@ -18,7 +18,7 @@
 
 .date-input-popover {
   .bp3-input {
-    height: 40px;
+    height: 34px;
   }
 
   .bp3-input-action {

--- a/src/ui/MultiSelect/_MultiSelect.scss
+++ b/src/ui/MultiSelect/_MultiSelect.scss
@@ -1,7 +1,7 @@
 .bp3-multi-select {
   position: relative;
   min-width: 223px;
-  min-height: 40px;
+  min-height: 34px;
 
   &.bp3-input {
     box-shadow: none;
@@ -11,7 +11,7 @@
 
   &-arrow {
     position: absolute;
-    top: 6px;
+    top: 5px;
     right: 8px;
   }
 

--- a/src/ui/QueryButton/QueryButton.js
+++ b/src/ui/QueryButton/QueryButton.js
@@ -14,7 +14,7 @@ const QueryButton = (props) => {
     <Button
       className='query-button'
       onClick={onClick}
-      intent={Intent.PRIMARY}
+      intent={Intent.SUCCESS}
       disabled={disabled}
     >
       {t('query.title')}

--- a/src/ui/QueryButton/_QueryButton.scss
+++ b/src/ui/QueryButton/_QueryButton.scss
@@ -1,7 +1,7 @@
 .query-button {
   width: auto;
   min-width: 100px;
-  height: 40px;
+  height: 34px;
 }
 
 @media screen and (min-width: 2560px) {

--- a/src/ui/RefreshButton/_RefreshButton.scss
+++ b/src/ui/RefreshButton/_RefreshButton.scss
@@ -1,6 +1,5 @@
 .refresh-button {
   height: 24px;
-  margin-bottom: 8px;
   cursor: pointer;
 }
 

--- a/src/ui/SectionHeader/SectionHeader.js
+++ b/src/ui/SectionHeader/SectionHeader.js
@@ -87,7 +87,14 @@ class SectionHeader extends PureComponent {
             )}
             {clearTargetPairs && <ClearFiltersButton onClick={clearTargetPairs} />}
             {clearTargetSymbols && <ClearFiltersButton onClick={clearTargetSymbols} />}
-            {filter && <ColumnsFilter target={target} />}
+            {filter && (
+              <SectionHeaderItem>
+                <SectionHeaderItemLabel>
+                  {t('selector.filter.columns')}
+                </SectionHeaderItemLabel>
+                <ColumnsFilter target={target} />
+              </SectionHeaderItem>
+            )}
             {refresh && <RefreshButton onClick={refresh} />}
           </SectionHeaderRow>
         )}

--- a/src/ui/SectionHeader/SectionHeader.js
+++ b/src/ui/SectionHeader/SectionHeader.js
@@ -67,9 +67,16 @@ class SectionHeader extends PureComponent {
           {t(title)}
         </SectionHeaderTitle>
         {showHeaderTabs && <SectionSwitch target={target} />}
-        {timeframe && <TimeRange className='section-header-time-range' />}
         {(selector || filter || refresh || clearTargetPairs) && (
           <SectionHeaderRow>
+            {timeframe && (
+              <SectionHeaderItem>
+                <SectionHeaderItemLabel>
+                  {t('selector.filter.date')}
+                </SectionHeaderItemLabel>
+                <TimeRange className='section-header-time-range' />
+              </SectionHeaderItem>
+            )}
             {selector && (
               <SectionHeaderItem>
                 <SectionHeaderItemLabel>

--- a/src/ui/SectionHeader/_SectionHeader.scss
+++ b/src/ui/SectionHeader/_SectionHeader.scss
@@ -69,7 +69,6 @@
   }
 
   .time-range {
-    margin: 0 2px 22px 2px;
     font-size: 15px;
   }
 }

--- a/src/ui/SectionHeader/_SectionHeader.scss
+++ b/src/ui/SectionHeader/_SectionHeader.scss
@@ -64,9 +64,9 @@
 
   &-item {
     &-label {
-      color: var(--color2);
-      margin-bottom: 10px;
       font-size: 14px;
+      margin-bottom: 5px;
+      color: var(--color2);
     }
   }
 

--- a/src/ui/SectionHeader/_SectionHeader.scss
+++ b/src/ui/SectionHeader/_SectionHeader.scss
@@ -71,7 +71,7 @@
   }
 
   .time-range {
-    font-size: 15px;
+    font-size: 14px;
   }
 }
 

--- a/src/ui/SectionHeader/_SectionHeader.scss
+++ b/src/ui/SectionHeader/_SectionHeader.scss
@@ -64,7 +64,9 @@
 
   &-item {
     &-label {
+      color: var(--color2);
       margin-bottom: 10px;
+      font-size: 14px;
     }
   }
 

--- a/src/ui/SectionHeader/_SectionHeader.scss
+++ b/src/ui/SectionHeader/_SectionHeader.scss
@@ -1,5 +1,5 @@
 .section-header {
-  margin-bottom: 31px;
+  margin-bottom: 20px;
 
   &-title {
     font-size: 30px;

--- a/src/ui/Select/_Select.scss
+++ b/src/ui/Select/_Select.scss
@@ -2,7 +2,7 @@
   .bp3-button {
     min-width: 180px;
     width: fit-content;
-    height: 40px;
+    height: 34px;
     padding-right: 8px;
     background-color: var(--multiBg);
     color: var(--color);

--- a/src/ui/SyncButton/_SyncButton.scss
+++ b/src/ui/SyncButton/_SyncButton.scss
@@ -1,6 +1,5 @@
 .sync-pref-button {
   height: 24px;
-  margin-bottom: 8px;
   cursor: pointer;
 }
 

--- a/src/ui/TimeRange/TimeRange.js
+++ b/src/ui/TimeRange/TimeRange.js
@@ -18,10 +18,10 @@ const TimeRange = ({
     className={classNames('time-range', className)}
     onClick={toggleTimeFrameDialog}
   >
-    {icon && <Icon.CALENDAR />}
     <span>
       {`${formatDate(start, timezone)} - ${formatDate(end, timezone)}`}
     </span>
+    {icon && <Icon.CALENDAR />}
   </div>
 )
 

--- a/src/ui/TimeRange/_TimeRange.scss
+++ b/src/ui/TimeRange/_TimeRange.scss
@@ -10,11 +10,12 @@
   border-radius: 4px;
 
   svg {
-    margin-right: 12px;
+    margin-left: 10px;
     vertical-align: middle;
+    transform: scale(0.65);
 
     path {
-      fill: var(--timeRangeColor);
+      fill: var(--color2);
     }
   }
 

--- a/src/ui/TimeRange/_TimeRange.scss
+++ b/src/ui/TimeRange/_TimeRange.scss
@@ -1,7 +1,7 @@
 .time-range {
   cursor: pointer;
   font-size: 18px;
-  padding: 5px 8px;
+  padding: 4px 8px;
   width: fit-content;
   vertical-align: middle;
   color: var(--timeRangeColor);


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205323623696509/f

#### Description:
- [x] Enhances `Reports` filter panels representation

#### Before:
<img width="784" alt="filter-panels-before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/33d3a9a4-1109-4d71-b08e-e24fe99614ab">

#### After:
<img width="774" alt="filter-panels-after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/6e492449-8264-46dc-9ff2-ed54aaf31934">

#### Depends on: 
- [bfx-report-ui #691](https://github.com/bitfinexcom/bfx-report-ui/pull/691)