### PR TITLE
(fix) Selected report type representation

### DIFF
--- a/src/ui/ReportTypeSelector/ReportTypeSelector.js
+++ b/src/ui/ReportTypeSelector/ReportTypeSelector.js
@@ -1,5 +1,6 @@
 import React, { memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 
 import Select from 'ui/Select'
 
@@ -17,9 +18,9 @@ const ReportTypeSelector = ({
       value={value}
       items={items}
       onChange={onChange}
-      className={className}
       type={'Select Report Type'}
       popoverClassName='bitfinex-select-menu--report-type'
+      className={classNames('bitfinex-select--report-type', className)}
     />
   )
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1214012780485289

#### Description:
- [x] Fixes selected type representation in the `Average Win/Loss` report

Note: selected items are supposed to be shown without additional icons all across the reports selectors for a consistent look

#### Before:
<img width="1075" height="362" alt="before" src="https://github.com/user-attachments/assets/aadc9b23-2564-402f-9445-d18d83d9a432" />


#### After:

https://github.com/user-attachments/assets/f28e743d-9dc9-4d01-b5d0-265b0bdcb89a

