### PR TITLE
(improvements) App logout flow during the sync

### DIFF
--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -11,7 +11,7 @@ import { isEmpty } from '@bitfinex/lib-js-util-base'
 
 import authTypes from 'state/auth/constants'
 import { makeFetchCall } from 'state/utils'
-import { selectAuth } from 'state/auth/selectors'
+import { getAuthStatus, selectAuth } from 'state/auth/selectors'
 import { updateErrorStatus, updateStatus } from 'state/status/actions'
 
 import types from './constants'
@@ -223,6 +223,9 @@ export function* initSync() {
 }
 
 function* progressUpdate({ payload }) {
+  const isAuthenticated = yield select(getAuthStatus)
+  if (!isAuthenticated) return
+
   const { result } = payload
   const {
     state,

--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -133,6 +133,9 @@ function* switchSyncMode({ mode }) {
 }
 
 function* refreshLastFinishedSyncMts() {
+  const isAuthenticated = yield select(getAuthStatus)
+  if (!isAuthenticated) return
+
   try {
     const { result, error } = yield call(getLastFinishedSyncMts)
     if (result) {


### PR DESCRIPTION
Tasks:
https://app.asana.com/0/1163495710802945/1209854016880889/f 
https://app.asana.com/0/1163495710802945/1209841971150296/f


#### Description:
- [x] Prevents `getLastFinishedSyncMts` requests and sync progress checking after the logout to avoid auth errors
- [x] Syncs `staging` with the latest `master` 

#### Before:
https://github.com/user-attachments/assets/1566829e-0b64-4546-85e0-4da781c9b7a8

#### After:
https://github.com/user-attachments/assets/ab3fc267-60c8-4405-8c51-d034ad64021e

