### PR TITLE
(improvements) Wallets filtering

### DIFF
--- a/src/state/affiliatesEarnings/saga.js
+++ b/src/state/affiliatesEarnings/saga.js
@@ -8,7 +8,7 @@ import {
 import { makeFetchCall } from 'state/utils'
 import { getTimeFrame } from 'state/timeRange/selectors'
 import { getQueryLimit } from 'state/query/utils'
-import { getFilterQuery } from 'state/filters/selectors'
+import { getLedgersFilterQuery } from 'state/filters/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import { refreshPagination, updatePagination } from 'state/pagination/actions'
 import { getAffiliatesEarnings } from 'state/affiliatesEarnings/selectors'
@@ -24,15 +24,17 @@ import actions from './actions'
 const TYPE = queryTypes.MENU_AFFILIATES_EARNINGS
 
 function getReqLedgers({
-  start,
   end,
-  targetSymbols,
+  start,
   filter,
+  wallet,
+  targetSymbols,
 }) {
   const params = {
     start,
     end,
     filter,
+    wallet,
     limit: getQueryLimit(TYPE),
     category: LEDGERS_CATEGORIES.AFFILIATE_REBATE,
     symbol: targetSymbols.length ? mapRequestSymbols(targetSymbols) : undefined,
@@ -47,12 +49,13 @@ function* fetchAffiliatesEarnings() {
     const { smallestMts } = yield select(getPaginationData, TYPE)
 
     const { start, end } = yield select(getTimeFrame, smallestMts)
-    const filter = yield select(getFilterQuery, TYPE)
+    const { filter, wallet } = yield select(getLedgersFilterQuery, TYPE)
     const { result, error } = yield call(fetchDataWithPagination, getReqLedgers, {
-      start,
       end,
-      targetSymbols,
+      start,
       filter,
+      wallet,
+      targetSymbols,
     })
     yield put(actions.updateAffiliatesEarnings(result))
     yield put(updatePagination(TYPE, result))

--- a/src/state/filters/selectors.js
+++ b/src/state/filters/selectors.js
@@ -1,5 +1,7 @@
 import { get, isEmpty } from '@bitfinex/lib-js-util-base'
 
+import { splitWalletFilter } from './utils'
+
 export const getColumns = (state, section) => get(state, ['filters', 'columns', section])
 export const getFilters = (state, section) => get(state, ['filters', section])
 export const getFilterQuery = (state, section) => {
@@ -8,8 +10,12 @@ export const getFilterQuery = (state, section) => {
   return isEmpty(filterQuery) ? undefined : filterQuery
 }
 
+// for the getLedgers based sections, the wallet condition is passed as a standalone param
+export const getLedgersFilterQuery = (state, section) => splitWalletFilter(getFilterQuery(state, section))
+
 export default {
   getColumns,
   getFilters,
   getFilterQuery,
+  getLedgersFilterQuery,
 }

--- a/src/state/filters/utils.js
+++ b/src/state/filters/utils.js
@@ -1,18 +1,30 @@
 /* eslint-disable import/prefer-default-export */
-import _reduce from 'lodash/reduce'
 import _set from 'lodash/set'
+import _find from 'lodash/find'
+import _omit from 'lodash/omit'
+import _uniq from 'lodash/uniq'
+import _isNaN from 'lodash/isNaN'
+import _reduce from 'lodash/reduce'
+import _sortBy from 'lodash/sortBy'
+import _filter from 'lodash/filter'
+import _countBy from 'lodash/countBy'
+import _findKey from 'lodash/findKey'
+import _toString from 'lodash/toString'
 import _toNumber from 'lodash/toNumber'
 import _toInteger from 'lodash/toInteger'
-import _toString from 'lodash/toString'
-import _findKey from 'lodash/findKey'
-import _sortBy from 'lodash/sortBy'
-import _find from 'lodash/find'
-import _isNaN from 'lodash/isNaN'
 import { get, isEmpty } from '@bitfinex/lib-js-util-base'
 
 import SECTION_COLUMNS, { TRANSFORMS } from 'ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns'
 import FILTER_TYPES, { FILTER_QUERY_TYPES, FILTERS, FILTER_KEYS } from 'var/filterTypes'
+import queryConstants from 'state/query/constants'
 import DATA_TYPES from 'var/dataTypes'
+
+const {
+  MENU_LEDGERS,
+  MENU_FPAYMENT,
+  MENU_SPAYMENTS,
+  MENU_AFFILIATES_EARNINGS,
+} = queryConstants
 
 const {
   NUMBER,
@@ -60,6 +72,9 @@ export const calculateFilterQuery = (filters = [], section) => {
 
   const validFilters = getValidFilters(filters)
   const columns = SECTION_COLUMNS[section]
+  const notEqualCountsByColumn = _countBy(
+    _filter(validFilters, { type: FILTERS.NOT_EQUAL_TO }), 'column',
+  )
 
   return _reduce(validFilters, (acc, filter) => {
     const {
@@ -90,8 +105,13 @@ export const calculateFilterQuery = (filters = [], section) => {
         _set(acc, `${FILTER_TYPES.EQ}.${column}`, filterValue)
         break
       case FILTERS.NOT_EQUAL_TO: {
-        const currentFilters = get(acc, `${FILTER_TYPES.NIN}.${column}`, [])
-        _set(acc, `${FILTER_TYPES.NIN}.${column}`, currentFilters.concat(filterValue))
+        // a single exclusion maps to $ne, multiple ones are collected into a $nin list
+        if (get(notEqualCountsByColumn, column, 0) > 1) {
+          const currentValues = get(acc, `${FILTER_TYPES.NIN}.${column}`, [])
+          _set(acc, `${FILTER_TYPES.NIN}.${column}`, _uniq(currentValues.concat(filterValue)))
+        } else {
+          _set(acc, `${FILTER_TYPES.NE}.${column}`, filterValue)
+        }
         break
       }
       case FILTERS.GREATER_THAN:
@@ -111,6 +131,29 @@ export const calculateFilterQuery = (filters = [], section) => {
 
     return acc
   }, {})
+}
+
+// sections backed by the getLedgers/getLedgersFile methods, which accept a dedicated wallet param
+export const WALLET_PARAM_SECTIONS = [
+  MENU_LEDGERS,
+  MENU_FPAYMENT,
+  MENU_SPAYMENTS,
+  MENU_AFFILIATES_EARNINGS,
+]
+
+// the backend resolves the dedicated `wallet` param faster than a generic $eq filter
+export const splitWalletFilter = (filterQuery) => {
+  const wallet = get(filterQuery, [FILTER_TYPES.EQ, 'wallet'])
+  if (isEmpty(wallet)) {
+    return { filter: filterQuery, wallet: undefined }
+  }
+
+  const restEqFilters = _omit(get(filterQuery, FILTER_TYPES.EQ), 'wallet')
+  const filter = isEmpty(restEqFilters)
+    ? _omit(filterQuery, FILTER_TYPES.EQ)
+    : { ...filterQuery, [FILTER_TYPES.EQ]: restEqFilters }
+
+  return { wallet, filter: isEmpty(filter) ? undefined : filter }
 }
 
 // returns a string with the encoded filters

--- a/src/state/filters/utils.js
+++ b/src/state/filters/utils.js
@@ -72,6 +72,9 @@ export const calculateFilterQuery = (filters = [], section) => {
 
   const validFilters = getValidFilters(filters)
   const columns = SECTION_COLUMNS[section]
+  const equalCountsByColumn = _countBy(
+    _filter(validFilters, { type: FILTERS.EQUAL_TO }), 'column',
+  )
   const notEqualCountsByColumn = _countBy(
     _filter(validFilters, { type: FILTERS.NOT_EQUAL_TO }), 'column',
   )
@@ -101,9 +104,16 @@ export const calculateFilterQuery = (filters = [], section) => {
       case FILTERS.ENDS_WITH:
         _set(acc, `${FILTER_TYPES.LIKE}.${column}`, `%${filterValue}`)
         break
-      case FILTERS.EQUAL_TO:
-        _set(acc, `${FILTER_TYPES.EQ}.${column}`, filterValue)
+      case FILTERS.EQUAL_TO: {
+        // a single value maps to $eq, multiple ones are collected into a $in list
+        if (get(equalCountsByColumn, column, 0) > 1) {
+          const currentValues = get(acc, `${FILTER_TYPES.IN}.${column}`, [])
+          _set(acc, `${FILTER_TYPES.IN}.${column}`, _uniq(currentValues.concat(filterValue)))
+        } else {
+          _set(acc, `${FILTER_TYPES.EQ}.${column}`, filterValue)
+        }
         break
+      }
       case FILTERS.NOT_EQUAL_TO: {
         // a single exclusion maps to $ne, multiple ones are collected into a $nin list
         if (get(notEqualCountsByColumn, column, 0) > 1) {

--- a/src/state/fundingPayment/saga.js
+++ b/src/state/fundingPayment/saga.js
@@ -9,7 +9,7 @@ import { makeFetchCall } from 'state/utils'
 import { toggleErrorDialog } from 'state/ui/actions'
 import { getTimeFrame } from 'state/timeRange/selectors'
 import { getQueryLimit } from 'state/query/utils'
-import { getFilterQuery } from 'state/filters/selectors'
+import { getLedgersFilterQuery } from 'state/filters/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import { refreshPagination, updatePagination } from 'state/pagination/actions'
 import { getPaginationData } from 'state/pagination/selectors'
@@ -25,15 +25,17 @@ import selectors from './selectors'
 const TYPE = queryTypes.MENU_FPAYMENT
 
 function getReqLedgers({
-  start,
   end,
-  targetSymbols,
+  start,
   filter,
+  wallet,
+  targetSymbols,
 }) {
   const params = {
     start,
     end,
     filter,
+    wallet,
     limit: getQueryLimit(TYPE),
     category: LEDGERS_CATEGORIES.FUNDING_PAYMENT,
     symbol: targetSymbols.length ? mapRequestSymbols(targetSymbols) : undefined,
@@ -47,12 +49,13 @@ function* fetchFPayment() {
     const targetSymbols = yield select(selectors.getTargetSymbols, TYPE)
     const { smallestMts } = yield select(getPaginationData, TYPE)
     const { start, end } = yield select(getTimeFrame, smallestMts)
-    const filter = yield select(getFilterQuery, TYPE)
+    const { filter, wallet } = yield select(getLedgersFilterQuery, TYPE)
     const { result, error } = yield call(fetchDataWithPagination, getReqLedgers, {
-      start,
       end,
-      targetSymbols,
+      start,
       filter,
+      wallet,
+      targetSymbols,
     })
     yield put(actions.updateFPayment(result))
     yield put(updatePagination(TYPE, result))

--- a/src/state/ledgers/saga.js
+++ b/src/state/ledgers/saga.js
@@ -11,7 +11,7 @@ import { getQueryLimit } from 'state/query/utils'
 import { updateErrorStatus } from 'state/status/actions'
 import queryTypes from 'state/query/constants'
 import { mapRequestSymbols } from 'state/symbols/utils'
-import { getFilterQuery } from 'state/filters/selectors'
+import { getLedgersFilterQuery } from 'state/filters/selectors'
 import { refreshPagination, updatePagination } from 'state/pagination/actions'
 import { getPaginationData } from 'state/pagination/selectors'
 import { fetchDataWithPagination } from 'state/sagas.helper'
@@ -23,16 +23,18 @@ import { getLedgers } from './selectors'
 const TYPE = queryTypes.MENU_LEDGERS
 
 function getReqLedgers({
-  start,
   end,
+  start,
+  filter,
+  wallet,
   targetCategory,
   targetSymbols,
-  filter,
 }) {
   const params = {
     start,
     end,
     filter,
+    wallet,
     limit: getQueryLimit(TYPE),
     category: targetCategory,
     symbol: targetSymbols.length ? mapRequestSymbols(targetSymbols) : undefined,
@@ -45,15 +47,16 @@ function* fetchLedgers() {
   try {
     const { targetCategory, targetSymbols } = yield select(getLedgers)
     const { smallestMts } = yield select(getPaginationData, TYPE)
-    const filter = yield select(getFilterQuery, TYPE)
+    const { filter, wallet } = yield select(getLedgersFilterQuery, TYPE)
 
     const { start, end } = yield select(getTimeFrame, smallestMts)
     const { result, error } = yield call(fetchDataWithPagination, getReqLedgers, {
-      start,
       end,
+      start,
+      filter,
+      wallet,
       targetCategory,
       targetSymbols,
-      filter,
     })
     yield put(actions.updateLedgers(result))
     yield put(updatePagination(TYPE, result))

--- a/src/state/query/saga.js
+++ b/src/state/query/saga.js
@@ -14,7 +14,8 @@ import { LANGUAGES } from 'locales/i18n'
 import { makeFetchCall } from 'state/utils'
 import { formatRawSymbols, mapRequestSymbols, mapRequestPairs } from 'state/symbols/utils'
 import { updateErrorStatus } from 'state/status/actions'
-import { getFilterQuery } from 'state/filters/selectors'
+import { WALLET_PARAM_SECTIONS } from 'state/filters/utils'
+import { getFilterQuery, getLedgersFilterQuery } from 'state/filters/selectors'
 import { getTimeframe as getAccountBalanceTimeframe } from 'state/accountBalance/selectors'
 import { getTargetSymbols as getAffiliatesEarningsSymbols } from 'state/affiliatesEarnings/selectors'
 import { getParams as getCandlesParams } from 'state/candles/selectors'
@@ -221,7 +222,13 @@ function* getOptions({ target }) {
   options.timezone = yield select(getTimezone)
   options.dateFormat = yield select(getDateFormat)
   options.milliseconds = yield select(getShowMilliseconds)
-  options.filter = yield select(getFilterQuery, target)
+  if (_includes(WALLET_PARAM_SECTIONS, target)) {
+    const { filter, wallet } = yield select(getLedgersFilterQuery, target)
+    options.filter = filter
+    options.wallet = wallet
+  } else {
+    options.filter = yield select(getFilterQuery, target)
+  }
   const selector = getSelector(target)
   const sign = selector ? yield select(selector) : ''
   const isFundingFees = showFrameworkMode ? yield select(getIsFundingFees) : ''

--- a/src/state/stakingPayments/saga.js
+++ b/src/state/stakingPayments/saga.js
@@ -9,7 +9,7 @@ import { makeFetchCall } from 'state/utils'
 import { toggleErrorDialog } from 'state/ui/actions'
 import { getTimeFrame } from 'state/timeRange/selectors'
 import { getQueryLimit } from 'state/query/utils'
-import { getFilterQuery } from 'state/filters/selectors'
+import { getLedgersFilterQuery } from 'state/filters/selectors'
 import { updateErrorStatus } from 'state/status/actions'
 import { refreshPagination, updatePagination } from 'state/pagination/actions'
 import { getPaginationData } from 'state/pagination/selectors'
@@ -25,15 +25,17 @@ import selectors from './selectors'
 const TYPE = queryTypes.MENU_SPAYMENTS
 
 function getReqLedgers({
-  start,
   end,
-  targetSymbols,
+  start,
   filter,
+  wallet,
+  targetSymbols,
 }) {
   const params = {
     start,
     end,
     filter,
+    wallet,
     limit: getQueryLimit(TYPE),
     category: LEDGERS_CATEGORIES.STAKING_PAYMENT,
     symbol: targetSymbols.length ? mapRequestSymbols(targetSymbols) : undefined,
@@ -47,12 +49,13 @@ function* fetchSPayments() {
     const targetSymbols = yield select(selectors.getTargetSymbols, TYPE)
     const { smallestMts } = yield select(getPaginationData, TYPE)
     const { start, end } = yield select(getTimeFrame, smallestMts)
-    const filter = yield select(getFilterQuery, TYPE)
+    const { filter, wallet } = yield select(getLedgersFilterQuery, TYPE)
     const { result, error } = yield call(fetchDataWithPagination, getReqLedgers, {
-      start,
       end,
-      targetSymbols,
+      start,
       filter,
+      wallet,
+      targetSymbols,
     })
     yield put(actions.updateData(result))
     yield put(updatePagination(TYPE, result))

--- a/src/ui/ColumnsFilter/ColumnsFilter.helpers.js
+++ b/src/ui/ColumnsFilter/ColumnsFilter.helpers.js
@@ -1,11 +1,58 @@
+import _get from 'lodash/get'
 import _size from 'lodash/size'
 import _filter from 'lodash/filter'
+import _reduce from 'lodash/reduce'
 import _toString from 'lodash/toString'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, isEqual } from '@bitfinex/lib-js-util-base'
+
+import { FILTERS } from 'var/filterTypes'
 
 const getActiveFilters = (filters) => _filter(
   filters, filter => !isEmpty(_toString(filter?.value ?? '')),
 )
+
+// filter types already applied to the same column, as re-using one overwrites the previous filter;
+// "not equal to" is exempt, since multiple exclusions are collected into a $nin list
+export const getUsedFilterTypes = (filters, index) => {
+  const { column } = _get(filters, index, {})
+  if (isEmpty(column)) {
+    return []
+  }
+
+  return _reduce(filters, (acc, filter, i) => {
+    const { column: filterColumn, type } = filter
+
+    if (!isEqual(i, index)
+      && isEqual(filterColumn, column)
+      && !isEmpty(type)
+      && !isEqual(type, FILTERS.NOT_EQUAL_TO)) {
+      acc.push(type)
+    }
+
+    return acc
+  }, [])
+}
+
+// values already used for the same column, as reusing one produces a contradictory query
+// (e.g. wallet `equal to` exchange combined with wallet `not equal to` exchange)
+export const getUsedFilterValues = (filters, index) => {
+  const { column } = _get(filters, index, {})
+  if (isEmpty(column)) {
+    return []
+  }
+
+  return _reduce(filters, (acc, filter, i) => {
+    const { column: filterColumn, value } = filter
+
+    if (!isEqual(i, index)
+      && isEqual(filterColumn, column)
+      && !isEmpty(_toString(value))) {
+      acc.push(value)
+    }
+
+    return acc
+  }, [])
+}
 
 export const getFiltersClassNames = (filters) => {
   const activeFilters = getActiveFilters(filters)
@@ -29,5 +76,7 @@ export const getFiltersTitle = (filters, t) => {
 
 export default {
   getFiltersTitle,
+  getUsedFilterTypes,
+  getUsedFilterValues,
   getFiltersClassNames,
 }

--- a/src/ui/ColumnsFilter/ColumnsFilter.helpers.js
+++ b/src/ui/ColumnsFilter/ColumnsFilter.helpers.js
@@ -3,16 +3,21 @@ import _size from 'lodash/size'
 import _filter from 'lodash/filter'
 import _reduce from 'lodash/reduce'
 import _toString from 'lodash/toString'
+import _includes from 'lodash/includes'
 import { isEmpty, isEqual } from '@bitfinex/lib-js-util-base'
 
 import { FILTERS } from 'var/filterTypes'
+
+// filter types whose repeated use on the same column is collected into a list ($in/$nin)
+// instead of overwriting the previous value, so duplicates are allowed for them
+const LIST_FILTER_TYPES = [FILTERS.EQUAL_TO, FILTERS.NOT_EQUAL_TO]
 
 const getActiveFilters = (filters) => _filter(
   filters, filter => !isEmpty(_toString(filter?.value ?? '')),
 )
 
 // filter types already applied to the same column, as re-using one overwrites the previous filter;
-// "not equal to" is exempt, since multiple exclusions are collected into a $nin list
+// list types (equal to / not equal to) are exempt, since their values are collected into a $in/$nin list
 export const getUsedFilterTypes = (filters, index) => {
   const { column } = _get(filters, index, {})
   if (isEmpty(column)) {
@@ -25,7 +30,7 @@ export const getUsedFilterTypes = (filters, index) => {
     if (!isEqual(i, index)
       && isEqual(filterColumn, column)
       && !isEmpty(type)
-      && !isEqual(type, FILTERS.NOT_EQUAL_TO)) {
+      && !_includes(LIST_FILTER_TYPES, type)) {
       acc.push(type)
     }
 

--- a/src/ui/ColumnsFilter/ColumnsFilter.js
+++ b/src/ui/ColumnsFilter/ColumnsFilter.js
@@ -25,7 +25,12 @@ import { propTypes, defaultProps } from './ColumnsFilter.props'
 import { FILTERS_SELECTOR } from './ColumnSelector/ColumnSelector.columns'
 import SideSelector from './Selectors/SideSelector'
 import WalletSelector from './Selectors/WalletSelector'
-import { getFiltersTitle, getFiltersClassNames } from './ColumnsFilter.helpers'
+import {
+  getFiltersTitle,
+  getUsedFilterTypes,
+  getUsedFilterValues,
+  getFiltersClassNames,
+} from './ColumnsFilter.helpers'
 
 const MAX_FILTERS = 7
 const { DATE } = DATA_TYPES
@@ -180,10 +185,11 @@ class ColumnsFilter extends PureComponent {
 
   renderSelect = ({ filter, index }) => {
     const { select, value } = filter
-    // eslint-disable-next-line no-unused-vars
+    const { filters } = this.state
     const selectProps = {
-      className: 'columns-filter-item-input columns-filter-item-input--select',
       value,
+      className: 'columns-filter-item-input columns-filter-item-input--select',
+      disabledValues: getUsedFilterValues(filters, index),
       onChange: itemValue => this.onSelectChange(index, itemValue),
     }
 
@@ -239,9 +245,10 @@ class ColumnsFilter extends PureComponent {
                       onChange={(column) => this.onColumnChange({ index, ...column })}
                     />
                     <FilterTypeSelector
-                      isSelect={!!select}
                       value={type}
+                      isSelect={!!select}
                       dataType={dataType}
+                      disabledTypes={getUsedFilterTypes(filters, index)}
                       onChange={filterType => this.updateFilter({ index, type: filterType })}
                     />
                     {select && this.renderSelect({ filter, index })}

--- a/src/ui/ColumnsFilter/FilterTypeSelector/FilterTypeSelector.js
+++ b/src/ui/ColumnsFilter/FilterTypeSelector/FilterTypeSelector.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { withTranslation } from 'react-i18next'
+import _includes from 'lodash/includes'
 
 import Select from 'ui/Select'
 import { FILTERS } from 'var/filterTypes'
@@ -22,7 +23,7 @@ class FilterTypeSelector extends React.PureComponent {
 
   render() {
     const {
-      dataType, isSelect, value, t,
+      dataType, disabledTypes, isSelect, value, t,
     } = this.props
 
     const dateTypes = (dataType === DATE)
@@ -65,6 +66,7 @@ class FilterTypeSelector extends React.PureComponent {
         className='columns-filter-item-filter'
         filterable={false}
         items={items}
+        itemDisabled={item => _includes(disabledTypes, item.value)}
         onChange={this.onChange}
         value={value}
       />

--- a/src/ui/ColumnsFilter/FilterTypeSelector/FilterTypeSelector.props.js
+++ b/src/ui/ColumnsFilter/FilterTypeSelector/FilterTypeSelector.props.js
@@ -4,10 +4,12 @@ export const propTypes = {
   isSelect: PropTypes.bool.isRequired,
   value: PropTypes.string.isRequired,
   dataType: PropTypes.string,
+  disabledTypes: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
 }
 
 export const defaultProps = {
   dataType: '',
+  disabledTypes: [],
 }

--- a/src/ui/ColumnsFilter/Selectors/SideSelector.js
+++ b/src/ui/ColumnsFilter/Selectors/SideSelector.js
@@ -1,5 +1,6 @@
-import React, { memo, useMemo } from 'react'
+import React, { memo, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
+import _includes from 'lodash/includes'
 import { useTranslation } from 'react-i18next'
 
 import Select from 'ui/Select'
@@ -8,6 +9,7 @@ const SideSelector = ({
   value,
   onChange,
   className,
+  disabledValues,
 }) => {
   const { t } = useTranslation()
 
@@ -17,12 +19,17 @@ const SideSelector = ({
     { value: 1, label: t('floan.side.provided') },
   ], [t])
 
+  const itemDisabled = useCallback(
+    item => _includes(disabledValues, item.value), [disabledValues],
+  )
+
   return (
     <Select
       value={value}
       items={items}
       onChange={onChange}
       className={className}
+      itemDisabled={itemDisabled}
     />
   )
 }
@@ -31,11 +38,13 @@ SideSelector.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  disabledValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
 }
 
 SideSelector.defaultProps = {
   value: '',
   className: '',
+  disabledValues: [],
 }
 
 export default memo(SideSelector)

--- a/src/ui/ColumnsFilter/Selectors/WalletSelector.js
+++ b/src/ui/ColumnsFilter/Selectors/WalletSelector.js
@@ -1,5 +1,6 @@
-import React, { memo, useMemo } from 'react'
+import React, { memo, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
+import _includes from 'lodash/includes'
 import { useTranslation } from 'react-i18next'
 
 import Select from 'ui/Select'
@@ -8,6 +9,7 @@ const WalletSelector = ({
   value,
   onChange,
   className,
+  disabledValues,
 }) => {
   const { t } = useTranslation()
 
@@ -19,12 +21,17 @@ const WalletSelector = ({
     { value: 'creditline', label: t('wallets.header.credit-line') },
   ], [t])
 
+  const itemDisabled = useCallback(
+    item => _includes(disabledValues, item.value), [disabledValues],
+  )
+
   return (
     <Select
       items={items}
       value={value}
       onChange={onChange}
       className={className}
+      itemDisabled={itemDisabled}
     />
   )
 }
@@ -33,11 +40,13 @@ WalletSelector.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  disabledValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
 }
 
 WalletSelector.defaultProps = {
   value: '',
   className: '',
+  disabledValues: [],
 }
 
 export default memo(WalletSelector)

--- a/src/ui/ColumnsFilter/var/defaultFilters.js
+++ b/src/ui/ColumnsFilter/var/defaultFilters.js
@@ -1,5 +1,6 @@
 import queryConstants from 'state/query/constants'
 import { FILTERS, EMPTY_FILTER } from 'var/filterTypes'
+import { FILTERS_SELECTOR } from 'ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns'
 import DATA_TYPES from 'var/dataTypes'
 
 const {
@@ -83,7 +84,7 @@ const DEFAULT_FILTERS = {
   [MENU_FPAYMENT]: [
     { column: 'amount', type: GREATER_THAN, dataType: NUMBER, value: '' },
     { column: 'balance', type: GREATER_THAN, dataType: NUMBER, value: '' },
-    { column: 'wallet', type: CONTAINS, dataType: STRING, value: '' },
+    { column: 'wallet', type: EQUAL_TO, dataType: STRING, select: FILTERS_SELECTOR.WALLET, value: '' },
   ],
   [MENU_SPAYMENTS]: DEFAULT_LEDGERS,
   [MENU_AFFILIATES_EARNINGS]: DEFAULT_LEDGERS,

--- a/src/ui/Select/Select.js
+++ b/src/ui/Select/Select.js
@@ -20,6 +20,7 @@ class Select extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     filterable: PropTypes.bool,
+    itemDisabled: PropTypes.func,
     itemPredicate: PropTypes.func,
     itemRenderer: PropTypes.func,
     items: PropTypes.arrayOf(PropTypes.oneOfType([
@@ -51,6 +52,7 @@ class Select extends PureComponent {
     filterable: false,
     popoverClassName: '',
     itemRenderer: undefined,
+    itemDisabled: undefined,
     itemPredicate: undefined,
     type: 'Select',
   }
@@ -111,6 +113,7 @@ class Select extends PureComponent {
     const {
       className,
       filterable,
+      itemDisabled,
       itemPredicate,
       itemRenderer,
       items,
@@ -144,6 +147,7 @@ class Select extends PureComponent {
           placeholder: t('inputs.filter_placeholder'),
         }}
         items={items}
+        itemDisabled={itemDisabled}
         itemRenderer={itemRenderer || this.itemRenderer}
         itemPredicate={itemPredicate || (filterable && filterSelectorItem)}
         onItemSelect={this.onChange}


### PR DESCRIPTION
Task: https://app.asana.com/1/29923630752984/home/task/1216704120538847

#### Description:

- [x] Improves `wallets` filtering flow for the `ledgers-based` reports in the following way:

**1. Single "Equal to"** -> top-level [wallet](https://docs.bitfinex.com/reference/rest-auth-ledgers) param instead of an `$eq` filter. The backend resolves the dedicated param at the query level, which is much faster

<img width="1347" height="682" alt="equal-wallet-prev" src="https://github.com/user-attachments/assets/21d9d233-67aa-43c8-b2e5-64be741eea48" />

&nbsp;

**2. Single "Not equal to"** -> `$ne` instead of `$nin`, since one exclusion means `"not equal"`, not `"not in list"`

<img width="1478" height="602" alt="not-equal-wallet-prev" src="https://github.com/user-attachments/assets/d6bed318-2004-4afe-afbf-bb4818d54e16" />

&nbsp;

**3. Multiple "Equal to"** -> `$in` list. Several `"Equal to"` rows on the same column are now allowed and merged into one `$in`. Before, the second row silently overwrote the first and only the last value was sent

<img width="1616" height="640" alt="multi-equal-wallet-prev" src="https://github.com/user-attachments/assets/aa66e6c9-801a-4b04-b402-1743e079a75c" />

&nbsp;

**4. Multiple "Not equal to"** -> `$nin` list, so several wallets can be excluded at once

<img width="1517" height="696" alt="multi-not-equal-wallet-prev" src="https://github.com/user-attachments/assets/4e81e235-dd3a-47ae-8ff7-5b927556ec49" />


---
**In short:** one value -> fast `wallet` param / `$ne`, two or more -> `$in` / `$nin`. Duplicate and contradictory selections are blocked in the UI, and the same applies across all **getLedgers-based** reports: `Ledgers`, `Funding Payment`, `Staking Payments` and `Affiliates Earnings`

#### Preview:

https://github.com/user-attachments/assets/2e3f4a74-ae11-4564-9b3a-b093a94e19c4

---
#### Depends on: 
- [bfx-reports-framework #524](https://github.com/bitfinexcom/bfx-reports-framework/pull/524)
- [bfx-report #489](https://github.com/bitfinexcom/bfx-report/pull/489)