### PR TITLE
(fix) OTP login request duplication possibility

### DIFF
--- a/src/components/Auth/LoginOtp/LoginOtp.js
+++ b/src/components/Auth/LoginOtp/LoginOtp.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import { Button, Intent } from '@blueprintjs/core'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, isEqual } from '@bitfinex/lib-js-util-base'
 
 import useKeyDown from 'hooks/useKeyDown'
 import { getIsAuthBtnDisabled } from 'state/auth/selectors'
@@ -26,7 +26,7 @@ export const LoginOtp = ({
   }, ['Enter'])
 
   useEffect(() => {
-    if (otp?.length === 6) {
+    if (isEqual(otp?.length, 6) && !isAuthBtnDisabled) {
       handleOneTimePassword()
     }
   }, [otp])

--- a/src/components/Auth/LoginOtp/LoginOtp.js
+++ b/src/components/Auth/LoginOtp/LoginOtp.js
@@ -55,7 +55,7 @@ export const LoginOtp = ({
           intent={Intent.SUCCESS}
           className='bitfinex-auth-check'
           onClick={handleOneTimePassword}
-          disabled={isEmpty(otp || isAuthBtnDisabled)}
+          disabled={isEmpty(otp) || isAuthBtnDisabled}
         >
           {t('auth.2FA.auth')}
         </Button>


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1207921781725071/f

#### Description:
- [x] Fixes `disabling` the `Authenticate` button during the `2FA` login flow to prevent the possibility of requests with the same token duplication and related errors

#### Before:

https://github.com/user-attachments/assets/3cb5c920-fd3d-4e8f-a6db-08b6cdadbd92

#### After:


https://github.com/user-attachments/assets/b7510f26-a472-4ab5-836c-6713bd6166bf

