### PR TITLE
(improvements) Notifications and auth flow when users try to re-add the existing account

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -68,6 +68,7 @@
     "accWithApiKey": "Add account with API key",
     "accWithoutApiKey": "Add account without API key",
     "accAddedWithApiKey": "You have already added this account using an API key",
+    "accAddedWithApiKeyLogin": "You have already added this account using an API key, logging you in...",
     "simpleAccounts": "Simple Accounts",
     "multipleAccounts": "Multiple Accounts",
     "login": "Login",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -67,6 +67,7 @@
     "apiSecret": "API Secret",
     "accWithApiKey": "Add account with API key",
     "accWithoutApiKey": "Add account without API key",
+    "accAddedWithApiKey": "You have already added this account using an API key",
     "simpleAccounts": "Simple Accounts",
     "multipleAccounts": "Multiple Accounts",
     "login": "Login",

--- a/src/components/Auth/SignUp/SignUp.container.js
+++ b/src/components/Auth/SignUp/SignUp.container.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { withTranslation } from 'react-i18next'
 
 import {
+  signIn,
   signUp,
   signUpOtp,
   updateAuth,
@@ -27,6 +28,7 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = {
+  signIn,
   signUp,
   signUpOtp,
   updateAuth,

--- a/src/components/Auth/SignUp/SignUp.container.js
+++ b/src/components/Auth/SignUp/SignUp.container.js
@@ -9,6 +9,7 @@ import {
   signUpEmail,
   showOtpLogin,
 } from 'state/auth/actions'
+import { updateStatus } from 'state/status/actions'
 import {
   getUsers,
   getAuthData,
@@ -31,6 +32,7 @@ const mapDispatchToProps = {
   updateAuth,
   signUpEmail,
   showOtpLogin,
+  updateStatus,
 }
 
 export default compose(

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -9,8 +9,8 @@ import {
   Intent,
 } from '@blueprintjs/core'
 import _map from 'lodash/map'
-// import _find from 'lodash/find'
-// import _isEqual from 'lodash/isEqual'
+import _find from 'lodash/find'
+import _isEqual from 'lodash/isEqual'
 import _includes from 'lodash/includes'
 
 import Icon from 'icons'
@@ -74,13 +74,7 @@ class SignUp extends PureComponent {
   }
 
   onSignUp = () => {
-    const {
-      // users,
-      signUp,
-      switchMode,
-      signUpEmail,
-      updateStatus,
-    } = this.props
+    const { signUp, signUpEmail } = this.props
     const {
       apiKey,
       apiSecret,
@@ -107,9 +101,7 @@ class SignUp extends PureComponent {
           isPersisted,
         })
       } else if (isRegisteredUserName) {
-        // const registeredUser = _find(users, user => _isEqual(user.email, userName))
-        updateStatus({ id: 'auth.accAddedWithApiKey' })
-        switchMode(MODES.SIGN_IN)
+        this.handleExistingUser(userName)
       } else {
         signUpEmail({
           login: userName,
@@ -166,6 +158,13 @@ class SignUp extends PureComponent {
       _map(users, user => user.email), userName,
     )
     return isRegisteredUserName
+  }
+
+  handleExistingUser = (userName) => {
+    const { users, switchMode, updateStatus } = this.props
+    const registeredUser = _find(users, user => _isEqual(user.email, userName))
+    updateStatus({ id: 'auth.accAddedWithApiKey' })
+    switchMode(MODES.SIGN_IN)
   }
 
   handleInputChange = (e) => {

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -8,6 +8,8 @@ import {
   Dialog,
   Intent,
 } from '@blueprintjs/core'
+import _map from 'lodash/map'
+import _includes from 'lodash/includes'
 
 import Icon from 'icons'
 import config from 'config'
@@ -85,6 +87,8 @@ class SignUp extends PureComponent {
     })
     tracker.trackEvent('Add Account')
     const isValid = this.validateForm()
+    const isRegisteredUserName = this.validateUsername(userName)
+    console.log('+++isRegisteredUserName', isRegisteredUserName)
     if (isValid) {
       if (useApiKey) {
         signUp({
@@ -142,6 +146,14 @@ class SignUp extends PureComponent {
     }
 
     return isValid
+  }
+
+  validateUsername = (userName) => {
+    const { users } = this.props
+    const isRegisteredUserName = _includes(
+      _map(users, user => user.email), userName,
+    )
+    return isRegisteredUserName
   }
 
   handleInputChange = (e) => {

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -9,6 +9,8 @@ import {
   Intent,
 } from '@blueprintjs/core'
 import _map from 'lodash/map'
+import _find from 'lodash/find'
+import _isEqual from 'lodash/isEqual'
 import _includes from 'lodash/includes'
 
 import Icon from 'icons'
@@ -71,7 +73,7 @@ class SignUp extends PureComponent {
   }
 
   onSignUp = () => {
-    const { signUp, signUpEmail } = this.props
+    const { signUp, signUpEmail, users } = this.props
     const {
       apiKey,
       apiSecret,
@@ -88,7 +90,6 @@ class SignUp extends PureComponent {
     tracker.trackEvent('Add Account')
     const isValid = this.validateForm()
     const isRegisteredUserName = this.validateUsername(userName)
-    console.log('+++isRegisteredUserName', isRegisteredUserName)
     if (isValid) {
       if (useApiKey) {
         signUp({
@@ -98,6 +99,11 @@ class SignUp extends PureComponent {
           isNotProtected: !isPasswordProtected,
           isPersisted,
         })
+      } else if (isRegisteredUserName) {
+        const registeredUser = _find(users, user => _isEqual(user.email, userName))
+        console.log('+++isRegisteredUserName', isRegisteredUserName)
+        console.log('++userName', userName)
+        console.log('++registeredUser', registeredUser)
       } else {
         signUpEmail({
           login: userName,

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -167,11 +167,12 @@ class SignUp extends PureComponent {
     } = this.props
     const registeredUser = _find(users, user => _isEqual(user.email, userName))
     const { email, isNotProtected } = registeredUser
-    updateStatus({ id: 'auth.accAddedWithApiKey' })
     if (isNotProtected) {
+      updateStatus({ id: 'auth.accAddedWithApiKeyLogin' })
       signIn({ email })
     } else {
       switchMode(MODES.SIGN_IN)
+      updateStatus({ id: 'auth.accAddedWithApiKey' })
     }
   }
 

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -161,10 +161,17 @@ class SignUp extends PureComponent {
   }
 
   handleExistingUser = (userName) => {
-    const { users, switchMode, updateStatus } = this.props
+    const {
+      users, switchMode, updateStatus, signIn,
+    } = this.props
     const registeredUser = _find(users, user => _isEqual(user.email, userName))
+    const { email, isNotProtected } = registeredUser
     updateStatus({ id: 'auth.accAddedWithApiKey' })
-    switchMode(MODES.SIGN_IN)
+    if (isNotProtected) {
+      signIn({ email })
+    } else {
+      switchMode(MODES.SIGN_IN)
+    }
   }
 
   handleInputChange = (e) => {

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -18,7 +18,7 @@ import config from 'config'
 import { tracker } from 'utils/trackers'
 import PlatformLogo from 'ui/PlatformLogo'
 
-import { MODES } from '../Auth'
+import { AUTH_TYPES, MODES } from '../Auth'
 import LoginOtp from '../LoginOtp'
 import LoginEmail from '../LoginEmail'
 import LoginApiKey from '../LoginApiKey'
@@ -73,7 +73,9 @@ class SignUp extends PureComponent {
   }
 
   onSignUp = () => {
-    const { signUp, signUpEmail, users } = this.props
+    const {
+      signUp, signUpEmail, users, switchMode, updateStatus,
+    } = this.props
     const {
       apiKey,
       apiSecret,
@@ -101,6 +103,10 @@ class SignUp extends PureComponent {
         })
       } else if (isRegisteredUserName) {
         const registeredUser = _find(users, user => _isEqual(user.email, userName))
+        updateStatus({ id: 'auth.accAddedWithApiKey' })
+        switchMode(MODES.SIGN_IN)
+
+
         console.log('+++isRegisteredUserName', isRegisteredUserName)
         console.log('++userName', userName)
         console.log('++registeredUser', registeredUser)

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -18,7 +18,7 @@ import config from 'config'
 import { tracker } from 'utils/trackers'
 import PlatformLogo from 'ui/PlatformLogo'
 
-import { AUTH_TYPES, MODES } from '../Auth'
+import { MODES } from '../Auth'
 import LoginOtp from '../LoginOtp'
 import LoginEmail from '../LoginEmail'
 import LoginApiKey from '../LoginApiKey'

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -9,8 +9,8 @@ import {
   Intent,
 } from '@blueprintjs/core'
 import _map from 'lodash/map'
-import _find from 'lodash/find'
-import _isEqual from 'lodash/isEqual'
+// import _find from 'lodash/find'
+// import _isEqual from 'lodash/isEqual'
 import _includes from 'lodash/includes'
 
 import Icon from 'icons'
@@ -44,6 +44,7 @@ class SignUp extends PureComponent {
     showOtpLogin: PropTypes.func.isRequired,
     isOtpLoginShown: PropTypes.bool.isRequired,
     switchMode: PropTypes.func.isRequired,
+    updateStatus: PropTypes.func.isRequired,
     users: PropTypes.arrayOf(PropTypes.shape({
       email: PropTypes.string.isRequired,
       isSubAccount: PropTypes.bool.isRequired,
@@ -74,7 +75,11 @@ class SignUp extends PureComponent {
 
   onSignUp = () => {
     const {
-      signUp, signUpEmail, users, switchMode, updateStatus,
+      // users,
+      signUp,
+      switchMode,
+      signUpEmail,
+      updateStatus,
     } = this.props
     const {
       apiKey,
@@ -102,14 +107,9 @@ class SignUp extends PureComponent {
           isPersisted,
         })
       } else if (isRegisteredUserName) {
-        const registeredUser = _find(users, user => _isEqual(user.email, userName))
+        // const registeredUser = _find(users, user => _isEqual(user.email, userName))
         updateStatus({ id: 'auth.accAddedWithApiKey' })
         switchMode(MODES.SIGN_IN)
-
-
-        console.log('+++isRegisteredUserName', isRegisteredUserName)
-        console.log('++userName', userName)
-        console.log('++registeredUser', registeredUser)
       } else {
         signUpEmail({
           login: userName,

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -38,6 +38,7 @@ class SignUp extends PureComponent {
     }).isRequired,
     loading: PropTypes.bool.isRequired,
     t: PropTypes.func.isRequired,
+    signIn: PropTypes.func.isRequired,
     signUp: PropTypes.func.isRequired,
     signUpOtp: PropTypes.func.isRequired,
     signUpEmail: PropTypes.func.isRequired,

--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -166,10 +166,10 @@ class SignUp extends PureComponent {
       users, switchMode, updateStatus, signIn,
     } = this.props
     const registeredUser = _find(users, user => _isEqual(user.email, userName))
-    const { email, isNotProtected } = registeredUser
+    const { email, isSubAccount, isNotProtected } = registeredUser
     if (isNotProtected) {
       updateStatus({ id: 'auth.accAddedWithApiKeyLogin' })
-      signIn({ email })
+      signIn({ email, isSubAccount })
     } else {
       switchMode(MODES.SIGN_IN)
       updateStatus({ id: 'auth.accAddedWithApiKey' })

--- a/src/components/Status/_Status.scss
+++ b/src/components/Status/_Status.scss
@@ -4,6 +4,7 @@
 
 .bp3-toast {
   min-height: 40px;
+  max-width: 550px;
   padding: 5px;
   border-radius: 2px;
   align-items: center;


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1208244802296793/f

#### Description:
- [x] Improves user [notification](https://bitfinex.slack.com/archives/C024AMXFVPD/p1725615372681239?thread_ts=1725614844.613809&cid=C024AMXFVPD) and auth flow [behavior](https://bitfinex.slack.com/archives/C024AMXFVPD/p1725616403170669?thread_ts=1725614844.613809&cid=C024AMXFVPD) for the cases when he tries to re-add an existing account via email/password according to the recent improvement proposals

#### Preview:

https://github.com/user-attachments/assets/2b117525-b7ed-466c-a9ee-1977a1e4dc04

