### PR TITLE
Fix exp backoff and jitter for ws reconnection

### DIFF
--- a/src/state/ws/index.js
+++ b/src/state/ws/index.js
@@ -91,7 +91,6 @@ class WS {
 
     websocket.onopen = () => {
       this.isConnected = true
-      this.reconnectAttempts = 0
       store.dispatch({ type: types.WS_CONNECT })
 
       if (!this.isFirstConnect) {
@@ -170,6 +169,7 @@ class WS {
       }
 
       if (action === '__ping__') {
+        this.reconnectAttempts = 0
         this.heartbeat()
         return
       }


### PR DESCRIPTION
This PR fixes exp backoff and jitter for ws reconnection

The issue is that when ws reconnects, it triggers `onopen` event and `this.reconnectAttempts` resets to `0`; that breaks the delay calculation, and we always start from `RECONNECT_BASE_DELAY = 300`

---

Related to this PR:
- https://github.com/bitfinexcom/bfx-report-ui/pull/1099

---


<img width="610" height="869" alt="Screenshot from 2026-08-05 13-51-25" src="https://github.com/user-attachments/assets/f6f060f5-bad2-465c-b305-af29f40aef54" />
<img width="610" height="964" alt="Screenshot from 2026-08-05 13-49-42" src="https://github.com/user-attachments/assets/286be9a1-fe11-4136-a9e0-0d6320ba20aa" />
