### PR TITLE
(improvement) Balance change representation

### DIFF
--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -8,6 +8,7 @@ import {
   formatUsdValue,
   formatPercentValue,
   formatUsdValueChange,
+  shouldShowPercentCheck,
 } from './AppSummary.helpers'
 
 export const getFeesColumns = ({
@@ -142,7 +143,7 @@ export const getAssetColumns = ({
     width: 178,
     renderer: (rowIndex) => {
       const { balanceUsd, valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
-      const shouldShowPercentChange = balanceUsd !== valueChange30dUsd
+      const shouldShowPercentChange = shouldShowPercentCheck(balanceUsd, valueChange30dUsd)
       return (
         <Cell tooltip={getTooltipContent(valueChange30dUsd, t)}>
           <>

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -141,17 +141,23 @@ export const getAssetColumns = ({
     name: 'summary.by_asset.balance_change',
     width: 178,
     renderer: (rowIndex) => {
-      const { valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
+      const { balanceUsd, valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
+      const shouldShowPercentChange = balanceUsd !== valueChange30dUsd
       return (
         <Cell tooltip={getTooltipContent(valueChange30dUsd, t)}>
           <>
             <span className='cell-value'>
               {formatUsdValueChange(valueChange30dUsd)}
             </span>
-            <br />
-            <span className='cell-value secondary-value'>
-              {formatPercentValue(valueChange30dPerc)}
-            </span>
+            {shouldShowPercentChange && (
+              <>
+                <br />
+                <span className='cell-value secondary-value'>
+                  {formatPercentValue(valueChange30dPerc)}
+                </span>
+              </>
+            )}
+
           </>
         </Cell>
       )

--- a/src/components/AppSummary/AppSummary.helpers.js
+++ b/src/components/AppSummary/AppSummary.helpers.js
@@ -25,3 +25,11 @@ export const formatUsdValueChange = (value) => {
   if (val < 0) return <span>{`-$${formatThousands(Math.abs(val))}`}</span>
   return <span>{`$${formatThousands(val)}`}</span>
 }
+
+export const shouldShowPercentCheck = (balance, balanceChange) => {
+  const bal = prepareNumericValue(balance)
+  const balChange = prepareNumericValue(balanceChange)
+  if (balChange === 0) return true
+  if (bal === balChange) return false
+  return true
+}


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1205968599642845/f

#### Description:
- [x] Improves `Balance Change` representation in the `Summary by Asset` section according to the following proposals:
```
- Hide 0% on balance change if the balance was previously 0 e.g. 
EUR was 0 and then it was deposited all current amount balance 432 balance change is also 432, 
it is confusing for users to have a percentage balance change 0% simply should be removed 

- If the balance change is 0$, then 0% should stay
```
#### Before:
<img width="1062" alt="balance-change-before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/055f4763-b78c-4afa-863d-4ea69bb4641a">

#### After:
<img width="1059" alt="balance-change-after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/e7899f25-e4cc-4bba-9636-17722c4e4d10">
