### PR TITLE
(improvement) Add exponential backoff and jitter for WS reconnection

### DIFF
--- a/src/state/ws/index.js
+++ b/src/state/ws/index.js
@@ -1,3 +1,6 @@
+import _clamp from 'lodash/clamp'
+import _random from 'lodash/random'
+
 import { store } from 'state/store'
 
 import { getWsAddress } from 'state/base/selectors'
@@ -7,6 +10,19 @@ import config from 'config'
 import types from './constants'
 
 const { REACT_APP_ENV } = process.env
+
+const RECONNECT_BASE_DELAY = 300 // ms
+const RECONNECT_MAX_DELAY = 30000 // ms (cap)
+
+// Full Jitter: random(0, min(cap, base * 2^attempt))
+const getReconnectDelay = (attempt = 0) => {
+  const exponential = _clamp(
+    RECONNECT_BASE_DELAY * (2 ** attempt),
+    RECONNECT_BASE_DELAY,
+    RECONNECT_MAX_DELAY,
+  )
+  return _random(0, exponential)
+}
 
 const getAuth = () => {
   const state = store.getState()
@@ -30,6 +46,8 @@ class WS {
     this.isConnected = false
     this.websocket = null
     this.isFirstConnect = true
+    this.reconnectAttempts = 0
+    this.reconnectTimeout = null
   }
 
   heartbeat = () => {
@@ -41,6 +59,8 @@ class WS {
   }
 
   connect = () => {
+    clearTimeout(this.reconnectTimeout)
+
     if (!config.showFrameworkMode || this.isConnected) {
       return
     }
@@ -57,6 +77,7 @@ class WS {
 
     websocket.onopen = () => {
       this.isConnected = true
+      this.reconnectAttempts = 0
       store.dispatch({ type: types.WS_CONNECT })
 
       if (!this.isFirstConnect) {
@@ -70,7 +91,9 @@ class WS {
 
     websocket.onclose = () => {
       this.isConnected = false
-      setTimeout(() => this.connect(), 300)
+      const delay = getReconnectDelay(this.reconnectAttempts)
+      this.reconnectAttempts += 1
+      this.reconnectTimeout = setTimeout(() => this.connect(), delay)
     }
 
     websocket.onmessage = this.onMessage

--- a/src/state/ws/index.js
+++ b/src/state/ws/index.js
@@ -13,14 +13,28 @@ const { REACT_APP_ENV } = process.env
 
 const RECONNECT_BASE_DELAY = 300 // ms
 const RECONNECT_MAX_DELAY = 30000 // ms (cap)
+const RECONNECT_FLAT_ATTEMPTS = 3 // attempts 1-3 retry with the flat base delay
+const RECONNECT_EXPONENTIAL_ATTEMPTS = 3 // attempts 4-6 grow exponentially, no jitter
 
-// Full Jitter: random(0, min(cap, base * 2^attempt))
+const getExponentialDelay = (attempt) => _clamp(
+  RECONNECT_BASE_DELAY * (2 ** (attempt - RECONNECT_FLAT_ATTEMPTS + 1)),
+  RECONNECT_BASE_DELAY,
+  RECONNECT_MAX_DELAY,
+)
+
+// Attempts 1-3: flat base delay, 4-6: plain exponential,
+// then Full Jitter: random(0, min(cap, base * 2^attempt))
 const getReconnectDelay = (attempt = 0) => {
-  const exponential = _clamp(
-    RECONNECT_BASE_DELAY * (2 ** attempt),
-    RECONNECT_BASE_DELAY,
-    RECONNECT_MAX_DELAY,
-  )
+  if (attempt < RECONNECT_FLAT_ATTEMPTS) {
+    return RECONNECT_BASE_DELAY
+  }
+
+  const exponential = getExponentialDelay(attempt)
+
+  if (attempt < RECONNECT_FLAT_ATTEMPTS + RECONNECT_EXPONENTIAL_ATTEMPTS) {
+    return exponential
+  }
+
   return _random(0, exponential)
 }
 


### PR DESCRIPTION
Task: https://app.asana.com/1/29923630752984/home/task/1211845900584305

#### Description:

- [x] Replaces the `fixed 300ms` WebSocket reconnect interval with a `staged backoff` - a few flat retries first, then `exponential backoff and full jitter` - to recover instantly from minor blips, to stop users from hammering the backend every 300ms while it is restarting or unavailable and to de-synchronize retries across users

Approach follows the `AWS` recommendation: 
https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

---
**Details:**
- Base `300ms`, cap `30000ms`, infinite retries; the schedule runs in three stages:
  - attempts `1-3`: flat `300ms`, so anything minor is recovered within `0.9s`
  - attempts `4-6`: plain exponential `600 / 1200 / 2400ms`, no randomization
  - attempts `7+`: full jitter, actual wait randomized in `[0, ceiling]`, ceiling keeps doubling up to the cap
- The exponent restarts with its own stage (`base * 2 ** (attempt - 3)`), so there is no `300ms -> 2400ms` jump right after the flat stage
- Attempt counter resets on successful `onopen`, so recovery starts from short delays again
- Pending reconnect timer cleared on `connect()` to avoid stacked reconnections
- Stage sizes live in `RECONNECT_FLAT_ATTEMPTS` / `RECONNECT_EXPONENTIAL_ATTEMPTS`, so the schedule is tunable in one place

#### Preview (with temporary logs added for clarity):
<img width="1033" height="562" alt="staged-backoff-prev" src="https://github.com/user-attachments/assets/d261f13f-687b-48d1-9ed7-649d69c425d1" />


---
#### Related to: 
- [bfx-report-ui #983](https://github.com/bitfinexcom/bfx-report-ui/pull/983)