### PR TITLE
(improvements) Concentration Risk during initial sync

### DIFF
--- a/src/components/ConcentrationRisk/ConcentrationRisk.container.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.container.js
@@ -10,7 +10,7 @@ import {
   getPageLoading,
   getDataReceived,
 } from 'state/wallets/selectors'
-import { getIsSyncRequired } from 'state/sync/selectors'
+import { getIsSyncRequired, getIsFirstSyncing } from 'state/sync/selectors'
 
 import ConcentrationRisk from './ConcentrationRisk'
 
@@ -20,6 +20,7 @@ const mapStateToProps = state => ({
   pageLoading: getPageLoading(state),
   dataReceived: getDataReceived(state),
   isSyncRequired: getIsSyncRequired(state),
+  isFirstSyncing: getIsFirstSyncing(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/ConcentrationRisk/ConcentrationRisk.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.js
@@ -190,7 +190,10 @@ class ConcentrationRisk extends PureComponent {
                 onChange={this.handleDateChange}
               />
             </SectionHeaderItem>
-            <RefreshButton onClick={refresh} />
+            <RefreshButton
+              onClick={refresh}
+              disabled={isFirstSyncing}
+            />
           </SectionHeaderRow>
         </SectionHeader>
         {showContent}

--- a/src/components/ConcentrationRisk/ConcentrationRisk.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.js
@@ -15,6 +15,7 @@ import {
 import DataTable from 'ui/DataTable'
 import DateInput from 'ui/DateInput'
 import PieChart from 'ui/Charts/PieChart'
+import InitSyncNote from 'ui/InitSyncNote'
 import RefreshButton from 'ui/RefreshButton'
 import SectionSwitch from 'ui/SectionSwitch'
 import { fixedFloat } from 'ui/utils'
@@ -36,6 +37,7 @@ class ConcentrationRisk extends PureComponent {
     dataReceived: PropTypes.bool.isRequired,
     pageLoading: PropTypes.bool.isRequired,
     isSyncRequired: PropTypes.bool.isRequired,
+    isFirstSyncing: PropTypes.bool.isRequired,
     refresh: PropTypes.func.isRequired,
     setTimestamp: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
@@ -123,6 +125,7 @@ class ConcentrationRisk extends PureComponent {
       refresh,
       pageLoading,
       dataReceived,
+      isFirstSyncing,
     } = this.props
     const isNoData = isEmpty(entries)
     const isLoading = !dataReceived && pageLoading
@@ -136,7 +139,9 @@ class ConcentrationRisk extends PureComponent {
     })
 
     let showContent
-    if (isNoData) {
+    if (isFirstSyncing) {
+      showContent = <InitSyncNote />
+    } else if (isNoData) {
       showContent = (
         <div className='concentration-risk-data-table'>
           <DataTable


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1209855454923406

#### Description:

- [x] Disables `Concentration Risk` refresh button during initial synchronization to prevent report generation errors
- [x] Adds a corresponding notice to communicate this to the user

#### Preview:

https://github.com/user-attachments/assets/61f21bfe-8324-4ed9-a5f9-6eadfbc6f771

