### PR TITLE
(improvements) USDT0 and XAUT0 support in filters

### DIFF
--- a/src/state/symbols/constants.js
+++ b/src/state/symbols/constants.js
@@ -1,4 +1,4 @@
-export const EXTENDED_CCY_LIST = ['LNX', 'ETH2P', 'ETH2R', 'ETH2U', 'USDT0ARB', 'USDT0INK', 'USDT0OPX']
+export const EXTENDED_CCY_LIST = ['LNX', 'ETH2P', 'ETH2R', 'ETH2U']
 
 export default {
   FETCH_SYMBOLS: 'BITFINEX/SYMBOLS/FETCH',

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -51,13 +51,13 @@ export function symbolsReducer(state = initialState, action) {
 
         let { symbol } = currency
 
-        const isUSDT0 = _isEqual(symbol, 'USDT0')
+        const isT0ccy = _isEqual(symbol, 'USDT0') || _isEqual(symbol, 'XAUT0')
 
         if (symbol === 'USDt' || _includes(symbol, 'USDT')) {
           tetherNames[id] = name
         }
 
-        if (!EXTENDED_CCY_LIST.includes(id) && !isInPair && !isUSDT0) {
+        if (!EXTENDED_CCY_LIST.includes(id) && !isInPair && !isT0ccy) {
           return
         }
 
@@ -68,7 +68,7 @@ export function symbolsReducer(state = initialState, action) {
           if (id.includes('F0')) {
             symbol = `${symbol} (deriv)`
           }
-          if (isUSDT0) {
+          if (isT0ccy) {
             symbol = id
           }
 

--- a/src/state/symbols/reducer.js
+++ b/src/state/symbols/reducer.js
@@ -51,11 +51,13 @@ export function symbolsReducer(state = initialState, action) {
 
         let { symbol } = currency
 
+        const isUSDT0 = _isEqual(symbol, 'USDT0')
+
         if (symbol === 'USDt' || _includes(symbol, 'USDT')) {
           tetherNames[id] = name
         }
 
-        if (!EXTENDED_CCY_LIST.includes(id) && !isInPair) {
+        if (!EXTENDED_CCY_LIST.includes(id) && !isInPair && !isUSDT0) {
           return
         }
 
@@ -66,7 +68,7 @@ export function symbolsReducer(state = initialState, action) {
           if (id.includes('F0')) {
             symbol = `${symbol} (deriv)`
           }
-          if (_isEqual(symbol, 'USDT0')) {
+          if (isUSDT0) {
             symbol = id
           }
 


### PR DESCRIPTION
Task: https://app.asana.com/1/29923630752984/home/task/1212773521580774

#### Description:

- [x] Extends `USDT0` and `XAUT0` currencies (not presented in pairs) support in the `symbol` filters

#### Before:
<img width="551" height="342" alt="usdt0-before" src="https://github.com/user-attachments/assets/c692acca-797f-4595-9ec7-f60f16f4e6fc" />


&nbsp;

<img width="557" height="297" alt="xaut0-before" src="https://github.com/user-attachments/assets/e7c2896a-27c2-4b69-99aa-eddf597493ec" />

#### After:
<img width="556" height="343" alt="usdt0-after" src="https://github.com/user-attachments/assets/995da191-05cb-4d85-9485-8e5f2e4c861e" />


&nbsp;

<img width="543" height="350" alt="xaut0-after" src="https://github.com/user-attachments/assets/03df44ba-bb79-4769-9e6c-328462b65081" />

