### PR TITLE
(improvement) DEB app releases download for Linux users

### DIFF
--- a/src/components/AppDownload/AppDownload.helpers.js
+++ b/src/components/AppDownload/AppDownload.helpers.js
@@ -13,7 +13,7 @@ export const getDownloadLink = (version) => {
       return getElectronReleaseLink({ version, platform, ext: 'exe' })
     case PLATFORMS.linux:
     default:
-      return getElectronReleaseLink({ version, platform, ext: 'AppImage.zip' })
+      return getElectronReleaseLink({ version, platform, ext: 'deb' })
   }
 }
 

--- a/src/var/electronVersion.js
+++ b/src/var/electronVersion.js
@@ -2,7 +2,7 @@ import { isEqual } from '@bitfinex/lib-js-util-base'
 
 import { PLATFORMS } from 'utils/getOS'
 
-const DEFAULT_ELECTRON_VERSION = '4.17.0'
+const DEFAULT_ELECTRON_VERSION = '4.42.0'
 
 const APP_RELEASES_URL = 'https://github.com/bitfinexcom/bfx-report-electron/releases/download/'
 

--- a/src/var/electronVersion.js
+++ b/src/var/electronVersion.js
@@ -11,7 +11,7 @@ const getDefaultExt = (platform) => {
     return 'exe'
   }
   if (isEqual(platform, PLATFORMS.linux)) {
-    return 'AppImage.zip'
+    return 'deb'
   }
 
   return 'zip'


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1211766201337349

#### Description:
- [x] Implements the possibility to download the `DEB` app releases instead of `AppImage` for better UX
- [x] Syncs `staging` with the latest `master`

---
Key advantages of `DEB` over `AppImage` for `Linux` users:
* **Native system integration** - installs into standard paths, appears in system app launcher, registers file associations and MIME types
* **Dependency management** - shared system libraries are reused instead of bundled, reducing disk footprint
* **Clean install/uninstall** - proper package lifecycle handled by dpkg, no leftover files
* **Better security** - benefits from system-level package verification and sandboxing policies

#### Preview:
<img width="1492" height="655" alt="web-deb-dwnload-prev" src="https://github.com/user-attachments/assets/cbbbd24d-bf9d-4618-8daa-bbccdb960903" />

---
#### Depends on: 
- [bfx-report-electron #564](https://github.com/bitfinexcom/bfx-report-electron/pull/564)
