### PR TITLE
(improvement) Add ability to refetch Electron menu states and rerender

### DIFF
--- a/src/components/ElectronMenu/ElectronMenu.dropdown.js
+++ b/src/components/ElectronMenu/ElectronMenu.dropdown.js
@@ -9,6 +9,7 @@ import {
   MenuDivider,
 } from '@blueprintjs/core'
 import _map from 'lodash/map'
+import _filter from 'lodash/filter'
 import { isEqual } from '@bitfinex/lib-js-util-base'
 
 import types from 'state/electronMenu/constants'
@@ -18,6 +19,7 @@ import SubMenu from './ElectronMenu.submenu'
 
 const DropdownMenu = ({ label, items }) => {
   const dispatch = useDispatch()
+  const visibleItems = _filter(items, 'visible')
 
   return (
     <div className='electron-menu-item'>
@@ -28,7 +30,7 @@ const DropdownMenu = ({ label, items }) => {
         content={(
           <div className='electron-menu-item-content'>
             <Menu>
-              {_map(items, ({
+              {_map(visibleItems, ({
                 id, label: itemLabel, type, accelerator, enabled, submenu,
               }, index) => {
                 if (isEqual(type, types.SEPARATOR)) return <MenuDivider key={index} />
@@ -66,6 +68,7 @@ DropdownMenu.propTypes = {
     type: PropTypes.string,
     label: PropTypes.string,
     enabled: PropTypes.bool,
+    visible: PropTypes.bool,
     submenu: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
     accelerator: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   })),

--- a/src/components/ElectronMenu/ElectronMenu.js
+++ b/src/components/ElectronMenu/ElectronMenu.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import _map from 'lodash/map'
+import _filter from 'lodash/filter'
 
 import { getElectronMenuTitle, getElectronMenuTemplate } from 'state/electronMenu/selectors'
 
@@ -9,10 +10,11 @@ import DropdownMenu from './ElectronMenu.dropdown'
 const ElectronMenu = () => {
   const items = useSelector(getElectronMenuTemplate)
   const menuTitle = useSelector(getElectronMenuTitle)
+  const visibleItems = _filter(items, 'visible')
 
   return (
     <div className='electron-menu'>
-      {_map(items, ({ label, submenu }, index) => (
+      {_map(visibleItems, ({ label, submenu }, index) => (
         <DropdownMenu
           key={index}
           label={label}

--- a/src/components/ElectronMenu/ElectronMenu.submenu.js
+++ b/src/components/ElectronMenu/ElectronMenu.submenu.js
@@ -3,16 +3,18 @@ import { useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import { MenuItem } from '@blueprintjs/core'
 import _map from 'lodash/map'
+import _filter from 'lodash/filter'
 
 import { executeMenuCommand } from 'state/electronMenu/actions'
 
 const SubMenu = ({ label, items }) => {
   const dispatch = useDispatch()
+  const visibleItems = _filter(items, 'visible')
 
   return (
     <div className='electron-menu-submenu'>
       <MenuItem text={label}>
-        {_map(items, ({
+        {_map(visibleItems, ({
           id, label: itemLabel, accelerator, enabled,
         }, index) => (
           <MenuItem
@@ -34,6 +36,7 @@ SubMenu.propTypes = {
     id: PropTypes.string,
     label: PropTypes.string,
     enabled: PropTypes.bool,
+    visible: PropTypes.bool,
     accelerator: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   })),
   label: PropTypes.string,

--- a/src/utils/handleElectronLoad.js
+++ b/src/utils/handleElectronLoad.js
@@ -24,6 +24,9 @@ const handleElectronLoad = () => {
     window.bfxReportElectronApi?.onHideMenuEvent(({ state }) => {
       store.dispatch(setElectronMenuHidden(state))
     })
+    window.bfxReportElectronApi?.onRerenderMenuEvent(() => {
+      store.dispatch(getElectronMenuConfig())
+    })
     window.bfxReportElectronApi?.onFireToastEvent((args) => {
       // close previous toast before showing the next one
       const { toastId: prevToastId } = selectAutoUpdateToast(store.getState())


### PR DESCRIPTION
Task: https://app.asana.com/0/home/1198734617779732/1211766200869813

#### Description:
- [x] Implements the possibility to refetch `Electron` menu states/rerender when `onRerenderMenuEvent` has been emitted and adds menus/items `visibility` state handling

---
**Note:** we need the dynamic menu options availability handling for the special scenarios, e.g., during the Electron app auto-updating flow, etc.



<img width="1107" height="452" alt="electron-menu-prev" src="https://github.com/user-attachments/assets/38c75fba-732f-47cd-8e23-430adee3a595" />


---
#### Depends on: 
- [bfx-report-electron #478](https://github.com/bitfinexcom/bfx-report-electron/pull/478)
- [bfx-report-electron #565](https://github.com/bitfinexcom/bfx-report-electron/pull/565)
