### PR TITLE
(improvements) Summary by asset: actualize columns

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -638,6 +638,7 @@
     },
     "by_asset":{
       "title": "Summary by Asset",
+      "sub_title": "For period ",
       "currency": "Currency",
       "amount": "Amount",
       "balance": "Balance",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -646,7 +646,8 @@
       "profits": "Profits",
       "volume": "Volume",
       "total": "Total",
-      "trading_fees": "Trading Fees"
+      "trading_fees": "Trading Fees",
+      "fund_earnings": "Funding Earnings"
     }
   },
   "symbols": {

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -624,7 +624,8 @@
     "no_data": "No related data for this period is available or data should be synced.",
     "fees": {
       "title": "Account Fees",
-      "sub_title": "Based on your trading volume",
+      "sub_title": "Based on your 30 days eligible trading volume",
+      "fee_tier_volume": "Eligible Trading Volume",
       "maker": "Maker Fees",
       "taker_crypto": "Taker Fees Crypto",
       "taker_fiat": "Taker Fees Fiat",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -640,6 +640,7 @@
       "title": "Summary by Asset",
       "sub_title": "For period ",
       "currency": "Currency",
+      "all_assets": "All Assets",
       "amount": "Amount",
       "balance": "Balance",
       "balance_change": "Balance Change",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -638,7 +638,6 @@
     },
     "by_asset":{
       "title": "Summary by Asset",
-      "sub_title":  "For the last 30 days",
       "currency": "Currency",
       "amount": "Amount",
       "balance": "Balance",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -645,7 +645,8 @@
       "balance_change": "Balance Change",
       "profits": "Profits",
       "volume": "Volume",
-      "total": "Total"
+      "total": "Total",
+      "trading_fees": "Trading Fees"
     }
   },
   "symbols": {

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -6,13 +6,14 @@ import { isEmpty } from '@bitfinex/lib-js-util-base'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DataTable from 'ui/DataTable'
-import { fetchData } from 'state/summaryByAsset/actions'
+import { fetchData, refresh } from 'state/summaryByAsset/actions'
 import {
   getPageLoading,
   getDataReceived,
   getSummaryByAssetTotal,
   getSummaryByAssetEntries,
 } from 'state/summaryByAsset/selectors'
+import { getTimeRange } from 'state/timeRange/selectors'
 import { getIsSyncRequired } from 'state/sync/selectors'
 
 import { getAssetColumns } from './AppSummary.columns'
@@ -21,6 +22,7 @@ import { prepareSummaryByAssetData } from './AppSummary.helpers'
 const AppSummaryByAsset = () => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const timeRange = useSelector(getTimeRange)
   const pageLoading = useSelector(getPageLoading)
   const dataReceived = useSelector(getDataReceived)
   const total = useSelector(getSummaryByAssetTotal)
@@ -32,6 +34,10 @@ const AppSummaryByAsset = () => {
       dispatch(fetchData())
     }
   }, [dataReceived, pageLoading, isSyncRequired])
