### PR TITLE
(improvement) Derivative currencies formatting

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -762,7 +762,9 @@
       "margin_funding_payment": "Margin funding payment",
       "affiliate_rebate": "Affiliate rebate",
       "staking_payment": "Staking payment",
-      "exchange": "Exchange"
+      "exchange": "Exchange",
+      "margin_trading": "Margin trading",
+      "derivative": "Derivative" 
     },
     "disclaimer": {
       "title": "Disclaimer",

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -59,10 +59,6 @@ export function symbolsReducer(state = initialState, action) {
           return
         }
 
-        if (_isEqual(symbol, id) && _includes(id, 'F0')) {
-          symbol = _replace(symbol, 'F0', ' (deriv)')
-        }
-
         if (symbol && id !== symbol) {
           if (id.includes('TEST')) {
             symbol = `${symbol} (Test)`
@@ -76,13 +72,18 @@ export function symbolsReducer(state = initialState, action) {
           dict[symbol] = name
           coins.push(symbol)
           if (isFunding) fundingCoins.push(symbol)
-          return
+        } else if (_includes(id, 'F0')) {
+          symbol = _replace(symbol, 'F0', ' (deriv)')
+          symbolMapping[id] = symbol
+          explorersDict[symbol] = explorer
+          dict[symbol] = name
+          coins.push(symbol)
+        } else {
+          explorersDict[id] = explorer
+          dict[id] = name
+          coins.push(id)
+          if (isFunding) fundingCoins.push(id)
         }
-
-        explorersDict[id] = explorer
-        dict[id] = name
-        coins.push(id)
-        if (isFunding) fundingCoins.push(id)
       })
 
       const preparedCoins = [...new Set(coins)].sort()

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -6,7 +6,6 @@ import _map from 'lodash/map'
 import _join from 'lodash/join'
 import _split from 'lodash/split'
 import _reduce from 'lodash/reduce'
-import _isEqual from 'lodash/isEqual'
 import _replace from 'lodash/replace'
 import _includes from 'lodash/includes'
 

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -6,6 +6,7 @@ import _map from 'lodash/map'
 import _join from 'lodash/join'
 import _split from 'lodash/split'
 import _reduce from 'lodash/reduce'
+import _isEqual from 'lodash/isEqual'
 import _replace from 'lodash/replace'
 import _includes from 'lodash/includes'
 
@@ -56,6 +57,10 @@ export function symbolsReducer(state = initialState, action) {
 
         if (!EXTENDED_CCY_LIST.includes(id) && !isInPair) {
           return
+        }
+
+        if (_isEqual(symbol, id) && _includes(id, 'F0')) {
+          _replace(symbol, 'F0', ' (deriv)')
         }
 
         if (symbol && id !== symbol) {

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -71,7 +71,7 @@ export function symbolsReducer(state = initialState, action) {
           dict[symbol] = name
           coins.push(symbol)
           if (isFunding) fundingCoins.push(symbol)
-        } else if (_includes(id, 'F0')) {
+        } else if (_includes(symbol, 'F0')) {
           symbol = _replace(symbol, 'F0', ' (deriv)')
           symbolMapping[id] = symbol
           explorersDict[symbol] = explorer

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -60,7 +60,7 @@ export function symbolsReducer(state = initialState, action) {
         }
 
         if (_isEqual(symbol, id) && _includes(id, 'F0')) {
-          _replace(symbol, 'F0', ' (deriv)')
+          symbol = _replace(symbol, 'F0', ' (deriv)')
         }
 
         if (symbol && id !== symbol) {


### PR DESCRIPTION
Task: https://app.asana.com/0/1163495710802945/1209711858900462/f

#### Description:
- [x] Improves derivative currencies formatting (like `ETHF0` ---> `ETH (deriv)` etc.) for a more consistent looking and representation

#### Preview:
<img width="1045" alt="improve-derivative-ccy-formatting" src="https://github.com/user-attachments/assets/58f4b794-d08c-471a-8ad0-878b26e5e27b" />

---
#### Related to: 
- [bfx-reports-framework #438](https://github.com/bitfinexcom/bfx-reports-framework/pull/438)
- [bfx-report-ui #909](https://github.com/bitfinexcom/bfx-report-ui/pull/909)
