### PR TITLE
(improvements) Snapshots during initial sync

### DIFF
--- a/src/components/Snapshots/Snapshots.container.js
+++ b/src/components/Snapshots/Snapshots.container.js
@@ -17,7 +17,7 @@ import {
   getWalletsEntries,
   getTimestamp,
 } from 'state/snapshots/selectors'
-import { getIsSyncRequired } from 'state/sync/selectors'
+import { getIsSyncRequired, getIsFirstSyncing } from 'state/sync/selectors'
 
 import Snapshots from './Snapshots'
 
@@ -32,6 +32,7 @@ const mapStateToProps = state => ({
   walletsTickersEntries: getWalletsTickersEntries(state),
   walletsEntries: getWalletsEntries(state),
   isSyncRequired: getIsSyncRequired(state),
+  isFirstSyncing: getIsFirstSyncing(state),
 })
 
 const mapDispatchToProps = {

--- a/src/components/Snapshots/Snapshots.js
+++ b/src/components/Snapshots/Snapshots.js
@@ -10,6 +10,7 @@ import {
   SectionHeaderItemLabel,
 } from 'ui/SectionHeader'
 import DateInput from 'ui/DateInput'
+import InitSyncNote from 'ui/InitSyncNote'
 import NavSwitcher from 'ui/NavSwitcher/NavSwitcher'
 import RefreshButton from 'ui/RefreshButton'
 import { isValidTimeStamp } from 'state/query/utils'
@@ -104,6 +105,7 @@ class Snapshots extends PureComponent {
       pageLoading,
       dataReceived,
       walletsEntries,
+      isFirstSyncing,
       positionsEntries,
       positionsTotalPlUsd,
       walletsTickersEntries,
@@ -118,7 +120,9 @@ class Snapshots extends PureComponent {
       || (section === MENU_WALLETS && !walletsEntries.length)
 
     let showContent
-    if (section === MENU_WALLETS) {
+    if (isFirstSyncing) {
+      showContent = <InitSyncNote />
+    } else if (section === MENU_WALLETS) {
       showContent = (
         <WalletsSnapshot
           isLoading={isLoading}

--- a/src/components/Snapshots/Snapshots.js
+++ b/src/components/Snapshots/Snapshots.js
@@ -172,7 +172,10 @@ class Snapshots extends PureComponent {
                 defaultValue={timestamp}
               />
             </SectionHeaderItem>
-            <RefreshButton onClick={refresh} />
+            <RefreshButton
+              onClick={refresh}
+              disabled={isFirstSyncing}
+            />
           </SectionHeaderRow>
         </SectionHeader>
         {showContent}

--- a/src/components/Snapshots/Snapshots.props.js
+++ b/src/components/Snapshots/Snapshots.props.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 export const propTypes = {
   currentTime: PropTypes.number,
   dataReceived: PropTypes.bool.isRequired,
+  isFirstSyncing: PropTypes.bool.isRequired,
   pageLoading: PropTypes.bool.isRequired,
   positionsTotalPlUsd: PropTypes.number,
   positionsEntries: PropTypes.array.isRequired,


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1210379600312641

#### Description:

- [x] Disables `Snapshots` refresh button during initial synchronization to prevent report generation errors
- [x] Adds a corresponding notice to communicate this to the user

#### Preview:
![snapshots-init-sync-prev](https://github.com/user-attachments/assets/0c965b57-b996-47f5-9c48-b5deb45c2784)
