### PR TITLE
(improvement) Dynamic date range support for summary by asset

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -638,7 +638,6 @@
     },
     "by_asset":{
       "title": "Summary by Asset",
-      "sub_title":  "For the last 30 days",
       "currency": "Currency",
       "amount": "Amount",
       "balance": "Balance",

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -6,13 +6,14 @@ import { isEmpty } from '@bitfinex/lib-js-util-base'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DataTable from 'ui/DataTable'
-import { fetchData } from 'state/summaryByAsset/actions'
+import { fetchData, refresh } from 'state/summaryByAsset/actions'
 import {
   getPageLoading,
   getDataReceived,
   getSummaryByAssetTotal,
   getSummaryByAssetEntries,
 } from 'state/summaryByAsset/selectors'
+import { getTimeRange } from 'state/timeRange/selectors'
 import { getIsSyncRequired } from 'state/sync/selectors'
 
 import { getAssetColumns } from './AppSummary.columns'
@@ -21,6 +22,7 @@ import { prepareSummaryByAssetData } from './AppSummary.helpers'
 const AppSummaryByAsset = () => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const timeRange = useSelector(getTimeRange)
   const pageLoading = useSelector(getPageLoading)
   const dataReceived = useSelector(getDataReceived)
   const total = useSelector(getSummaryByAssetTotal)
@@ -32,6 +34,10 @@ const AppSummaryByAsset = () => {
       dispatch(fetchData())
     }
   }, [dataReceived, pageLoading, isSyncRequired])
+
+  useEffect(() => {
+    dispatch(refresh())
+  }, [timeRange])
 
   const preparedData = useMemo(
     () => prepareSummaryByAssetData(entries, total, t),

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -70,9 +70,6 @@ const AppSummaryByAsset = () => {
       <div className='app-summary-item-title'>
         {t('summary.by_asset.title')}
       </div>
-      <div className='app-summary-item-sub-title'>
-        {t('summary.by_asset.sub_title')}
-      </div>
       {showContent}
     </div>
   )

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -131,7 +131,7 @@
 .full-width-item {
   width: 100%;
   max-width: 100%;
-  min-height: 320px;
+  min-height: 300px;
 
   .bp3-table-container {
     box-shadow: none;
@@ -186,7 +186,7 @@
 
   .loading-container {
     display: flex;
-    min-height: 320px;
+    min-height: 300px;
     max-width: 1000px;
 
     .loading {
@@ -196,7 +196,7 @@
 
   .no-data {
     max-width: 1000px;
-    min-height: 320px;
+    min-height: 300px;
     
     &-wrapper {
       margin: 150px auto;

--- a/src/state/summaryByAsset/saga.js
+++ b/src/state/summaryByAsset/saga.js
@@ -8,15 +8,18 @@ import {
 import { makeFetchCall } from 'state/utils'
 import { updateErrorStatus } from 'state/status/actions'
 import { getIsSyncRequired } from 'state/sync/selectors'
+import { getTimeFrame } from 'state/timeRange/selectors'
 
 import types from './constants'
 import actions from './actions'
 
-export const getReqSummaryByAsset = () => makeFetchCall('getSummaryByAsset')
+export const getReqSummaryByAsset = (params) => makeFetchCall('getSummaryByAsset', params)
 
 export function* fetchSummaryByAsset() {
   try {
-    const { result = {}, error } = yield call(getReqSummaryByAsset)
+    const { start, end } = yield select(getTimeFrame)
+    const params = { start, end }
+    const { result = {}, error } = yield call(getReqSummaryByAsset, params)
     yield put(actions.updateData(result))
 
     if (error) {


### PR DESCRIPTION
Task:  https://app.asana.com/0/1163495710802945/1205924412881192/f

#### Description:
- [x] Implements dynamic selectable date range support for the `Summary by Asset` section

#### Before:
<img width="1062" alt="summary_by_asset_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/53b22c96-1625-4678-a0d9-75979565e187">

#### After:
![summary_by_asset_after](https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/881fa67b-8ed2-4261-baa9-44eb43e14d79)

https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/eb2db9b3-24aa-447a-8eff-b9ea5a228f09

#### Depends on: 
- [bfx-reports-framework #342](https://github.com/bitfinexcom/bfx-reports-framework/pull/342)
