### PR TITLE
(fix) Showing the sync state when the scheduler launches the sync

### DIFF
--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -211,9 +211,11 @@ function* progressUpdate({ payload }) {
     yield put(actions.setIsSyncing(false))
     yield put(actions.showInitSyncPopup(false))
   } else {
+    const isSyncing = yield select(getIsSyncing)
     const syncProgress = Number.isInteger(progress)
       ? progress
       : 0
+    if (isSyncInProgress && !isSyncing) yield put(actions.setIsSyncing(true))
     yield put(actions.setSyncProgress(syncProgress))
     yield put(actions.setEstimatedTime(estimatedTimeValues))
   }


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1207814579692859/f

#### Description:
- [x] Fixes issue with showing the sync state in some cases when the scheduler launches the synchronization

![scheduled-sync-progress](https://github.com/user-attachments/assets/d756c850-5a58-4231-893a-6e86db304921)
