### PR TITLE
(improvement) Submitting via enter for the 2FA sign-up flow

### DIFF
--- a/src/components/Auth/LoginEmail/LoginEmail.js
+++ b/src/components/Auth/LoginEmail/LoginEmail.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import InputKey from '../InputKey'
@@ -6,27 +6,45 @@ import InputKey from '../InputKey'
 export const LoginEmail = ({
   userName,
   onChange,
+  onSignUp,
   userPassword,
-}) => (
-  <>
-    <InputKey
-      type='text'
-      name='userName'
-      value={userName}
-      onChange={onChange}
-      label='auth.loginEmail.emailOrUserName'
-    />
-    <InputKey
-      name='userPassword'
-      value={userPassword}
-      onChange={onChange}
-      label='auth.loginEmail.bfxAccPassword'
-    />
-  </>
-)
+}) => {
+  useEffect(() => {
+    const keyDownHandler = (event) => {
+      if (event?.key === 'Enter') {
+        event.preventDefault()
+        onSignUp()
+      }
+    }
+    document.addEventListener('keydown', keyDownHandler)
+
+    return () => {
+      document.removeEventListener('keydown', keyDownHandler)
+    }
+  }, [])
+
+  return (
+    <>
+      <InputKey
+        type='text'
+        name='userName'
+        value={userName}
+        onChange={onChange}
+        label='auth.loginEmail.emailOrUserName'
+      />
+      <InputKey
+        name='userPassword'
+        value={userPassword}
+        onChange={onChange}
+        label='auth.loginEmail.bfxAccPassword'
+      />
+    </>
+  )
+}
 
 LoginEmail.propTypes = {
   onChange: PropTypes.func.isRequired,
+  onSignUp: PropTypes.func.isRequired,
   userName: PropTypes.string.isRequired,
   userPassword: PropTypes.string.isRequired,
 }

--- a/src/components/Auth/LoginEmail/LoginEmail.js
+++ b/src/components/Auth/LoginEmail/LoginEmail.js
@@ -1,7 +1,7 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 
-import { useKeyDown } from 'hooks/useKeyDown'
+import useKeyDown from 'hooks/useKeyDown'
 
 import InputKey from '../InputKey'
 

--- a/src/components/Auth/LoginEmail/LoginEmail.js
+++ b/src/components/Auth/LoginEmail/LoginEmail.js
@@ -1,5 +1,7 @@
-import React, { memo, useEffect } from 'react'
+import React, { memo } from 'react'
 import PropTypes from 'prop-types'
+
+import { useKeyDown } from 'hooks/useKeyDown'
 
 import InputKey from '../InputKey'
 
@@ -9,19 +11,9 @@ export const LoginEmail = ({
   onSignUp,
   userPassword,
 }) => {
-  useEffect(() => {
-    const keyDownHandler = (event) => {
-      if (event?.key === 'Enter') {
-        event.preventDefault()
-        onSignUp()
-      }
-    }
-    document.addEventListener('keydown', keyDownHandler)
-
-    return () => {
-      document.removeEventListener('keydown', keyDownHandler)
-    }
-  }, [])
+  useKeyDown(() => {
+    onSignUp()
+  }, ['Enter'])
 
   return (
     <>

--- a/src/components/Auth/LoginOtp/LoginOtp.js
+++ b/src/components/Auth/LoginOtp/LoginOtp.js
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Button, Intent } from '@blueprintjs/core'
 import { isEmpty } from '@bitfinex/lib-js-util-base'
 
-import { useKeyDown } from 'hooks/useKeyDown'
+import useKeyDown from 'hooks/useKeyDown'
 
 import InputKey from '../InputKey'
 

--- a/src/components/Auth/LoginOtp/LoginOtp.js
+++ b/src/components/Auth/LoginOtp/LoginOtp.js
@@ -16,7 +16,7 @@ export const LoginOtp = ({
 
   useEffect(() => {
     const keyDownHandler = (event) => {
-      if (event.key === 'Enter') {
+      if (event?.key === 'Enter') {
         event.preventDefault()
         handleOneTimePassword()
       }

--- a/src/components/Auth/LoginOtp/LoginOtp.js
+++ b/src/components/Auth/LoginOtp/LoginOtp.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import { Button, Intent } from '@blueprintjs/core'
@@ -13,6 +13,21 @@ export const LoginOtp = ({
   handleOneTimePassword,
 }) => {
   const { t } = useTranslation()
+
+  useEffect(() => {
+    const keyDownHandler = (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        handleOneTimePassword()
+      }
+    }
+    document.addEventListener('keydown', keyDownHandler)
+
+    return () => {
+      document.removeEventListener('keydown', keyDownHandler)
+    }
+  }, [])
+
   return (
     <div className='sign-in--otp'>
       <InputKey

--- a/src/components/Auth/LoginOtp/LoginOtp.js
+++ b/src/components/Auth/LoginOtp/LoginOtp.js
@@ -1,8 +1,10 @@
-import React, { memo, useEffect } from 'react'
+import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import { Button, Intent } from '@blueprintjs/core'
 import { isEmpty } from '@bitfinex/lib-js-util-base'
+
+import { useKeyDown } from 'hooks/useKeyDown'
 
 import InputKey from '../InputKey'
 
@@ -14,19 +16,9 @@ export const LoginOtp = ({
 }) => {
   const { t } = useTranslation()
 
-  useEffect(() => {
-    const keyDownHandler = (event) => {
-      if (event?.key === 'Enter') {
-        event.preventDefault()
-        handleOneTimePassword()
-      }
-    }
-    document.addEventListener('keydown', keyDownHandler)
-
-    return () => {
-      document.removeEventListener('keydown', keyDownHandler)
-    }
-  }, [])
+  useKeyDown(() => {
+    handleOneTimePassword()
+  }, ['Enter'])
 
   return (
     <div className='sign-in--otp'>

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -235,6 +235,7 @@ class SignUp extends PureComponent {
                 {showLoginEmail && (
                   <LoginEmail
                     userName={userName}
+                    onSignUp={this.onSignUp}
                     userPassword={userPassword}
                     onChange={this.handleInputChange}
                   />

--- a/src/hooks/useKeyDown.js
+++ b/src/hooks/useKeyDown.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+export const useKeyDown = (callback, keys) => {
+  const onKeyDown = (event) => {
+    const wasAnyKeyPressed = keys.some((key) => event.key === key)
+    if (wasAnyKeyPressed) {
+      event.preventDefault()
+      callback()
+    }
+  }
+  useEffect(() => {
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [onKeyDown])
+}

--- a/src/hooks/useKeyDown.js
+++ b/src/hooks/useKeyDown.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-export const useKeyDown = (callback, keys) => {
+const useKeyDown = (callback, keys) => {
   const onKeyDown = (event) => {
     const wasAnyKeyPressed = keys.some((key) => event.key === key)
     if (wasAnyKeyPressed) {
@@ -15,3 +15,5 @@ export const useKeyDown = (callback, keys) => {
     }
   }, [onKeyDown])
 }
+
+export default useKeyDown


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205737078890392/f

#### Description:
- [x] Implements the possibility of submitting `username/password` and `OTP` via the `Enter` button during the `2FA` sign-up flow 
#### Preview:

https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/63c831e1-f83d-45dc-b353-50982d68a418

