### PR TITLE
(improvement) Hide unrealized profit selectors

### DIFF
--- a/src/components/AccountBalance/AccountBalance.js
+++ b/src/components/AccountBalance/AccountBalance.js
@@ -142,15 +142,17 @@ class AccountBalance extends PureComponent {
                 onChange={this.handleTimeframeChange}
               />
             </SectionHeaderItem>
-            <SectionHeaderItem>
-              <SectionHeaderItemLabel>
-                {t('selector.unrealized-profits.title')}
-              </SectionHeaderItemLabel>
-              <UnrealizedProfitSelector
-                value={isUnrealizedProfitExcluded}
-                onChange={this.handleUnrealizedProfitChange}
-              />
-            </SectionHeaderItem>
+            <div className='hidden'>
+              <SectionHeaderItem>
+                <SectionHeaderItemLabel>
+                  {t('selector.unrealized-profits.title')}
+                </SectionHeaderItemLabel>
+                <UnrealizedProfitSelector
+                  value={isUnrealizedProfitExcluded}
+                  onChange={this.handleUnrealizedProfitChange}
+                />
+              </SectionHeaderItem>
+            </div>
             <QueryButton
               disabled={!hasChanges}
               onClick={this.handleQuery}

--- a/src/components/AppSummary/AppSummary.js
+++ b/src/components/AppSummary/AppSummary.js
@@ -87,15 +87,17 @@ const AppSummary = ({
                 onChange={handleTimeFrameChange}
               />
             </SectionHeaderItem>
-            <SectionHeaderItem>
-              <SectionHeaderItemLabel>
-                {t('selector.unrealized-profits.title')}
-              </SectionHeaderItemLabel>
-              <UnrealizedProfitSelector
-                value={isUnrealizedProfitExcluded}
-                onChange={handleUnrealizedProfitChange}
-              />
-            </SectionHeaderItem>
+            <div className='hidden'>
+              <SectionHeaderItem>
+                <SectionHeaderItemLabel>
+                  {t('selector.unrealized-profits.title')}
+                </SectionHeaderItemLabel>
+                <UnrealizedProfitSelector
+                  value={isUnrealizedProfitExcluded}
+                  onChange={handleUnrealizedProfitChange}
+                />
+              </SectionHeaderItem>
+            </div>
             <RefreshButton onClick={onRefresh} />
           </SectionHeaderRow>
         </SectionHeader>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -70,6 +70,10 @@ html {
   display: none !important;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .app {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Task: https://bitfinex.slack.com/archives/C024AMXFVPD/p1699977613046249?thread_ts=1699973411.324929&cid=C024AMXFVPD

#### Description:
- [x] Temporarily hides  `Unrealized Profit` selectors from the new app `Summary` and `Account Balance` reports according to [this](https://bitfinex.slack.com/archives/C024AMXFVPD/p1699977613046249?thread_ts=1699973411.324929&cid=C024AMXFVPD) proposal

#### Preview:
<img width="1058" alt="Screenshot 2023-11-14 at 18 37 53" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/7ed0a0bb-7672-42ee-9908-d4c76cec84d2">

