### PR TITLE
(internal) Actualize redux-saga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,12 +45,13 @@
         "redux-first-history": "^5.2.0",
         "redux-logger": "3.0.6",
         "redux-persist": "6.0.0",
-        "redux-saga": "0.16.2",
+        "redux-saga": "1.4.2",
         "sass": "1.50.0",
         "shelljs": "^0.10.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "7.21.11",
+        "@redux-saga/testing-utils": "^1.2.1",
         "babel-eslint": "^10.1.0",
         "concurrently": "^5.0.0",
         "cross-env": "^7.0.3",
@@ -2039,12 +2040,10 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
-      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3628,6 +3627,72 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@redux-saga/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-nIMLGKo6jV6Wc1sqtVQs1iqbB3Kq20udB/u9XEaZQisT6YZ0NRB8+4L6WqD/E+YziYutd27NJbG8EWUPkb7c6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@redux-saga/deferred": "^1.3.1",
+        "@redux-saga/delay-p": "^1.3.1",
+        "@redux-saga/is": "^1.2.1",
+        "@redux-saga/symbols": "^1.2.1",
+        "@redux-saga/types": "^1.3.1",
+        "typescript-tuple": "^2.2.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/redux-saga"
+      }
+    },
+    "node_modules/@redux-saga/deferred": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.3.1.tgz",
+      "integrity": "sha512-0YZ4DUivWojXBqLB/TmuRRpDDz7tyq1I0AuDV7qi01XlLhM5m51W7+xYtIckH5U2cMlv9eAuicsfRAi1XHpXIg==",
+      "license": "MIT"
+    },
+    "node_modules/@redux-saga/delay-p": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.3.1.tgz",
+      "integrity": "sha512-597I7L5MXbD/1i3EmcaOOjL/5suxJD7p5tnbV1PiWnE28c2cYiIHqmSMK2s7us2/UrhOL2KTNBiD0qBg6KnImg==",
+      "license": "MIT",
+      "dependencies": {
+        "@redux-saga/symbols": "^1.2.1"
+      }
+    },
+    "node_modules/@redux-saga/is": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.2.1.tgz",
+      "integrity": "sha512-x3aWtX3GmQfEvn8dh0ovPbsXgK9JjpiR24wKztpGbZP8JZUWWvUgKrvnWZ/T/4iphOBftyVc9VrIwhAnsM+OFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@redux-saga/symbols": "^1.2.1",
+        "@redux-saga/types": "^1.3.1"
+      }
+    },
+    "node_modules/@redux-saga/symbols": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.2.1.tgz",
+      "integrity": "sha512-3dh+uDvpBXi7EUp/eO+N7eFM4xKaU4yuGBXc50KnZGzIrR/vlvkTFQsX13zsY8PB6sCFYAgROfPSRUj8331QSA==",
+      "license": "MIT"
+    },
+    "node_modules/@redux-saga/testing-utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/testing-utils/-/testing-utils-1.2.1.tgz",
+      "integrity": "sha512-dbbiPrGj9bc236nnjm6UnuJhJoAnt6iXGf4KOUHJLd0vF0LJCtv2GIhcY/lc6D3LFPTQE/KxrG42LWvStUXM4g==",
+      "dev": true,
+      "dependencies": {
+        "@redux-saga/symbols": "^1.2.1",
+        "@redux-saga/types": "^1.3.1"
+      }
+    },
+    "node_modules/@redux-saga/types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.3.1.tgz",
+      "integrity": "sha512-YRCrJdhQLobGIQ8Cj1sta3nn6DrZDTSUnrIYhS2e5V590BmfVDleKoAquclAiKSBKWJwmuXTb+b4BL6rSHnahw==",
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -17496,8 +17561,13 @@
       }
     },
     "node_modules/redux-saga": {
-      "version": "0.16.2",
-      "license": "MIT"
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.4.2.tgz",
+      "integrity": "sha512-QLIn/q+7MX/B+MkGJ/K6R3//60eJ4QNy65eqPsJrfGezbxdh1Jx+37VRKE2K4PsJnNET5JufJtgWdT30WBa+6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@redux-saga/core": "^1.4.2"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -17542,10 +17612,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -19926,6 +19992,30 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "license": "MIT",
+      "dependencies": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "node_modules/typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==",
+      "license": "MIT"
+    },
+    "node_modules/typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "typescript-compare": "^0.0.2"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -52,12 +52,13 @@
     "redux-first-history": "^5.2.0",
     "redux-logger": "3.0.6",
     "redux-persist": "6.0.0",
-    "redux-saga": "0.16.2",
+    "redux-saga": "1.4.2",
     "sass": "1.50.0",
     "shelljs": "^0.10.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "7.21.11",
+    "@redux-saga/testing-utils": "^1.2.1",
     "babel-eslint": "^10.1.0",
     "concurrently": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/src/state/accountBalance/__tests__/sagas.test.js
+++ b/src/state/accountBalance/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchAccountBalance, getReqBalance } from '../saga'
 import actions from '../actions'

