### PR TITLE
(improvements) Initialization requests order

### DIFF
--- a/src/components/AccountBalance/AccountBalance.container.js
+++ b/src/components/AccountBalance/AccountBalance.container.js
@@ -16,6 +16,7 @@ import {
   getCurrentFetchParams,
   getIsUnrealizedProfitExcluded,
 } from 'state/accountBalance/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import AccountBalance from './AccountBalance'
 
@@ -23,6 +24,7 @@ const mapStateToProps = state => ({
   currentFetchParams: getCurrentFetchParams(state),
   dataReceived: getDataReceived(state),
   entries: getEntries(state),
+  isSyncRequired: getIsSyncRequired(state),
   isUnrealizedProfitExcluded: getIsUnrealizedProfitExcluded(state),
   pageLoading: getPageLoading(state),
   timeframe: getTimeframe(state),

--- a/src/components/AffiliatesEarnings/AffiliatesEarnings.container.js
+++ b/src/components/AffiliatesEarnings/AffiliatesEarnings.container.js
@@ -22,6 +22,7 @@ import {
 } from 'state/affiliatesEarnings/selectors'
 import queryConstants from 'state/query/constants'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 
 import AffiliatesEarnings from './AffiliatesEarnings'
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   entries: getFilteredEntries(state, queryConstants.MENU_AFFILIATES_EARNINGS, getEntries(state)),
   existingCoins: getExistingCoins(state),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   pageLoading: getPageLoading(state),
   targetSymbols: getTargetSymbols(state),
   timeOffset: getTimeOffset(state),

--- a/src/components/AverageWinLoss/AverageWinLoss.container.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.container.js
@@ -17,6 +17,7 @@ import {
   getDataReceived,
   getCurrentFetchParams,
 } from 'state/winLoss/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import AverageWinLoss from './AverageWinLoss'
 
@@ -26,6 +27,7 @@ const mapStateToProps = state => ({
   reportType: getReportType(state),
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
+  isSyncRequired: getIsSyncRequired(state),
   currentFetchParams: getCurrentFetchParams(state),
 })
 

--- a/src/components/Candles/Candles.container.js
+++ b/src/components/Candles/Candles.container.js
@@ -19,6 +19,7 @@ import {
   getDataReceived,
   getCurrentFetchParams,
 } from 'state/candles/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import Candles from './Candles'
 
@@ -27,6 +28,7 @@ const mapStateToProps = state => ({
   currentFetchParams: getCurrentFetchParams(state),
   dataReceived: getDataReceived(state),
   isChartLoading: getChartLoading(state),
+  isSyncRequired: getIsSyncRequired(state),
   pairs: getPairs(state),
   pageLoading: getPageLoading(state),
   params: getParams(state),

--- a/src/components/ChangeLogs/ChangeLogs.container.js
+++ b/src/components/ChangeLogs/ChangeLogs.container.js
@@ -9,6 +9,7 @@ import {
 } from 'state/changeLogs/actions'
 import queryConstants from 'state/query/constants'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
 import { getFullTime, getTimeOffset } from 'state/base/selectors'
 import {
@@ -23,6 +24,7 @@ const mapStateToProps = state => ({
   columns: getColumns(state, queryConstants.MENU_CHANGE_LOGS),
   entries: getFilteredEntries(state, queryConstants.MENU_CHANGE_LOGS, getEntries(state)),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   dataReceived: getDataReceived(state),
   pageLoading: getPageLoading(state),
   timeOffset: getTimeOffset(state),

--- a/src/components/ConcentrationRisk/ConcentrationRisk.container.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.container.js
@@ -10,6 +10,7 @@ import {
   getPageLoading,
   getDataReceived,
 } from 'state/wallets/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import ConcentrationRisk from './ConcentrationRisk'
 
@@ -18,6 +19,7 @@ const mapStateToProps = state => ({
   currentTime: getTimestamp(state),
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
+  isSyncRequired: getIsSyncRequired(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/ConcentrationRisk/ConcentrationRisk.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.js
@@ -38,6 +38,7 @@ class ConcentrationRisk extends PureComponent {
     fetchWallets: PropTypes.func.isRequired,
     dataReceived: PropTypes.bool.isRequired,
     pageLoading: PropTypes.bool.isRequired,
+    isSyncRequired: PropTypes.bool.isRequired,
     refresh: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
   }
@@ -57,8 +58,18 @@ class ConcentrationRisk extends PureComponent {
   }
 
   componentDidMount() {
-    const { dataReceived, pageLoading, fetchWallets } = this.props
-    if (!dataReceived && !pageLoading) {
+    const {
+      dataReceived, pageLoading, fetchWallets, isSyncRequired,
+    } = this.props
+    if (!isSyncRequired && !dataReceived && !pageLoading) {
+      fetchWallets()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { fetchWallets, isSyncRequired } = this.props
+    const { isSyncRequired: prevIsSyncRequired } = prevProps
+    if (isSyncRequired !== prevIsSyncRequired) {
       fetchWallets()
     }
   }

--- a/src/components/Derivatives/Derivatives.container.js
+++ b/src/components/Derivatives/Derivatives.container.js
@@ -21,6 +21,7 @@ import {
   getExistingPairs,
 } from 'state/derivatives/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -34,6 +35,7 @@ const mapStateToProps = state => ({
   existingPairs: getExistingPairs(state),
   getFullTime: getFullTime(state),
   inactivePairs: getInactivePairs(state),
+  isSyncRequired: getIsSyncRequired(state),
   pairs: getPairs(state),
   pageLoading: getPageLoading(state),
   targetPairs: getTargetPairs(state),

--- a/src/components/FeesReport/FeesReport.container.js
+++ b/src/components/FeesReport/FeesReport.container.js
@@ -22,6 +22,7 @@ import {
   getTargetSymbols,
   getCurrentFetchParams,
 } from 'state/feesReport/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import FeesReport from './FeesReport'
 
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   currentFetchParams: getCurrentFetchParams(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/FeesReport/FeesReport.js
+++ b/src/components/FeesReport/FeesReport.js
@@ -28,6 +28,7 @@ import queryConstants from 'state/query/constants'
 import constants from 'ui/ReportTypeSelector/constants'
 import {
   checkInit,
+  checkFetch,
   toggleSymbol,
   clearAllSymbols,
 } from 'state/utils'
@@ -80,6 +81,10 @@ class FeesReport extends PureComponent {
 
   componentDidMount() {
     checkInit(this.props, TYPE)
+  }
+
+  componentDidUpdate(prevProps) {
+    checkFetch(prevProps, this.props, TYPE)
   }
 
   handleQuery = () => {

--- a/src/components/FundingCreditHistory/FundingCreditHistory.container.js
+++ b/src/components/FundingCreditHistory/FundingCreditHistory.container.js
@@ -21,6 +21,7 @@ import {
   getTargetSymbols,
 } from 'state/fundingCreditHistory/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   existingCoins: getExistingCoins(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_FCREDIT),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_FCREDIT),
   entries: getFilteredEntries(state, queryConstants.MENU_FCREDIT, getEntries(state)),

--- a/src/components/FundingLoanHistory/FundingLoanHistory.container.js
+++ b/src/components/FundingLoanHistory/FundingLoanHistory.container.js
@@ -22,6 +22,7 @@ import {
 } from 'state/fundingLoanHistory/selectors'
 import queryConstants from 'state/query/constants'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 
 import FundingLoanHistory from './FundingLoanHistory'
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   existingCoins: getExistingCoins(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_FLOAN),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_FLOAN),
   entries: getFilteredEntries(state, queryConstants.MENU_FLOAN, getEntries(state)),

--- a/src/components/FundingOfferHistory/FundingOfferHistory.container.js
+++ b/src/components/FundingOfferHistory/FundingOfferHistory.container.js
@@ -22,6 +22,7 @@ import {
 } from 'state/fundingOfferHistory/selectors'
 import queryConstants from 'state/query/constants'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 
 import FundingOfferHistory from './FundingOfferHistory'
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   existingCoins: getExistingCoins(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_FOFFER),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_FOFFER),
   entries: getFilteredEntries(state, queryConstants.MENU_FOFFER, getEntries(state)),

--- a/src/components/FundingPayment/FundingPayment.container.js
+++ b/src/components/FundingPayment/FundingPayment.container.js
@@ -22,6 +22,7 @@ import {
 } from 'state/fundingPayment/selectors'
 import queryConstants from 'state/query/constants'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 
 import FundingPayment from './FundingPayment'
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   entries: getFilteredEntries(state, queryConstants.MENU_FPAYMENT, getEntries(state)),
   existingCoins: getExistingCoins(state),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   pageLoading: getPageLoading(state),
   targetSymbols: getTargetSymbols(state),
   timeOffset: getTimeOffset(state),

--- a/src/components/Invoices/Invoices.container.js
+++ b/src/components/Invoices/Invoices.container.js
@@ -21,6 +21,7 @@ import {
   getTargetSymbols,
 } from 'state/invoices/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
 import queryConstants from 'state/query/constants'
@@ -35,6 +36,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   existingCoins: getExistingCoins(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_INVOICES),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_INVOICES),
   entries: getFilteredEntries(state, queryConstants.MENU_INVOICES, getEntries(state)),

--- a/src/components/Ledgers/Ledgers.container.js
+++ b/src/components/Ledgers/Ledgers.container.js
@@ -22,6 +22,7 @@ import {
   getTargetCategory,
 } from 'state/ledgers/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
 import queryConstants from 'state/query/constants'
@@ -35,6 +36,7 @@ const mapStateToProps = state => ({
   entries: getFilteredEntries(state, queryConstants.MENU_LEDGERS, getEntries(state)),
   existingCoins: getExistingCoins(state),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   pageLoading: getPageLoading(state),
   targetCategory: getTargetCategory(state),
   targetSymbols: getTargetSymbols(state),

--- a/src/components/LoanReport/LoanReport.container.js
+++ b/src/components/LoanReport/LoanReport.container.js
@@ -20,6 +20,7 @@ import {
   getTargetSymbols,
   getCurrentFetchParams,
 } from 'state/loanReport/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import LoanReport from './LoanReport'
 
@@ -29,6 +30,7 @@ const mapStateToProps = state => ({
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
   currentFetchParams: getCurrentFetchParams(state),
 })
 

--- a/src/components/Logins/Logins.container.js
+++ b/src/components/Logins/Logins.container.js
@@ -16,6 +16,7 @@ import {
 } from 'state/logins/selectors'
 import queryConstants from 'state/query/constants'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 
 import Logins from './Logins'
@@ -25,6 +26,7 @@ const mapStateToProps = state => ({
   timeOffset: getTimeOffset(state),
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_LOGINS),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_LOGINS),
   entries: getFilteredEntries(state, queryConstants.MENU_LOGINS, getEntries(state)),

--- a/src/components/Movements/Movements.container.js
+++ b/src/components/Movements/Movements.container.js
@@ -14,6 +14,7 @@ import {
 } from 'state/movements/actions'
 import { jumpPage } from 'state/pagination/actions'
 import { getTetherNames } from 'state/symbols/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
 import { getFullTime, getTimeOffset } from 'state/base/selectors'
 import {
@@ -37,6 +38,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   existingCoins: getExistingCoins(state),
   targetSymbols: getTargetSymbols(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_MOVEMENTS),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_MOVEMENTS),
   entries: getFilteredEntries(state, queryConstants.MENU_MOVEMENTS, getEntries(state)),

--- a/src/components/Orders/Orders.container.js
+++ b/src/components/Orders/Orders.container.js
@@ -11,6 +11,7 @@ import {
   removeTargetPair,
   clearTargetPairs,
 } from 'state/orders/actions'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
 import { getFullTime, getTimeOffset } from 'state/base/selectors'
 import {
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
   existingPairs: getExistingPairs(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_ORDERS),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_ORDERS),
   entries: getFilteredEntries(state, queryConstants.MENU_ORDERS, getEntries(state)),

--- a/src/components/Positions/Positions.container.js
+++ b/src/components/Positions/Positions.container.js
@@ -11,6 +11,7 @@ import {
   removeTargetPair,
   clearTargetPairs,
 } from 'state/positions/actions'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
 import { getFullTime, getTimeOffset } from 'state/base/selectors'
 import {
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   targetPairs: getTargetPairs(state),
   dataReceived: getDataReceived(state),
   existingPairs: getExistingPairs(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_POSITIONS),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_POSITIONS),
   entries: getFilteredEntries(state, queryConstants.MENU_POSITIONS, getEntries(state)),

--- a/src/components/PublicFunding/PublicFunding.container.js
+++ b/src/components/PublicFunding/PublicFunding.container.js
@@ -15,6 +15,7 @@ import {
   getTargetSymbol,
 } from 'state/publicFunding/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -25,6 +26,7 @@ const mapStateToProps = state => ({
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_PUBLIC_FUNDING),
   entries: getFilteredEntries(state, queryConstants.MENU_PUBLIC_FUNDING, getEntries(state)),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   dataReceived: getDataReceived(state),
   pageLoading: getPageLoading(state),
   targetSymbol: getTargetSymbol(state),

--- a/src/components/PublicTrades/PublicTrades.container.js
+++ b/src/components/PublicTrades/PublicTrades.container.js
@@ -15,6 +15,7 @@ import {
   getTargetPair,
 } from 'state/publicTrades/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -26,6 +27,7 @@ const mapStateToProps = state => ({
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_PUBLIC_TRADES),
   getFullTime: getFullTime(state),
   dataReceived: getDataReceived(state),
+  isSyncRequired: getIsSyncRequired(state),
   pageLoading: getPageLoading(state),
   targetPair: getTargetPair(state),
   timeOffset: getTimeOffset(state),

--- a/src/components/Snapshots/Snapshots.container.js
+++ b/src/components/Snapshots/Snapshots.container.js
@@ -16,6 +16,7 @@ import {
   getWalletsEntries,
   getTimestamp,
 } from 'state/snapshots/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import Snapshots from './Snapshots'
 
@@ -29,6 +30,7 @@ const mapStateToProps = state => ({
   walletsTotalBalanceUsd: getWalletsTotalBalance(state),
   walletsTickersEntries: getWalletsTickersEntries(state),
   walletsEntries: getWalletsEntries(state),
+  isSyncRequired: getIsSyncRequired(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/Snapshots/Snapshots.js
+++ b/src/components/Snapshots/Snapshots.js
@@ -40,8 +40,18 @@ class Snapshots extends PureComponent {
   }
 
   componentDidMount() {
-    const { dataReceived, pageLoading, fetchData } = this.props
-    if (!dataReceived && !pageLoading) {
+    const {
+      dataReceived, pageLoading, fetchData, isSyncRequired,
+    } = this.props
+    if (!isSyncRequired && !dataReceived && !pageLoading) {
+      fetchData()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { fetchData, isSyncRequired } = this.props
+    const { isSyncRequired: prevIsSyncRequired } = prevProps
+    if (isSyncRequired !== prevIsSyncRequired) {
       fetchData()
     }
   }

--- a/src/components/StakingPayments/StakingPayments.container.js
+++ b/src/components/StakingPayments/StakingPayments.container.js
@@ -21,6 +21,7 @@ import {
   getTargetSymbols,
 } from 'state/stakingPayments/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -33,6 +34,7 @@ const mapStateToProps = state => ({
   entries: getFilteredEntries(state, queryConstants.MENU_SPAYMENTS, getEntries(state)),
   existingCoins: getExistingCoins(state),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   pageLoading: getPageLoading(state),
   targetSymbols: getTargetSymbols(state),
   timeOffset: getTimeOffset(state),

--- a/src/components/TaxReport/Result/Result.container.js
+++ b/src/components/TaxReport/Result/Result.container.js
@@ -9,6 +9,7 @@ import {
   getDataReceived,
   getPageLoading,
 } from 'state/taxReport/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getFullTime, getTimeOffset } from 'state/base/selectors'
 
 import Result from './Result'
@@ -19,6 +20,7 @@ const mapStateToProps = state => ({
   timeOffset: getTimeOffset(state),
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
+  isSyncRequired: getIsSyncRequired(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/TaxReport/Snapshot/Snapshot.container.js
+++ b/src/components/TaxReport/Snapshot/Snapshot.container.js
@@ -11,7 +11,6 @@ import {
 } from 'state/taxReport/selectors'
 import { getIsSyncRequired } from 'state/sync/selectors'
 
-
 import Snapshot from './Snapshot'
 
 const mapStateToProps = (state, { match }) => {

--- a/src/components/TaxReport/Snapshot/Snapshot.container.js
+++ b/src/components/TaxReport/Snapshot/Snapshot.container.js
@@ -9,6 +9,8 @@ import {
   getSnapshotPageLoading,
   getSnapshotDataReceived,
 } from 'state/taxReport/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
+
 
 import Snapshot from './Snapshot'
 
@@ -18,6 +20,7 @@ const mapStateToProps = (state, { match }) => {
     data: getSnapshot(state, snapshotSection),
     pageLoading: getSnapshotPageLoading(state, snapshotSection),
     dataReceived: getSnapshotDataReceived(state, snapshotSection),
+    isSyncRequired: getIsSyncRequired(state),
   }
 }
 

--- a/src/components/Tickers/Tickers.container.js
+++ b/src/components/Tickers/Tickers.container.js
@@ -20,6 +20,7 @@ import {
   getTargetPairs,
 } from 'state/tickers/selectors'
 import { getColumns } from 'state/filters/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -31,6 +32,7 @@ const mapStateToProps = state => ({
   entries: getFilteredEntries(state, queryConstants.MENU_TICKERS, getEntries(state)),
   existingPairs: getExistingPairs(state),
   getFullTime: getFullTime(state),
+  isSyncRequired: getIsSyncRequired(state),
   dataReceived: getDataReceived(state),
   pageLoading: getPageLoading(state),
   targetPairs: getTargetPairs(state),

--- a/src/components/TradedVolume/TradedVolume.container.js
+++ b/src/components/TradedVolume/TradedVolume.container.js
@@ -18,6 +18,7 @@ import {
   getParams,
   getTargetPairs,
 } from 'state/tradedVolume/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import TradedVolume from './TradedVolume'
 
@@ -28,6 +29,7 @@ const mapStateToProps = state => ({
   targetPairs: getTargetPairs(state),
   dataReceived: getDataReceived(state),
   pageLoading: getPageLoading(state),
+  isSyncRequired: getIsSyncRequired(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/Trades/Trades.container.js
+++ b/src/components/Trades/Trades.container.js
@@ -9,8 +9,9 @@ import {
   removeTargetPair,
   clearTargetPairs,
 } from 'state/trades/actions'
-import { getFullTime, getTimeOffset } from 'state/base/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getFilteredEntries } from 'state/pagination/selectors'
+import { getFullTime, getTimeOffset } from 'state/base/selectors'
 import {
   getDataReceived,
   getEntries,
@@ -34,6 +35,7 @@ const mapStateToProps = state => ({
   pageLoading: getPageLoading(state),
   targetPairs: getTargetPairs(state),
   timeOffset: getTimeOffset(state),
+  isSyncRequired: getIsSyncRequired(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/Wallets/Wallets.container.js
+++ b/src/components/Wallets/Wallets.container.js
@@ -19,6 +19,7 @@ import {
   getPageLoading as getSnapshotLoading,
   getDataReceived as getSnapshotReceived,
 } from 'state/snapshots/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 
 import Wallets from './Wallets'
 
@@ -28,6 +29,7 @@ const mapStateToProps = state => ({
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
   exactBalance: getExactBalance(state),
+  isSyncRequired: getIsSyncRequired(state),
   snapshotLoading: getSnapshotLoading(state),
   snapshotReceived: getSnapshotReceived(state),
   walletsSnapshotEntries: getWalletsEntries(state),

--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -43,9 +43,20 @@ class Wallets extends PureComponent {
       pageLoading,
       dataReceived,
       fetchSnapshots,
+      isSyncRequired,
     } = this.props
 
-    if (!dataReceived && !pageLoading) {
+    if (!isSyncRequired && !dataReceived && !pageLoading) {
+      fetchData()
+      if (isFrameworkMode)fetchSnapshots()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isSyncRequired: prevIsSyncRequired } = prevProps
+    const { fetchData, fetchSnapshots, isSyncRequired } = this.props
+
+    if (isSyncRequired !== prevIsSyncRequired) {
       fetchData()
       if (isFrameworkMode)fetchSnapshots()
     }

--- a/src/components/WeightedAverages/WeightedAverages.container.js
+++ b/src/components/WeightedAverages/WeightedAverages.container.js
@@ -20,6 +20,7 @@ import {
 } from 'state/weightedAverages/selectors'
 import { getColumns } from 'state/filters/selectors'
 import { getTimeFrame } from 'state/timeRange/selectors'
+import { getIsSyncRequired } from 'state/sync/selectors'
 import { getColumnsWidth } from 'state/columns/selectors'
 import queryConstants from 'state/query/constants'
 
@@ -35,6 +36,7 @@ const mapStateToProps = state => ({
   dataReceived: getDataReceived(state),
   existingPairs: getExistingPairs(state),
   inactivePairs: getInactivePairs(state),
+  isSyncRequired: getIsSyncRequired(state),
   columns: getColumns(state, queryConstants.MENU_WEIGHTED_AVERAGES),
   columnsWidth: getColumnsWidth(state, queryConstants.MENU_WEIGHTED_AVERAGES),
   getFullTime: getFullTime(state),

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -175,10 +175,6 @@ export const checkInit = (props, type) => {
 
   const shouldWaitInitialSync = showFrameworkMode && isSyncRequired
 
-  console.log('++iisSyncRequired', isSyncRequired)
-  console.log('++isFrameworkMode', showFrameworkMode)
-  console.log('++shouldWaitInitialSync', shouldWaitInitialSync)
-
   if (shouldWaitInitialSync) {
     return
   }

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -272,8 +272,6 @@ export function checkFetch(prevProps, props, type) {
     dataReceived, pageLoading, fetchData, isSyncRequired,
   } = props
   const shouldRefresh = prevIsSyncRequired !== isSyncRequired
-  console.log('+++prevIsSyncRequired', prevIsSyncRequired)
-  console.log('+++isSyncRequired', prevIsSyncRequired)
   if (!dataReceived && dataReceived !== prevDataReceived && !pageLoading) {
     fetchData()
   }

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -46,6 +46,8 @@ const {
   MENU_WEIGHTED_AVERAGES,
 } = queryType
 
+const { isElectronApp, HOME_URL } = config
+
 export const getAuthFromStore = () => {
   const state = store.getState()
   return selectAuth(state)
@@ -57,13 +59,13 @@ export const getApiUrlFromStore = () => {
 }
 
 // turned off for firefox
-export const getDefaultTableScrollSetting = () => config.isElectronApp || !navigator.userAgent.includes('Firefox')
+export const getDefaultTableScrollSetting = () => isElectronApp || !navigator.userAgent.includes('Firefox')
 
 export function postJsonFetch(url, bodyJson) {
   return fetch(url, {
     method: 'POST',
     headers: {
-      Origin: config.HOME_URL,
+      Origin: HOME_URL,
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -269,9 +269,19 @@ export function checkFetch(prevProps, props, type) {
   if (!isValidateType(type)) {
     return
   }
-  const { dataReceived: prevDataReceived } = prevProps
-  const { dataReceived, pageLoading, fetchData } = props
+  const {
+    dataReceived: prevDataReceived, isSyncRequired: prevIsSyncRequired,
+  } = prevProps
+  const {
+    dataReceived, pageLoading, fetchData, isSyncRequired,
+  } = props
+  const shouldRefresh = prevIsSyncRequired !== isSyncRequired
+  console.log('+++prevIsSyncRequired', prevIsSyncRequired)
+  console.log('+++isSyncRequired', prevIsSyncRequired)
   if (!dataReceived && dataReceived !== prevDataReceived && !pageLoading) {
+    fetchData()
+  }
+  if (showFrameworkMode && shouldRefresh) {
     fetchData()
   }
 }

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -46,7 +46,7 @@ const {
   MENU_WEIGHTED_AVERAGES,
 } = queryType
 
-const { isElectronApp, HOME_URL } = config
+const { isElectronApp, showFrameworkMode, HOME_URL } = config
 
 export const getAuthFromStore = () => {
   const state = store.getState()
@@ -164,7 +164,7 @@ export const checkInit = (props, type) => {
     pageLoading,
     fetchData,
     match,
-
+    isSyncRequired,
     setTargetSymbol,
     setTargetSymbols,
     setTargetPair,
@@ -172,6 +172,16 @@ export const checkInit = (props, type) => {
     targetIds,
     setTargetIds,
   } = props
+
+  const shouldWaitInitialSync = showFrameworkMode && isSyncRequired
+
+  console.log('++iisSyncRequired', isSyncRequired)
+  console.log('++isFrameworkMode', showFrameworkMode)
+  console.log('++shouldWaitInitialSync', shouldWaitInitialSync)
+
+  if (shouldWaitInitialSync) {
+    return
+  }
 
   switch (type) {
     case MENU_PUBLIC_FUNDING: {


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1206007823285775/f

#### Description:
- [x] Improves initialization requests order for all reports according to the following proposals to prevent received data inconsistency in some cases
```
- isSyncModeWithDbData 
- getSyncProgress 
- haveCollsBeenSyncedAtLeastOnce 
- enableSyncMode 
- get < *report name* >
```
#### Preview:
https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/91f55983-24d2-4a81-aba9-ac0e32883240

#### Depends on: 
- [bfx-report-ui #731](https://github.com/bitfinexcom/bfx-report-ui/pull/731)