### PR TITLE
(improvement) Movements navigation

### DIFF
--- a/src/components/Movements/Movements.js
+++ b/src/components/Movements/Movements.js
@@ -170,7 +170,6 @@ class Movements extends PureComponent {
         <SectionHeader
           title={title}
           target={TYPE}
-          showHeaderTabs
           symbolsSelectorProps={{
             currentFilters: targetSymbols,
             existingCoins,

--- a/src/components/Wallets/Wallets.js
+++ b/src/components/Wallets/Wallets.js
@@ -17,15 +17,12 @@ import {
 } from 'ui/SectionHeader'
 import QueryButton from 'ui/QueryButton'
 import RefreshButton from 'ui/RefreshButton'
-import SectionSwitch from 'ui/SectionSwitch'
 import { isValidTimeStamp } from 'state/query/utils'
-import queryConstants from 'state/query/constants'
 
 import WalletsData from './Wallets.data'
 import { propTypes, defaultProps } from './Wallets.props'
 
 const isFrameworkMode = config.showFrameworkMode
-const TYPE = queryConstants.MENU_WALLETS
 
 class Wallets extends PureComponent {
   constructor(props) {
@@ -116,7 +113,6 @@ class Wallets extends PureComponent {
           <SectionHeaderTitle>
             {t('navItems.myHistory.walletsTabs.balances')}
           </SectionHeaderTitle>
-          <SectionSwitch target={TYPE} />
           {isFrameworkMode && (
             <SectionHeaderRow>
               <SectionHeaderItem>

--- a/src/ui/NavMenu/NavMenu.helpers.js
+++ b/src/ui/NavMenu/NavMenu.helpers.js
@@ -70,7 +70,7 @@ export const getSections = (menuType, isTurkishSite) => {
     case MENU_MY_HISTORY:
       return [
         [MENU_LEDGERS, 'ledgers.title'],
-        [MENU_MOVEMENTS, 'navItems.myHistory.walletsTabs.movements'],
+        [MENU_MOVEMENTS, 'movements.title'],
         [[MENU_TRADES, MENU_CANDLES], 'trades.title'],
         [[MENU_ORDERS, MENU_ORDER_TRADES], 'orders.title'],
         [[MENU_POSITIONS, MENU_POSITIONS_ACTIVE, MENU_POSITIONS_AUDIT], 'positions.title'],

--- a/src/ui/NavMenu/NavMenu.helpers.js
+++ b/src/ui/NavMenu/NavMenu.helpers.js
@@ -7,7 +7,6 @@ import {
   ANALYSIS_STAT_TARGETS,
   FUNDING_TARGETS,
   EARNINGS_TARGETS,
-  WALLETS_TARGETS,
 } from 'ui/SectionSwitch/SectionSwitch.helpers'
 
 import constants from './NavMenu.constants'
@@ -22,6 +21,7 @@ const {
   MENU_FPAYMENT,
   MENU_INVOICES,
   MENU_LEDGERS,
+  MENU_MOVEMENTS,
   MENU_TRADES,
   MENU_CANDLES,
   MENU_ORDERS,
@@ -70,12 +70,13 @@ export const getSections = (menuType, isTurkishSite) => {
     case MENU_MY_HISTORY:
       return [
         [MENU_LEDGERS, 'ledgers.title'],
+        [MENU_MOVEMENTS, 'navItems.myHistory.walletsTabs.movements'],
         [[MENU_TRADES, MENU_CANDLES], 'trades.title'],
         [[MENU_ORDERS, MENU_ORDER_TRADES], 'orders.title'],
         [[MENU_POSITIONS, MENU_POSITIONS_ACTIVE, MENU_POSITIONS_AUDIT], 'positions.title'],
         [MENU_FOFFER, 'navItems.myHistory.funding', isTurkishSite, FUNDING_TARGETS],
         [MENU_FPAYMENT, 'navItems.myHistory.earnings', isTurkishSite, EARNINGS_TARGETS],
-        [MENU_WALLETS, 'wallets.title', false, WALLETS_TARGETS],
+        [MENU_WALLETS, 'wallets.title'],
       ]
     case MENU_MERCHANT_HISTORY:
       return [

--- a/src/ui/SectionSwitch/SectionSwitch.helpers.js
+++ b/src/ui/SectionSwitch/SectionSwitch.helpers.js
@@ -33,11 +33,6 @@ export const EARNINGS_TARGETS = [
   queryConstants.MENU_AFFILIATES_EARNINGS,
 ]
 
-export const WALLETS_TARGETS = [
-  queryConstants.MENU_WALLETS,
-  queryConstants.MENU_MOVEMENTS,
-]
-
 
 export const ANALYSIS_STAT_SECTIONS = [
   {
@@ -118,24 +113,12 @@ export const POSITIONS_SECTIONS = [
   },
 ]
 
-export const WALLETS_SECTIONS = [
-  {
-    targetSection: queryConstants.MENU_WALLETS,
-    description: 'navItems.myHistory.walletsTabs.balances',
-  },
-  {
-    targetSection: queryConstants.MENU_MOVEMENTS,
-    description: 'navItems.myHistory.walletsTabs.movements',
-  },
-]
-
 export const getSections = (target, hasSubSections) => {
   if (_includes(TRADES_TARGETS, target) && hasSubSections) return TRADES_SECTIONS
   if (_includes(POSITIONS_TARGETS, target) && hasSubSections) return POSITIONS_SECTIONS
   if (_includes(ANALYSIS_STAT_TARGETS, target)) return ANALYSIS_STAT_SECTIONS
   if (_includes(FUNDING_TARGETS, target)) return FUNDING_SECTIONS
   if (_includes(EARNINGS_TARGETS, target)) return EARNINGS_SECTIONS
-  if (_includes(WALLETS_TARGETS, target)) return WALLETS_SECTIONS
 
   return []
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1206520910910874/f

#### Description:

- [x] Reworks navigation for the `Movements` report according to the latest UX improvement proposals:
```
- Remove tabs from wallets & movements
- Make movements a separate navigation item under "My History"
```

#### Before:
![movements_nav_before](https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/f31cc1ae-73b1-4d0b-91cc-6f18ee925170)

#### After:
![movements_nav_after](https://github.com/bitfinexcom/bfx-report-ui/assets/41899906/403b15c9-330d-4bac-b184-4fdb3b41c39b)
