### PR TITLE
(improvements) Account Balance during initial sync 

### DIFF
--- a/src/components/AccountBalance/AccountBalance.js
+++ b/src/components/AccountBalance/AccountBalance.js
@@ -124,7 +124,10 @@ const AccountBalance = () => {
               onChange={handleUnrealizedProfitChange}
             />
           </SectionHeaderItem>
-          <RefreshButton onClick={onRefresh} />
+          <RefreshButton
+            onClick={onRefresh}
+            disabled={isFirstSync}
+          />
         </SectionHeaderRow>
       </SectionHeader>
       {showContent}


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1211221406459367

#### Description:

- [x] Disables `Account Balance` refresh button during initial synchronization to prevent report generation errors possibility
<img width="999" height="199" alt="gen-err-init-sync" src="https://github.com/user-attachments/assets/a0a89f55-6c94-4f0b-87b3-f16c3f26829e" />

- [x] Adds a corresponding notice to communicate this to the user
- [x] Syncs `staging` with the latest `master`

#### Preview:
<img width="1492" height="537" alt="acc-balance-init-sync-prev" src="https://github.com/user-attachments/assets/587763c0-041e-4742-8b98-e622b67c4464" />