### PR TITLE
(improvement) Extend tax reports sources support

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -762,7 +762,9 @@
       "margin_funding_payment": "Margin funding payment",
       "affiliate_rebate": "Affiliate rebate",
       "staking_payment": "Staking payment",
-      "exchange": "Exchange"
+      "exchange": "Exchange",
+      "margin_trading": "Margin trading",
+      "derivative": "Derivative" 
     },
     "disclaimer": {
       "title": "Disclaimer",


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1209711858900469/f

#### Description:
- [x] Adds `Margin trading` and `Derivative` support to the `Tax Report` sources

#### Preview:
<img width="302" alt="extend-tax-report-sources" src="https://github.com/user-attachments/assets/f55c4630-b1dc-4768-bb11-9de13e1dacf6" />

---
#### Related to: 
- [bfx-reports-framework #438](https://github.com/bitfinexcom/bfx-reports-framework/pull/438)

