### PR TITLE
(fix) Actualize getActivePositionsFile query params

### DIFF
--- a/src/state/query/utils.js
+++ b/src/state/query/utils.js
@@ -218,6 +218,7 @@ export const NO_TIME_FRAME_TARGETS = [
   MENU_DERIVATIVES,
   MENU_WALLETS,
   MENU_SNAPSHOTS,
+  MENU_POSITIONS_ACTIVE,
 ]
 
 export function isValidTimeStamp(n) {


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1210761513319831

#### Description:
- [x] Removes redundant (start, end, limit) params for the `getActivePositionsFile` request according to the latest backend validation changes
- [x] Syncs `staging` with the latest `master`
#### Before:
<img width="600" height="684" alt="req-params-before" src="https://github.com/user-attachments/assets/7f22cb35-fb04-44c2-8dd0-0eae0f4e77a5" />

#### After:
<img width="675" height="444" alt="req-params-after" src="https://github.com/user-attachments/assets/9853d5fc-38ff-41cc-b023-28b04ad7ac83" />

---
#### Depends on: 
- [bfx-reports-framework #466](https://github.com/bitfinexcom/bfx-reports-framework/pull/466)
- [bfx-report #438](https://github.com/bitfinexcom/bfx-report/pull/438)