+
+  useEffect(() => {
+    dispatch(refresh())
+  }, [timeRange])
 
   const preparedData = useMemo(
     () => prepareSummaryByAssetData(entries, total, t),

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -70,9 +70,6 @@ const AppSummaryByAsset = () => {
       <div className='app-summary-item-title'>
         {t('summary.by_asset.title')}
       </div>
-      <div className='app-summary-item-sub-title'>
-        {t('summary.by_asset.sub_title')}
-      </div>
       {showContent}
     </div>
   )

--- a/src/components/AppSummary/AppSummary.byAsset.js
+++ b/src/components/AppSummary/AppSummary.byAsset.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@bitfinex/lib-js-util-base'
 import NoData from 'ui/NoData'
 import Loading from 'ui/Loading'
 import DataTable from 'ui/DataTable'
+import { formatDate } from 'state/utils'
 import { fetchData, refresh } from 'state/summaryByAsset/actions'
 import {
   getPageLoading,
@@ -13,8 +14,9 @@ import {
   getSummaryByAssetTotal,
   getSummaryByAssetEntries,
 } from 'state/summaryByAsset/selectors'
-import { getTimeRange } from 'state/timeRange/selectors'
+import { getTimezone } from 'state/base/selectors'
 import { getIsSyncRequired } from 'state/sync/selectors'
+import { getTimeRange, getTimeFrame } from 'state/timeRange/selectors'
 
 import { getAssetColumns } from './AppSummary.columns'
 import { prepareSummaryByAssetData } from './AppSummary.helpers'
@@ -22,12 +24,14 @@ import { prepareSummaryByAssetData } from './AppSummary.helpers'
 const AppSummaryByAsset = () => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const timezone = useSelector(getTimezone)
   const timeRange = useSelector(getTimeRange)
   const pageLoading = useSelector(getPageLoading)
   const dataReceived = useSelector(getDataReceived)
   const total = useSelector(getSummaryByAssetTotal)
   const entries = useSelector(getSummaryByAssetEntries)
   const isSyncRequired = useSelector(getIsSyncRequired)
+  const { start, end } = useSelector(getTimeFrame)
 
   useEffect(() => {
     if (!dataReceived && !pageLoading && !isSyncRequired) {
@@ -69,6 +73,10 @@ const AppSummaryByAsset = () => {
     <div className='app-summary-item full-width-item'>
       <div className='app-summary-item-title'>
         {t('summary.by_asset.title')}
+      </div>
+      <div className='app-summary-item-sub-title'>
+        {t('summary.by_asset.sub_title')}
+        {`${formatDate(start, timezone)} - ${formatDate(end, timezone)}`}
       </div>
       {showContent}
     </div>

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -109,33 +109,34 @@ export const getAssetColumns = ({
   },
   {
     id: 'balance',
-    name: 'summary.by_asset.amount',
+    name: 'summary.by_asset.balance',
     width: 225,
     renderer: (rowIndex) => {
-      const { balance = null } = preparedData[rowIndex]
+      const { currency, balance = null, balanceUsd = null } = preparedData[rowIndex]
+      const isTotal = currency === 'Total'
       return (
         <Cell tooltip={getTooltipContent(balance, t)}>
-          {fixedFloat(balance)}
+          {isTotal ? (
+            <span className='cell-value'>
+              $
+              {formatUsdValue(balanceUsd)}
+            </span>
+          ) : (
+            <>
+              <span className='cell-value'>
+                {fixedFloat(balance)}
+              </span>
+              <br />
+              <span className='cell-value secondary-value'>
+                $
+                {formatUsdValue(balanceUsd)}
+              </span>
+            </>
+          )}
         </Cell>
       )
     },
     copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.balance),
-  },
-  {
-    id: 'balanceUsd',
-    name: 'summary.by_asset.balance',
-    width: 225,
-    renderer: (rowIndex) => {
-      const { balanceUsd } = preparedData[rowIndex]
-      return (
-        <Cell tooltip={getTooltipContent(balanceUsd, t)}>
-          $
-          {formatUsdValue(balanceUsd)}
-        </Cell>
-      )
-    },
-    isNumericValue: true,
-    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.balanceUsd, 2),
   },
   {
     id: 'valueChange30dUsd',
@@ -158,13 +159,28 @@ export const getAssetColumns = ({
                 </span>
               </>
             )}
-
           </>
         </Cell>
       )
     },
     isNumericValue: true,
     copyText: rowIndex => preparedData[rowIndex]?.valueChange30dUsd,
+  },
+  {
+    id: 'volume30dUsd',
+    name: 'summary.by_asset.volume',
+    width: 225,
+    renderer: (rowIndex) => {
+      const { volume30dUsd } = preparedData[rowIndex]
+      return (
+        <Cell tooltip={getTooltipContent(volume30dUsd, t)}>
+          $
+          {formatUsdValue(volume30dUsd)}
+        </Cell>
+      )
+    },
+    isNumericValue: true,
+    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume30dUsd, 2),
   },
   {
     id: 'volume30dUsd',

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -99,9 +99,24 @@ export const getAssetColumns = ({
     width: 110,
     renderer: (rowIndex) => {
       const { currency } = preparedData[rowIndex]
+      const isTotal = getIsTotal(currency, t)
       return (
         <Cell tooltip={getTooltipContent(currency, t)}>
-          {currency}
+          {isTotal ? (
+            <>
+              <span>
+                {currency}
+              </span>
+              <br />
+              <span className='cell-value secondary-value'>
+                {t('summary.by_asset.all_assets')}
+              </span>
+            </>
+          ) : (
+            <span className='cell-value'>
+              {currency}
+            </span>
+          )}
         </Cell>
       )
     },

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -129,8 +129,9 @@ export const getAssetColumns = ({
     renderer: (rowIndex) => {
       const { currency, balance = null, balanceUsd = null } = preparedData[rowIndex]
       const isTotal = getIsTotal(currency, t)
+      const tooltipContent = isTotal ? balanceUsd : balance
       return (
-        <Cell tooltip={getTooltipContent(balance, t)}>
+        <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
             <span className='cell-value'>
               $
@@ -162,8 +163,9 @@ export const getAssetColumns = ({
         currency, balanceChange, balanceChangeUsd, balanceChangePerc,
       } = preparedData[rowIndex]
       const isTotal = getIsTotal(currency, t)
+      const tooltipContent = isTotal ? balanceChangeUsd : balanceChange
       return (
-        <Cell tooltip={getTooltipContent(balanceChange, t)}>
+        <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
             <>
               <span className='cell-value'>
@@ -197,8 +199,9 @@ export const getAssetColumns = ({
     renderer: (rowIndex) => {
       const { currency, volume, volumeUsd } = preparedData[rowIndex]
       const isTotal = getIsTotal(currency, t)
+      const tooltipContent = isTotal ? volumeUsd : volume
       return (
-        <Cell tooltip={getTooltipContent(volume, t)}>
+        <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
             <span className='cell-value'>
               $
@@ -228,8 +231,9 @@ export const getAssetColumns = ({
     renderer: (rowIndex) => {
       const { tradingFees, tradingFeesUsd, currency } = preparedData[rowIndex]
       const isTotal = getIsTotal(currency, t)
+      const tooltipContent = isTotal ? tradingFeesUsd : tradingFees
       return (
-        <Cell tooltip={getTooltipContent(tradingFees, t)}>
+        <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
             <span className='cell-value'>
               $
@@ -252,9 +256,11 @@ export const getAssetColumns = ({
     name: 'summary.by_asset.fund_earnings',
     width: 178,
     renderer: (rowIndex) => {
-      const { marginFundingPayment = null } = preparedData[rowIndex]
+      const { marginFundingPayment, currency } = preparedData[rowIndex]
+      const isTotal = getIsTotal(currency, t)
+      const tooltipContent = isTotal ? '' : marginFundingPayment
       return (
-        <Cell tooltip={getTooltipContent(marginFundingPayment, t)}>
+        <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {fixedFloat(marginFundingPayment)}
         </Cell>
       )

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -97,7 +97,7 @@ export const getAssetColumns = ({
     id: 'currency',
     className: 'align-left',
     name: 'summary.by_asset.currency',
-    width: 100,
+    width: 110,
     renderer: (rowIndex) => {
       const { currency } = preparedData[rowIndex]
       return (
@@ -111,7 +111,7 @@ export const getAssetColumns = ({
   {
     id: 'balance',
     name: 'summary.by_asset.balance',
-    width: 225,
+    width: 178,
     renderer: (rowIndex) => {
       const { currency, balance = null, balanceUsd = null } = preparedData[rowIndex]
       const isTotal = getIsTotal(currency, t)
@@ -142,7 +142,7 @@ export const getAssetColumns = ({
   {
     id: 'valueChange30dUsd',
     name: 'summary.by_asset.balance_change',
-    width: 225,
+    width: 178,
     renderer: (rowIndex) => {
       const { balanceUsd, valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
       const shouldShowPercentChange = shouldShowPercentCheck(balanceUsd, valueChange30dUsd)
@@ -170,7 +170,7 @@ export const getAssetColumns = ({
   {
     id: 'volume30dUsd',
     name: 'summary.by_asset.volume',
-    width: 225,
+    width: 178,
     renderer: (rowIndex) => {
       const { volume30dUsd } = preparedData[rowIndex]
       return (
@@ -185,8 +185,24 @@ export const getAssetColumns = ({
   },
   {
     id: 'tradingFees',
-    name: 'summary.by_asset.volume',
-    width: 225,
+    name: 'summary.by_asset.trading_fees',
+    width: 178,
+    renderer: (rowIndex) => {
+      const { volume30dUsd } = preparedData[rowIndex]
+      return (
+        <Cell tooltip={getTooltipContent(volume30dUsd, t)}>
+          $
+          {formatUsdValue(volume30dUsd)}
+        </Cell>
+      )
+    },
+    isNumericValue: true,
+    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume30dUsd, 2),
+  },
+  {
+    id: 'marginFundingPayment',
+    name: 'summary.by_asset.fund_earnings',
+    width: 178,
     renderer: (rowIndex) => {
       const { volume30dUsd } = preparedData[rowIndex]
       return (

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -5,6 +5,7 @@ import { formatFee, fixedFloat } from 'ui/utils'
 import { getTooltipContent } from 'utils/columns'
 
 import {
+  getIsTotal,
   formatUsdValue,
   formatPercentValue,
   formatUsdValueChange,
@@ -113,7 +114,7 @@ export const getAssetColumns = ({
     width: 225,
     renderer: (rowIndex) => {
       const { currency, balance = null, balanceUsd = null } = preparedData[rowIndex]
-      const isTotal = currency === t('summary.by_asset.total')
+      const isTotal = getIsTotal(currency, t)
       return (
         <Cell tooltip={getTooltipContent(balance, t)}>
           {isTotal ? (
@@ -183,7 +184,7 @@ export const getAssetColumns = ({
     copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume30dUsd, 2),
   },
   {
-    id: 'volume30dUsd',
+    id: 'tradingFees',
     name: 'summary.by_asset.volume',
     width: 225,
     renderer: (rowIndex) => {

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -167,29 +167,6 @@ export const getAssetColumns = ({
     copyText: rowIndex => preparedData[rowIndex]?.valueChange30dUsd,
   },
   {
-    id: 'result30dUsd',
-    name: 'summary.by_asset.profits',
-    width: 178,
-    renderer: (rowIndex) => {
-      const { result30dUsd, result30dPerc } = preparedData[rowIndex]
-      return (
-        <Cell tooltip={getTooltipContent(result30dUsd, t)}>
-          <>
-            <span className='cell-value'>
-              {formatUsdValueChange(result30dUsd)}
-            </span>
-            <br />
-            <span className='cell-value secondary-value'>
-              {formatPercentValue(result30dPerc)}
-            </span>
-          </>
-        </Cell>
-      )
-    },
-    isNumericValue: true,
-    copyText: rowIndex => preparedData[rowIndex]?.result30dUsd,
-  },
-  {
     id: 'volume30dUsd',
     name: 'summary.by_asset.volume',
     width: 178,

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -96,7 +96,7 @@ export const getAssetColumns = ({
     id: 'currency',
     className: 'align-left',
     name: 'summary.by_asset.currency',
-    width: 110,
+    width: 100,
     renderer: (rowIndex) => {
       const { currency } = preparedData[rowIndex]
       return (
@@ -110,7 +110,7 @@ export const getAssetColumns = ({
   {
     id: 'balance',
     name: 'summary.by_asset.amount',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { balance = null } = preparedData[rowIndex]
       return (
@@ -124,7 +124,7 @@ export const getAssetColumns = ({
   {
     id: 'balanceUsd',
     name: 'summary.by_asset.balance',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { balanceUsd } = preparedData[rowIndex]
       return (
@@ -140,7 +140,7 @@ export const getAssetColumns = ({
   {
     id: 'valueChange30dUsd',
     name: 'summary.by_asset.balance_change',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { balanceUsd, valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
       const shouldShowPercentChange = shouldShowPercentCheck(balanceUsd, valueChange30dUsd)
@@ -169,7 +169,7 @@ export const getAssetColumns = ({
   {
     id: 'volume30dUsd',
     name: 'summary.by_asset.volume',
-    width: 178,
+    width: 225,
     renderer: (rowIndex) => {
       const { volume30dUsd } = preparedData[rowIndex]
       return (

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -188,7 +188,6 @@ export const getAssetColumns = ({
         </Cell>
       )
     },
-    isNumericValue: true,
     copyText: rowIndex => preparedData[rowIndex]?.balanceChange,
   },
   {
@@ -220,7 +219,6 @@ export const getAssetColumns = ({
         </Cell>
       )
     },
-    isNumericValue: true,
     copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume, 2),
   },
   {
@@ -247,7 +245,6 @@ export const getAssetColumns = ({
         </Cell>
       )
     },
-    isNumericValue: true,
     copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.tradingFees, 2),
   },
   {
@@ -262,7 +259,6 @@ export const getAssetColumns = ({
         </Cell>
       )
     },
-    isNumericValue: true,
     copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.marginFundingPayment, 2),
   },
 ]

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -9,7 +9,6 @@ import {
   formatUsdValue,
   formatPercentValue,
   formatUsdValueChange,
-  shouldShowPercentCheck,
 } from './AppSummary.helpers'
 
 export const getFeesColumns = ({
@@ -140,32 +139,42 @@ export const getAssetColumns = ({
     copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.balance),
   },
   {
-    id: 'valueChange30dUsd',
+    id: 'balanceChange',
     name: 'summary.by_asset.balance_change',
     width: 178,
     renderer: (rowIndex) => {
-      const { balanceUsd, valueChange30dUsd, valueChange30dPerc } = preparedData[rowIndex]
-      const shouldShowPercentChange = shouldShowPercentCheck(balanceUsd, valueChange30dUsd)
+      const {
+        currency, balanceChange, balanceChangeUsd, balanceChangePerc,
+      } = preparedData[rowIndex]
+      const isTotal = getIsTotal(currency, t)
       return (
-        <Cell tooltip={getTooltipContent(valueChange30dUsd, t)}>
-          <>
-            <span className='cell-value'>
-              {formatUsdValueChange(valueChange30dUsd)}
-            </span>
-            {shouldShowPercentChange && (
-              <>
-                <br />
-                <span className='cell-value secondary-value'>
-                  {formatPercentValue(valueChange30dPerc)}
-                </span>
-              </>
-            )}
-          </>
+        <Cell tooltip={getTooltipContent(balanceChange, t)}>
+          {isTotal ? (
+            <>
+              <span className='cell-value'>
+                {formatUsdValueChange(balanceChangeUsd)}
+              </span>
+              <br />
+              <span className='cell-value secondary-value'>
+                {formatPercentValue(balanceChangePerc)}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className='cell-value'>
+                {fixedFloat(balanceChange)}
+              </span>
+              <br />
+              <span className='cell-value secondary-value'>
+                {formatPercentValue(balanceChangePerc)}
+              </span>
+            </>
+          )}
         </Cell>
       )
     },
     isNumericValue: true,
-    copyText: rowIndex => preparedData[rowIndex]?.valueChange30dUsd,
+    copyText: rowIndex => preparedData[rowIndex]?.balanceChange,
   },
   {
     id: 'volume30dUsd',

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -13,6 +13,7 @@ import {
 
 export const getFeesColumns = ({
   makerFee,
+  feeTierVolume,
   isTurkishSite,
   derivTakerFee,
   takerFeeToFiat,
@@ -20,6 +21,17 @@ export const getFeesColumns = ({
   takerFeeToCrypto,
   derivMakerRebate,
 }) => [
+  {
+    id: 'feeTierVolume',
+    name: 'summary.fees.fee_tier_volume',
+    width: 100,
+    renderer: () => (
+      <Cell>
+        $
+        {formatUsdValue(feeTierVolume)}
+      </Cell>
+    ),
+  },
   {
     id: 'makerFee',
     name: 'summary.fees.maker',

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -177,20 +177,36 @@ export const getAssetColumns = ({
     copyText: rowIndex => preparedData[rowIndex]?.balanceChange,
   },
   {
-    id: 'volume30dUsd',
+    id: 'volume',
     name: 'summary.by_asset.volume',
     width: 178,
     renderer: (rowIndex) => {
-      const { volume30dUsd } = preparedData[rowIndex]
+      const { currency, volume, volumeUsd } = preparedData[rowIndex]
+      const isTotal = getIsTotal(currency, t)
       return (
-        <Cell tooltip={getTooltipContent(volume30dUsd, t)}>
-          $
-          {formatUsdValue(volume30dUsd)}
+        <Cell tooltip={getTooltipContent(volume, t)}>
+          {isTotal ? (
+            <span className='cell-value'>
+              $
+              {formatUsdValue(volumeUsd)}
+            </span>
+          ) : (
+            <>
+              <span className='cell-value'>
+                {fixedFloat(volume)}
+              </span>
+              <br />
+              <span className='cell-value secondary-value'>
+                $
+                {formatUsdValue(volumeUsd)}
+              </span>
+            </>
+          )}
         </Cell>
       )
     },
     isNumericValue: true,
-    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume30dUsd, 2),
+    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume, 2),
   },
   {
     id: 'tradingFees',

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -188,16 +188,27 @@ export const getAssetColumns = ({
     name: 'summary.by_asset.trading_fees',
     width: 178,
     renderer: (rowIndex) => {
-      const { volume30dUsd } = preparedData[rowIndex]
+      const { tradingFees, tradingFeesUsd, currency } = preparedData[rowIndex]
+      const isTotal = getIsTotal(currency, t)
       return (
-        <Cell tooltip={getTooltipContent(volume30dUsd, t)}>
-          $
-          {formatUsdValue(volume30dUsd)}
+        <Cell tooltip={getTooltipContent(tradingFees, t)}>
+          {isTotal ? (
+            <span className='cell-value'>
+              $
+              {formatUsdValue(tradingFeesUsd)}
+            </span>
+          ) : (
+            <>
+              <span className='cell-value'>
+                {fixedFloat(tradingFees)}
+              </span>
+            </>
+          )}
         </Cell>
       )
     },
     isNumericValue: true,
-    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume30dUsd, 2),
+    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.tradingFees, 2),
   },
   {
     id: 'marginFundingPayment',

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -113,7 +113,7 @@ export const getAssetColumns = ({
     width: 225,
     renderer: (rowIndex) => {
       const { currency, balance = null, balanceUsd = null } = preparedData[rowIndex]
-      const isTotal = currency === 'Total'
+      const isTotal = currency === t('summary.by_asset.total')
       return (
         <Cell tooltip={getTooltipContent(balance, t)}>
           {isTotal ? (

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -215,15 +215,14 @@ export const getAssetColumns = ({
     name: 'summary.by_asset.fund_earnings',
     width: 178,
     renderer: (rowIndex) => {
-      const { volume30dUsd } = preparedData[rowIndex]
+      const { marginFundingPayment = null } = preparedData[rowIndex]
       return (
-        <Cell tooltip={getTooltipContent(volume30dUsd, t)}>
-          $
-          {formatUsdValue(volume30dUsd)}
+        <Cell tooltip={getTooltipContent(marginFundingPayment, t)}>
+          {fixedFloat(marginFundingPayment)}
         </Cell>
       )
     },
     isNumericValue: true,
-    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.volume30dUsd, 2),
+    copyText: rowIndex => fixedFloat(preparedData[rowIndex]?.marginFundingPayment, 2),
   },
 ]

--- a/src/components/AppSummary/AppSummary.fees.js
+++ b/src/components/AppSummary/AppSummary.fees.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { isEmpty } from '@bitfinex/lib-js-util-base'
 
@@ -7,6 +7,7 @@ import Loading from 'ui/Loading'
 import CollapsedTable from 'ui/CollapsedTable'
 
 import { getFeesColumns } from './AppSummary.columns'
+import { getFeeTierVolume } from './AppSummary.helpers'
 
 const AppSummaryFees = ({
   t,
@@ -24,8 +25,14 @@ const AppSummaryFees = ({
     derivMakerRebate = 0,
   } = data
 
+  const feeTierVolume = useMemo(
+    () => getFeeTierVolume(data),
+    [data],
+  )
+
   const columns = getFeesColumns({
     makerFee,
+    feeTierVolume,
     isTurkishSite,
     derivTakerFee,
     takerFeeToFiat,

--- a/src/components/AppSummary/AppSummary.helpers.js
+++ b/src/components/AppSummary/AppSummary.helpers.js
@@ -33,3 +33,5 @@ export const shouldShowPercentCheck = (balance, balanceChange) => {
   if (bal === balChange) return false
   return true
 }
+
+export const getIsTotal = (currency, t) => currency === t('summary.by_asset.total')

--- a/src/components/AppSummary/AppSummary.helpers.js
+++ b/src/components/AppSummary/AppSummary.helpers.js
@@ -35,3 +35,5 @@ export const shouldShowPercentCheck = (balance, balanceChange) => {
 }
 
 export const getIsTotal = (currency, t) => currency === t('summary.by_asset.total')
+
+export const getFeeTierVolume = (data) => data?.trade_vol_30d?.at(-1)?.vol_safe ?? 0

--- a/src/components/AppSummary/AppSummary.value.js
+++ b/src/components/AppSummary/AppSummary.value.js
@@ -71,7 +71,7 @@ const AccountSummaryValue = () => {
           {formattedPercValue}
         </div>
         <Chart
-          aspect={1.675}
+          aspect={1.455}
           data={chartData}
           showLegend={false}
           dataKeys={presentCurrencies}

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -131,7 +131,7 @@
 .full-width-item {
   width: 100%;
   max-width: 100%;
-  min-height: 320px;
+  min-height: 300px;
 
   .bp3-table-container {
     box-shadow: none;
@@ -186,7 +186,7 @@
 
   .loading-container {
     display: flex;
-    min-height: 320px;
+    min-height: 300px;
     max-width: 1000px;
 
     .loading {
@@ -196,7 +196,7 @@
 
   .no-data {
     max-width: 1000px;
-    min-height: 320px;
+    min-height: 300px;
     
     &-wrapper {
       margin: 150px auto;

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -158,7 +158,7 @@
       font-size: 14px;
       padding: 0 5px 0 2px;
 
-      &:nth-last-child(-n+6) {
+      &:nth-last-child(-n+5) {
         box-shadow: none;
       }
 

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -165,6 +165,10 @@
       &:nth-last-child(6) {
         .bp3-table-truncated-text {
           font-weight: 600;
+
+          .secondary-value {
+            font-weight: 400;
+          }
         }
       }
     }

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -158,7 +158,7 @@
       font-size: 14px;
       padding: 0 5px 0 2px;
 
-      &:nth-last-child(-n+5) {
+      &:nth-last-child(-n+6) {
         box-shadow: none;
       }
 

--- a/src/components/AppSummary/_AppSummary.scss
+++ b/src/components/AppSummary/_AppSummary.scss
@@ -86,13 +86,17 @@
               border-bottom: 1px solid var(--tableBorder);
       
               &:first-child {
-                width: 45%;
+                width: 50%;
               }
       
               &:last-child {
                 padding: 4px 5px;
                 text-align: end;
                 word-break: break-word;
+              }
+
+              .cell-description {
+                font-size: 14px;
               }
             }
       

--- a/src/state/summaryByAsset/saga.js
+++ b/src/state/summaryByAsset/saga.js
@@ -8,15 +8,18 @@ import {
 import { makeFetchCall } from 'state/utils'
 import { updateErrorStatus } from 'state/status/actions'
 import { getIsSyncRequired } from 'state/sync/selectors'
+import { getTimeFrame } from 'state/timeRange/selectors'
 
 import types from './constants'
 import actions from './actions'
 
-export const getReqSummaryByAsset = () => makeFetchCall('getSummaryByAsset')
+export const getReqSummaryByAsset = (params) => makeFetchCall('getSummaryByAsset', params)
 
 export function* fetchSummaryByAsset() {
   try {
-    const { result = {}, error } = yield call(getReqSummaryByAsset)
+    const { start, end } = yield select(getTimeFrame)
+    const params = { start, end }
+    const { result = {}, error } = yield call(getReqSummaryByAsset, params)
     yield put(actions.updateData(result))
 
     if (error) {

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -128,9 +128,8 @@ export function formatTime(mts, {
 export function formatDate(mts, timezone, format = 'MMM DD YYYY') {
   if (timezone) {
     return moment(mts, 'x').tz(timezone).utcOffset('0').format(format)
-      .toUpperCase()
   }
-  return moment(mts, 'x').format('MMM DD YYYY').toUpperCase()
+  return moment(mts, 'x').format('MMM DD YYYY')
 }
 
 export function timeOffset(timezone) {

--- a/src/ui/CollapsedTable/CollapsedTable.js
+++ b/src/ui/CollapsedTable/CollapsedTable.js
@@ -13,13 +13,20 @@ class CollapsedTable extends PureComponent {
           <div className='collapsed-table-item' key={rowIndex}>
             {tableColumns.map((column) => {
               const {
-                id, name, nameStr, renderer,
+                id, name, nameStr, renderer, description,
               } = column
               const cell = renderer(rowIndex)
-
               return (
                 <div key={id}>
-                  <div>{nameStr || t(name)}</div>
+                  <div>
+                    {nameStr || t(name)}
+                    <br />
+                    {description && (
+                      <span className='cell-description'>
+                        {t(description)}
+                      </span>
+                    )}
+                  </div>
                   <div>{cell.props.children}</div>
                 </div>
               )


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1206140059050433/f

#### Description:
- [x] Reworks and actualizes `Summary by Asset` columns representation according to the latest proposals and backend updates
```
- Added Trading Fees and Funding Earnings
- Updated Balance, Balance Change, Currency and Volume
```
#### Preview:
<img width="1044" alt="actualized_summary_by_asset_columns" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/50ba7682-b862-48e7-84b9-28829eb7cb4e">

#### Depends on: 
- [bfx-reports-framework #344](https://github.com/bitfinexcom/bfx-reports-framework/pull/344)
- [bfx-report-ui #743](https://github.com/bitfinexcom/bfx-report-ui/pull/743)
- [bfx-report-ui #745](https://github.com/bitfinexcom/bfx-report-ui/pull/745)
