### PR TITLE
(improvements) Assets summary section

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -670,7 +670,7 @@
       "sub_title": "End of day profits/losses excluding Deposits/Withdrawals"
     },
     "by_asset":{
-      "title": "Summary by Asset",
+      "title": "Your Assets",
       "sub_title": "For period ",
       "currency": "Currency",
       "all_assets": "All Assets",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -671,7 +671,7 @@
     },
     "by_asset":{
       "title": "Your Assets",
-      "sub_title": "For period ",
+      "sub_title": "Summary for period ",
       "currency": "Currency",
       "all_assets": "All Assets",
       "amount": "Amount",

--- a/src/components/AppSummary/AppSummary.columns.js
+++ b/src/components/AppSummary/AppSummary.columns.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Cell } from '@blueprintjs/table'
 
+import { mapSymbol } from 'state/symbols/utils'
 import { formatAmount, fixedFloat } from 'ui/utils'
 import LoadingPlaceholder from 'ui/LoadingPlaceholder'
 import {
@@ -119,12 +120,13 @@ export const getAssetColumns = ({
       if (isNoData) return getCellNoData(t('column.noResults'))
       const { currency } = preparedData[rowIndex]
       const isTotal = getIsTotal(currency, t)
+      const formattedCurrency = mapSymbol(currency)
       return (
-        <Cell tooltip={getTooltipContent(currency, t)}>
+        <Cell tooltip={getTooltipContent(formattedCurrency, t)}>
           {isTotal ? (
             <>
               <span>
-                {currency}
+                {formattedCurrency}
               </span>
               <br />
               <span className='cell-value secondary-value'>
@@ -134,14 +136,14 @@ export const getAssetColumns = ({
           ) : (
             <>
               <span className='cell-value'>
-                {currency}
+                {formattedCurrency}
               </span>
             </>
           )}
         </Cell>
       )
     },
-    copyText: rowIndex => preparedData[rowIndex]?.currency,
+    copyText: rowIndex => mapSymbol(preparedData[rowIndex]?.currency),
   },
   {
     id: 'balance',


### PR DESCRIPTION
Tasks:
https://app.asana.com/0/1163495710802945/1208499237324980/f
https://app.asana.com/0/1163495710802945/1208499237324987/f


#### Description:
- [x] Actualizes assets section title/subtitle on the `Summary` page
- [x] Improves currencies formatting

#### Before:
<img width="373" alt="assets-before" src="https://github.com/user-attachments/assets/9d4d0830-f526-49c6-b27e-fac054eab12c">

#### After:
<img width="378" alt="assets-after" src="https://github.com/user-attachments/assets/81c0ca09-5ec1-4a47-a517-4ef258bc3193">
