### PR TITLE
(internal) Add test coverage for the Derivatives

### DIFF
--- a/src/state/derivatives/__tests__/sagas.test.js
+++ b/src/state/derivatives/__tests__/sagas.test.js
@@ -1,0 +1,80 @@
+import { put, call, select } from 'redux-saga/effects'
+import { cloneableGenerator } from '@redux-saga/testing-utils'
+
+import queryTypes from 'state/query/constants'
+import { getFilterQuery } from 'state/filters/selectors'
+
+import actions from '../actions'
+import { getTargetPairs } from '../selectors'
+import { fetchDerivatives, getReqDerivatives } from '../saga'
+
+const FILTER = {}
+const ERROR = { message: 'fail' }
+const TARGET_PAIRS = ['BTCF0:USTF0']
+
+describe('Derivatives saga', () => {
+  const generator = cloneableGenerator(fetchDerivatives)()
+
+  it('selects the target pairs', () => {
+    const result = generator.next().value
+    expect(result).toEqual(select(getTargetPairs))
+  })
+
+  it('selects the filter query', () => {
+    const result = generator.next(TARGET_PAIRS).value
+    expect(result).toEqual(select(getFilterQuery, queryTypes.MENU_DERIVATIVES))
+  })
+
+  it('calls the API', () => {
+    const result = generator.next(FILTER).value
+    expect(result).toEqual(call(getReqDerivatives, {
+      targetPairs: TARGET_PAIRS,
+      filter: FILTER,
+    }))
+  })
+
+  describe('request returns error', () => {
+    let clone
+
+    beforeAll(() => {
+      clone = generator.clone()
+      clone.next({ result: [], error: ERROR }) // skips data update
+    })
+
+    it('raises failed action', () => {
+      const result = clone.next().value
+      expect(result).toEqual(put(actions.fetchFail({
+        id: 'status.fail',
+        topic: 'derivatives.title',
+        detail: ERROR.message,
+      })))
+    })
+  })
+
+  describe('request throws error', () => {
+    let clone
+
+    beforeAll(() => {
+      clone = generator.clone()
+    })
+
+    it('raises failed action', () => {
+      const result = clone.throw({}).value
+      expect(result).toEqual(put(actions.fetchFail({
+        id: 'status.request.error',
+        topic: 'derivatives.title',
+        detail: JSON.stringify({}),
+      })))
+    })
+
+    it('performs no further work', () => {
+      const result = clone.next().done
+      expect(result).toBe(true)
+    })
+  })
+
+  it('updates data', () => {
+    const result = generator.next({ result: [], error: false }).value
+    expect(result).toEqual(put(actions.updateDerivatives([])))
+  })
+})

--- a/src/state/derivatives/__tests__/state.test.js
+++ b/src/state/derivatives/__tests__/state.test.js
@@ -1,0 +1,97 @@
+import actions from '../actions'
+import reducer, { initialState } from '../reducer'
+
+const TEST_PAIR = 'BTCF0:USTF0'
+const TEST_ENTRY = {
+  key: 'tBTCF0:USTF0',
+  price: 100,
+  clampMin: 0,
+  clampMax: 1,
+  fundBal: 5,
+  priceSpot: 99,
+  fundingStep: 1,
+  timestamp: 1000,
+  fundingAccrued: 0.1,
+}
+
+describe('Derivatives state', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState)
+  })
+
+  it('should set loading on fetch', () => {
+    expect(reducer(initialState, actions.fetchDerivatives()))
+      .toEqual({
+        ...initialState,
+        pageLoading: true,
+      })
+  })
+
+  it('should update derivatives', () => {
+    const { key, ...entry } = TEST_ENTRY
+    expect(reducer(initialState, actions.updateDerivatives({ res: [TEST_ENTRY] })))
+      .toEqual({
+        ...initialState,
+        dataReceived: true,
+        entries: [{
+          ...entry,
+          pair: TEST_PAIR,
+        }],
+      })
+  })
+
+  it('should keep entries on empty update', () => {
+    expect(reducer(initialState, actions.updateDerivatives(undefined)))
+      .toEqual({
+        ...initialState,
+        dataReceived: true,
+      })
+  })
+
+  it('should add target pair', () => {
+    expect(reducer(initialState, actions.addTargetPair(TEST_PAIR)))
+      .toEqual({
+        ...initialState,
+        targetPairs: [TEST_PAIR],
+      })
+  })
+
+  it('should remove target pair', () => {
+    const state = {
+      ...initialState,
+      targetPairs: [TEST_PAIR],
+    }
+    expect(reducer(state, actions.removeTargetPair(TEST_PAIR)))
+      .toEqual(initialState)
+  })
+
+  it('should set target pairs', () => {
+    expect(reducer(initialState, actions.setTargetPairs([TEST_PAIR])))
+      .toEqual({
+        ...initialState,
+        targetPairs: [TEST_PAIR],
+      })
+  })
+
+  it('should clear target pairs', () => {
+    const state = {
+      ...initialState,
+      targetPairs: [TEST_PAIR],
+    }
+    expect(reducer(state, actions.clearTargetPairs()))
+      .toEqual(initialState)
+  })
+
+  it('should refresh data', () => {
+    const state = {
+      ...initialState,
+      dataReceived: true,
+      targetPairs: [TEST_PAIR],
+    }
+    expect(reducer(state, actions.refresh()))
+      .toEqual({
+        ...initialState,
+        targetPairs: state.targetPairs,
+      })
+  })
+})

--- a/src/state/derivatives/reducer.js
+++ b/src/state/derivatives/reducer.js
@@ -18,7 +18,7 @@ import { formatPair, mapPair } from 'state/symbols/utils'
 
 import types from './constants'
 
-const initialState = {
+export const initialState = {
   ...basePairState,
 }
 

--- a/src/state/derivatives/saga.js
+++ b/src/state/derivatives/saga.js
@@ -17,7 +17,7 @@ import { getTargetPairs } from './selectors'
 
 const TYPE = queryTypes.MENU_DERIVATIVES
 
-function getReqDerivatives({ targetPairs, filter }) {
+export function getReqDerivatives({ targetPairs, filter }) {
   const params = { filter }
   if (targetPairs.length) {
     params.symbol = formatRawSymbols(mapRequestPairs(targetPairs))
@@ -26,7 +26,7 @@ function getReqDerivatives({ targetPairs, filter }) {
   return makeFetchCall('getStatusMessages', params)
 }
 
-function* fetchDerivatives() {
+export function* fetchDerivatives() {
   try {
     const targetPairs = yield select(getTargetPairs)
     const filter = yield select(getFilterQuery, TYPE)


### PR DESCRIPTION
Tasks:
https://app.asana.com/1/29923630752984/home/task/1217017871309571
https://app.asana.com/1/29923630752984/home/task/1216923668680296 

#### Description:
- [x] Adds test coverage for the `Derivatives` report logic

#### Preview:
<img width="468" height="394" alt="derivatives-tests-prev" src="https://github.com/user-attachments/assets/0f8f2882-b4ea-49c7-9446-6b4b93030f82" />

---
#### Related to: 
- [bfx-report-ui #1097](https://github.com/bitfinexcom/bfx-report-ui/pull/1097)
- [bfx-report-ui #1095](https://github.com/bitfinexcom/bfx-report-ui/pull/1095)
