### PR TITLE
(improvement) Temporally remove profits from the summary by asset

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -638,7 +638,6 @@
     },
     "by_asset":{
       "title": "Summary by Asset",
-      "sub_title":  "For the last 30 days",
       "currency": "Currency",
       "amount": "Amount",
       "balance": "Balance",

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -6,13 +6,14 @@ import { isEmpty } from '@bitfinex/lib-js-util-base'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DataTable from 'ui/DataTable'
-import { fetchData } from 'state/summaryByAsset/actions'
+import { fetchData, refresh } from 'state/summaryByAsset/actions'
 import {
   getPageLoading,
   getDataReceived,
   getSummaryByAssetTotal,
   getSummaryByAssetEntries,
 } from 'state/summaryByAsset/selectors'
+import { getTimeRange } from 'state/timeRange/selectors'
 import { getIsSyncRequired } from 'state/sync/selectors'
 
 import { getAssetColumns } from './AppSummary.columns'
@@ -21,6 +22,7 @@ import { prepareSummaryByAssetData } from './AppSummary.helpers'
 const AppSummaryByAsset = () => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const timeRange = useSelector(getTimeRange)
   const pageLoading = useSelector(getPageLoading)
   const dataReceived = useSelector(getDataReceived)
   const total = useSelector(getSummaryByAssetTotal)
@@ -32,6 +34,10 @@ const AppSummaryByAsset = () => {
       dispatch(fetchData())
     }
   }, [dataReceived, pageLoading, isSyncRequired])
+
+  useEffect(() => {
+    dispatch(refresh())
+  }, [timeRange])
 
   const preparedData = useMemo(
     () => prepareSummaryByAssetData(entries, total, t),

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -70,9 +70,6 @@ const AppSummaryByAsset = () => {
       <div className='app-summary-item-title'>
         {t('summary.by_asset.title')}
       </div>
-      <div className='app-summary-item-sub-title'>
-        {t('summary.by_asset.sub_title')}
-      </div>
       {showContent}
     </div>
   )

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -167,29 +167,6 @@ export const getAssetColumns = ({
     copyText: rowIndex => preparedData[rowIndex]?.valueChange30dUsd,
   },
   {
-    id: 'result30dUsd',
-    name: 'summary.by_asset.profits',
-    width: 178,
-    renderer: (rowIndex) => {
-      const { result30dUsd, result30dPerc } = preparedData[rowIndex]
-      return (
-        <Cell tooltip={getTooltipContent(result30dUsd, t)}>
-          <>
-            <span className='cell-value'>
-              {formatUsdValueChange(result30dUsd)}
-            </span>
-            <br />
-            <span className='cell-value secondary-value'>
-              {formatPercentValue(result30dPerc)}
-            </span>
-          </>
-        </Cell>
-      )
-    },
-    isNumericValue: true,
-    copyText: rowIndex => preparedData[rowIndex]?.result30dUsd,
-  },
-  {
     id: 'volume30dUsd',
     name: 'summary.by_asset.volume',
     width: 178,

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -96,7 +96,7 @@ export const getAssetColumns = ({
     id: 'currency',
     className: 'align-left',
     name: 'summary.by_asset.currency',
-    width: 110,
+    width: 100,
     renderer: (rowIndex) => {
       const { currency } = preparedData[rowIndex]
       return (
@@ -110,7 +110,7 @@ export const getAssetColumns = ({
   {
     id: 'balance',
     name: 'summary.by_asset.amount',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { balance = null } = preparedData[rowIndex]
       return (
@@ -124,7 +124,7 @@ export const getAssetColumns = ({
   {
     id: 'balanceUsd',
     name: 'summary.by_asset.balance',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { balanceUsd } = preparedData[rowIndex]
       return (
@@ -140,7 +140,7 @@ export const getAssetColumns = ({
   {
     id: 'valueChange30dUsd',
     name: 'summary.by_asset.balance_change',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { balanceUsd, valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
       const shouldShowPercentChange = shouldShowPercentCheck(balanceUsd, valueChange30dUsd)
@@ -169,7 +169,7 @@ export const getAssetColumns = ({
   {
     id: 'volume30dUsd',
     name: 'summary.by_asset.volume',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { volume30dUsd } = preparedData[rowIndex]
       return (

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -131,7 +131,7 @@
 .full-width-item {
   width: 100%;
   max-width: 100%;
-  min-height: 320px;
+  min-height: 300px;
 
   .bp3-table-container {
     box-shadow: none;
@@ -186,7 +186,7 @@
 
   .loading-container {
     display: flex;
-    min-height: 320px;
+    min-height: 300px;
     max-width: 1000px;
 
     .loading {
@@ -196,7 +196,7 @@
 
   .no-data {
     max-width: 1000px;
-    min-height: 320px;
+    min-height: 300px;
     
     &-wrapper {
       margin: 150px auto;

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -158,7 +158,7 @@
       font-size: 14px;
       padding: 0 5px 0 2px;
 
-      &:nth-last-child(-n+6) {
+      &:nth-last-child(-n+5) {
         box-shadow: none;
       }
 

--- a/src/state/summaryByAsset/saga.js
+++ b/src/state/summaryByAsset/saga.js
@@ -8,15 +8,18 @@ import {
 import { makeFetchCall } from 'state/utils'
 import { updateErrorStatus } from 'state/status/actions'
 import { getIsSyncRequired } from 'state/sync/selectors'
+import { getTimeFrame } from 'state/timeRange/selectors'
 
 import types from './constants'
 import actions from './actions'
 
-export const getReqSummaryByAsset = () => makeFetchCall('getSummaryByAsset')
+export const getReqSummaryByAsset = (params) => makeFetchCall('getSummaryByAsset', params)
 
 export function* fetchSummaryByAsset() {
   try {
-    const { result = {}, error } = yield call(getReqSummaryByAsset)
+    const { start, end } = yield select(getTimeFrame)
+    const params = { start, end }
+    const { result = {}, error } = yield call(getReqSummaryByAsset, params)
     yield put(actions.updateData(result))
 
     if (error) {


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1206138402175082/f

#### Description:
- [x] Temporally removes the `Profits` column from the `Summary by Asset` table

#### Before:
<img width="1045" alt="summ_by_asset_before" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/8706b831-0e62-49b3-8175-97e97d165b01">

#### After:
<img width="1042" alt="summ_by_asset_after" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/71f11998-2d97-4122-b1e7-da4651d7411f">



#### Depends on: 
- [bfx-report-ui #741](https://github.com/bitfinexcom/bfx-report-ui/pull/741)