### PR TITLE
(fix) Actualize getPositionsAuditFile query params

### DIFF
--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -6,6 +6,7 @@ import {
 } from 'redux-saga/effects'
 import queryString from 'query-string'
 import _assign from 'lodash/assign'
+import _isArray from 'lodash/isArray'
 import _includes from 'lodash/includes'
 
 import { LANGUAGES } from 'locales/i18n'
@@ -272,7 +273,7 @@ function* getOptions({ target }) {
     case MENU_CHANGE_LOGS:
       break
     case MENU_POSITIONS_AUDIT:
-      options.id = sign || undefined
+      options.id = _isArray(sign) ? sign.map(Number) : undefined
       break
     default: {
       const symbol = formatSymbol(target, sign)


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1210878359791667

#### Description:
- [x] Actualizes `id` param type (should be an array of numbers) for the `getPositionsAuditFile` request according to the latest backend validation changes

#### Before:
<img width="1088" height="722" alt="pos-audit-export-before" src="https://github.com/user-attachments/assets/b5fffdfd-02cf-4391-b5ee-a7f3112ecbd3" />


#### After:
<img width="1156" height="727" alt="pos-audit-export-after" src="https://github.com/user-attachments/assets/b9a22bce-f07a-4ea7-b60d-87b5485804a5" />

---
#### Depends on: 
- [bfx-reports-framework #466](https://github.com/bitfinexcom/bfx-reports-framework/pull/466)
- [bfx-report #438](https://github.com/bitfinexcom/bfx-report/pull/438)