### PR TITLE
(internal) Add test coverage for the Account Summary

### DIFF
--- a/src/state/accountSummary/__tests__/sagas.test.js
+++ b/src/state/accountSummary/__tests__/sagas.test.js
@@ -1,0 +1,61 @@
+import { put, call } from 'redux-saga/effects'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
+
+import actions from '../actions'
+import { fetchAccountSummary, getReqAccountSummary } from '../saga'
+
+const ERROR = { message: 'fail' }
+
+describe('AccountSummary saga', () => {
+  const generator = cloneableGenerator(fetchAccountSummary)()
+
+  it('calls the API', () => {
+    const result = generator.next().value
+    expect(result).toEqual(call(getReqAccountSummary))
+  })
+
+  describe('request returns error', () => {
+    let clone
+
+    beforeAll(() => {
+      clone = generator.clone()
+      clone.next({ result: {}, error: ERROR }) // skips data update
+    })
+
+    it('raises failed action', () => {
+      const result = clone.next().value
+      expect(result).toEqual(put(actions.fetchFail({
+        id: 'status.fail',
+        topic: 'accountsummary.title',
+        detail: ERROR.message,
+      })))
+    })
+  })
+
+  describe('request throws error', () => {
+    let clone
+
+    beforeAll(() => {
+      clone = generator.clone()
+    })
+
+    it('raises failed action', () => {
+      const result = clone.throw({}).value
+      expect(result).toEqual(put(actions.fetchFail({
+        id: 'status.request.error',
+        topic: 'accountsummary.title',
+        detail: JSON.stringify({}),
+      })))
+    })
+
+    it('performs no further work', () => {
+      const result = clone.next().done
+      expect(result).toBe(true)
+    })
+  })
+
+  it('updates data', () => {
+    const result = generator.next({ result: {}, error: false }).value
+    expect(result).toEqual(put(actions.updateData({})))
+  })
+})

--- a/src/state/accountSummary/__tests__/state.test.js
+++ b/src/state/accountSummary/__tests__/state.test.js
@@ -1,0 +1,48 @@
+import actions from '../actions'
+import reducer, { initialState } from '../reducer'
+
+const TEST_DATA = {
+  trade_vol_30d: [{ curr: 'USD', vol: 100 }],
+}
+
+describe('AccountSummary state', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState)
+  })
+
+  it('should set loading on fetch', () => {
+    expect(reducer(initialState, actions.fetchData()))
+      .toEqual({
+        ...initialState,
+        pageLoading: true,
+      })
+  })
+
+  it('should update data', () => {
+    expect(reducer(initialState, actions.updateData([TEST_DATA])))
+      .toEqual({
+        ...initialState,
+        dataReceived: true,
+        data: TEST_DATA,
+      })
+  })
+
+  it('should reset data on empty update', () => {
+    expect(reducer(initialState, actions.updateData([])))
+      .toEqual({
+        ...initialState,
+        dataReceived: true,
+        data: {},
+      })
+  })
+
+  it('should refresh data', () => {
+    const state = {
+      ...initialState,
+      dataReceived: true,
+      data: TEST_DATA,
+    }
+    expect(reducer(state, actions.refresh()))
+      .toEqual(initialState)
+  })
+})


### PR DESCRIPTION
Tasks:
https://app.asana.com/1/29923630752984/home/task/1217017871309565
https://app.asana.com/1/29923630752984/home/task/1216923668680296 

#### Description:
- [x] Adds test coverage for the `Account Summary` reports logic

#### Preview:
<img width="494" height="306" alt="acc-summary-test-prev" src="https://github.com/user-attachments/assets/5172189d-c39e-4e34-a0c7-2714f93720c7" />

---
#### Related to: 
- [bfx-report-ui #1097](https://github.com/bitfinexcom/bfx-report-ui/pull/1097)
- [bfx-report-ui #1095](https://github.com/bitfinexcom/bfx-report-ui/pull/1095)