### PR TITLE
(fix) Parent cell height related warnings

### DIFF
--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -153,7 +153,6 @@ export const getAssetColumns = ({
                 {formatUsdValue(balanceUsd)}
               </span>
             </>
-
           ) : (
             <>
               <span className='cell-value'>

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -125,9 +125,11 @@ export const getAssetColumns = ({
               </span>
             </>
           ) : (
-            <span className='cell-value'>
-              {currency}
-            </span>
+            <>
+              <span className='cell-value'>
+                {currency}
+              </span>
+            </>
           )}
         </Cell>
       )
@@ -145,10 +147,13 @@ export const getAssetColumns = ({
       return (
         <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
-            <span className='cell-value'>
-              $
-              {formatUsdValue(balanceUsd)}
-            </span>
+            <>
+              <span className='cell-value'>
+                $
+                {formatUsdValue(balanceUsd)}
+              </span>
+            </>
+
           ) : (
             <>
               <span className='cell-value'>
@@ -215,10 +220,12 @@ export const getAssetColumns = ({
       return (
         <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
-            <span className='cell-value'>
-              $
-              {formatUsdValue(volumeUsd)}
-            </span>
+            <>
+              <span className='cell-value'>
+                $
+                {formatUsdValue(volumeUsd)}
+              </span>
+            </>
           ) : (
             <>
               <span className='cell-value'>
@@ -247,10 +254,12 @@ export const getAssetColumns = ({
       return (
         <Cell tooltip={getTooltipContent(tooltipContent, t)}>
           {isTotal ? (
-            <span className='cell-value'>
-              $
-              {formatUsdValue(tradingFeesUsd)}
-            </span>
+            <>
+              <span className='cell-value'>
+                $
+                {formatUsdValue(tradingFeesUsd)}
+              </span>
+            </>
           ) : (
             <>
               <span className='cell-value'>


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1206168266409447/f

#### Description:
- [x] Fixes `parentCellHeight` related warnings for the several column configurations
<img width="711" alt="parent-cell-height-related-warn" src="https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/81483c63-9e96-41ae-8edc-7f4e8e467719">

