### PR TITLE
(improvement) Show unrealized profit selectors

### DIFF
--- a/src/components/AccountBalance/AccountBalance.js
+++ b/src/components/AccountBalance/AccountBalance.js
@@ -142,17 +142,15 @@ class AccountBalance extends PureComponent {
                 onChange={this.handleTimeframeChange}
               />
             </SectionHeaderItem>
-            <div className='hidden'>
-              <SectionHeaderItem>
-                <SectionHeaderItemLabel>
-                  {t('selector.unrealized-profits.title')}
-                </SectionHeaderItemLabel>
-                <UnrealizedProfitSelector
-                  value={isUnrealizedProfitExcluded}
-                  onChange={this.handleUnrealizedProfitChange}
-                />
-              </SectionHeaderItem>
-            </div>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.unrealized-profits.title')}
+              </SectionHeaderItemLabel>
+              <UnrealizedProfitSelector
+                value={isUnrealizedProfitExcluded}
+                onChange={this.handleUnrealizedProfitChange}
+              />
+            </SectionHeaderItem>
             <QueryButton
               disabled={!hasChanges}
               onClick={this.handleQuery}

--- a/src/components/AppSummary/AppSummary.js
+++ b/src/components/AppSummary/AppSummary.js
@@ -90,17 +90,15 @@ const AppSummary = ({
                 onChange={handleTimeFrameChange}
               />
             </SectionHeaderItem>
-            <div className='hidden'>
-              <SectionHeaderItem>
-                <SectionHeaderItemLabel>
-                  {t('selector.unrealized-profits.title')}
-                </SectionHeaderItemLabel>
-                <UnrealizedProfitSelector
-                  value={isUnrealizedProfitExcluded}
-                  onChange={handleUnrealizedProfitChange}
-                />
-              </SectionHeaderItem>
-            </div>
+            <SectionHeaderItem>
+              <SectionHeaderItemLabel>
+                {t('selector.unrealized-profits.title')}
+              </SectionHeaderItemLabel>
+              <UnrealizedProfitSelector
+                value={isUnrealizedProfitExcluded}
+                onChange={handleUnrealizedProfitChange}
+              />
+            </SectionHeaderItem>
             <RefreshButton onClick={onRefresh} />
           </SectionHeaderRow>
         </SectionHeader>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -70,10 +70,6 @@ html {
   display: none !important;
 }
 
-.hidden {
-  display: none !important;
-}
-
 .app {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1206054378193502/f

#### Description:
- [x] Shows  `Unrealized Profit` selectors on the new app `Summary` and `Account Balance` reports, reverts bitfinexcom/bfx-report-ui#730

#### Preview:
<img width="1409" alt="show_unrealized_profit" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/93cc8ae5-35ac-434b-83a8-0a6c694d9fe4">


#### Depends on: 
- [bfx-reports-framework #340](https://github.com/bitfinexcom/bfx-reports-framework/pull/340)