--- a/src/state/auth/saga.js
+++ b/src/state/auth/saga.js
@@ -6,8 +6,8 @@ import {
   put,
   select,
   takeLatest,
+  delay,
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 import _last from 'lodash/last'
 import _isArray from 'lodash/isArray'
 import { isEmpty, isEqual } from '@bitfinex/lib-js-util-base'

--- a/src/state/base/saga.js
+++ b/src/state/base/saga.js
@@ -3,8 +3,8 @@ import {
   call,
   select,
   takeLatest,
+  delay,
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 import { get, isEqual } from '@bitfinex/lib-js-util-base'
 
 import config from 'config'
@@ -36,7 +36,7 @@ function* updateTheme() {
 const WAIT_INTERVAL = 500
 
 function* updateLang() {
-  yield call(delay, WAIT_INTERVAL)
+  yield delay(WAIT_INTERVAL)
   const locale = yield select(getLocale)
   i18n.changeLanguage(LANGUAGES[locale])
 }

--- a/src/state/electronAutoUpdateToast/saga.js
+++ b/src/state/electronAutoUpdateToast/saga.js
@@ -1,7 +1,6 @@
 import {
-  take, race, put,
+  take, race, put, delay,
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 
 import types from './constants'
 import { hideAutoUpdateToast } from './actions'

--- a/src/state/feesReport/__tests__/sagas.test.js
+++ b/src/state/feesReport/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchFeesReport, getFeesReport } from '../saga'
 import actions from '../actions'

--- a/src/state/loanReport/__tests__/sagas.test.js
+++ b/src/state/loanReport/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchLoanReport, getLoanReport } from '../saga'
 import actions from '../actions'

--- a/src/state/snapshots/__tests__/sagas.test.js
+++ b/src/state/snapshots/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchSnapshots, getReqSnapshots } from '../saga'
 import actions from '../actions'

--- a/src/state/sync/saga.js
+++ b/src/state/sync/saga.js
@@ -4,8 +4,8 @@ import {
   put,
   select,
   takeLatest,
+  delay,
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 import _includes from 'lodash/includes'
 import { isEmpty } from '@bitfinex/lib-js-util-base'
 

--- a/src/state/taxReport/__tests__/sagas.test.js
+++ b/src/state/taxReport/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, select, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchTaxReport, getReqTaxReport } from '../saga'
 import actions from '../actions'

--- a/src/state/tradedVolume/__tests__/sagas.test.js
+++ b/src/state/tradedVolume/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchTradedVolume, getTradedVolume } from '../saga'
 import actions from '../actions'

--- a/src/state/tradedVolume/saga.js
+++ b/src/state/tradedVolume/saga.js
@@ -64,6 +64,6 @@ function* fetchTradedVolumeFail({ payload }) {
 
 export default function* tradedVolumeSaga() {
   yield takeLatest(types.FETCH_TRADED_VOLUME, fetchTradedVolume)
-  yield takeLatest([types.REFRESH, types.SET_PARAMS, types.CLEAR_SYMBOLS], refreshTradedVolume)
+  yield takeLatest([types.REFRESH, types.SET_PARAMS, types.CLEAR_PAIRS], refreshTradedVolume)
   yield takeLatest(types.FETCH_FAIL, fetchTradedVolumeFail)
 }

--- a/src/state/weightedAverages/saga.js
+++ b/src/state/weightedAverages/saga.js
@@ -57,6 +57,6 @@ function* fetchWeightedAveragesFail({ payload }) {
 }
 
 export default function* weightedAveragesSaga() {
-  yield takeLatest([types.FETCH_WEIGHTED_AVERAGES, types.CLEAR_PAIRS], fetchWeightedAverages)
+  yield takeLatest(types.FETCH_WEIGHTED_AVERAGES, fetchWeightedAverages)
   yield takeLatest(types.FETCH_FAIL, fetchWeightedAveragesFail)
 }

--- a/src/state/winLoss/__tests__/sagas.test.js
+++ b/src/state/winLoss/__tests__/sagas.test.js
@@ -1,5 +1,5 @@
 import { put, call } from 'redux-saga/effects'
-import { cloneableGenerator } from 'redux-saga/utils'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
 
 import { fetchWinLoss, getReqWinLoss } from '../saga'
 import actions from '../actions'

--- a/src/state/ws/signIn.js
+++ b/src/state/ws/signIn.js
@@ -3,8 +3,8 @@ import {
   put,
   take,
   race,
+  delay,
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 
 import WS from 'state/ws'
 import types from 'state/auth/constants'


### PR DESCRIPTION
Tasks:
https://app.asana.com/0/home/1198734617779732/1213696121840426
https://app.asana.com/0/home/1198734617779732/1213037610883302

#### Description:
- [x]  Bumps `redux-saga` from `0.16.2` to `1.4.2`, actualizes effects/utils usage and fixes a couple of legacy bugs

---
**Note:** while migrating 2 legacy bugs were uncovered and fixed:

- **weightedAverages/saga.js** - removed `types.CLEAR_PAIRS` from `takeLatest` pattern. This constant doesn't exist in `weightedAverages/constants.js`, so it was resolving to `undefined`

- **tradedVolume/saga.js** - replaced `types.CLEAR_SYMBOLS` with `types.CLEAR_PAIRS` in `takeLatest` pattern. `CLEAR_SYMBOLS` doesn't exist in `tradedVolume/constants.js` (the module works with pairs, not symbols), so it was also resolving to `undefined`

Why it didn't fail before: In `redux-saga@0.16.2`, pattern validation was lenient - `undefined` values inside a `takeLatest` pattern array were silently ignored (such effects simply never matched any dispatched action). In `redux-saga@1.x`, strict pattern validation via `@redux-saga/is` was introduced, and `undefined` patterns now throw an Invalid pattern `error` at runtime

These were essentially dead references left over from past refactors that never triggered any matches, so the removal/correction is safe and restores the originally intended behavior