### PR TITLE
(improvement) Trading fees currency formatting

### DIFF
--- a/src/components/AccountSummary/AccountSummary.paidFees.js
+++ b/src/components/AccountSummary/AccountSummary.paidFees.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Cell } from '@blueprintjs/table'
 
 import DataTable from 'ui/DataTable'
+import { mapSymbol } from 'state/symbols/utils'
 import { fixedFloat, formatAmount } from 'ui/utils'
 import {
   COLUMN_WIDTHS,
@@ -28,13 +29,14 @@ export const getColumns = ({
       if (isLoading) return getCellLoader(14, 72)
       if (isNoData) return getCellNoData(t('column.noResults'))
       const { curr } = data[rowIndex]
+      const formattedCurrency = mapSymbol(curr)
       return (
-        <Cell tooltip={getTooltipContent(curr, t)}>
-          {curr}
+        <Cell tooltip={getTooltipContent(formattedCurrency, t)}>
+          {formattedCurrency}
         </Cell>
       )
     },
-    copyText: rowIndex => data[rowIndex].curr,
+    copyText: rowIndex => mapSymbol(data[rowIndex].curr),
   },
   {
     id: 'volume',


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1210223774407239

#### Description:
- [x] Improves currency formatting in the `Trading fees charged in the last 30 days` section
- [x] Syncs `staging` with the latest `master`

#### Before:
![fees-ccy-format-before](https://github.com/user-attachments/assets/b18b7d9b-f968-4ffc-bdbc-b54bf4db590d)

#### After:
![fees-ccy-format-after](https://github.com/user-attachments/assets/7254fe23-e238-456f-9b8f-db09c6b046c1)