### PR TITLE
fix: the application depends on @bitfinex/lib-js-uti... in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.64.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
+        "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#ad25616c4a0717409c573fef3a37f63e60cc9e5d",
         "@blueprintjs/core": "3.54.0",
         "@blueprintjs/datetime": "3.24.1",
         "@blueprintjs/icons": "3.33.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "/",
   "dependencies": {
-    "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
+    "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#ad25616c4a0717409c573fef3a37f63e60cc9e5d",
     "@blueprintjs/core": "3.54.0",
     "@blueprintjs/datetime": "3.24.1",
     "@blueprintjs/icons": "3.33.0",


### PR DESCRIPTION
## Summary
Fix high severity security issue in `package.json`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `package.json:24` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The application depends on @bitfinex/lib-js-util-base fetched directly from a GitHub repository using the git+https protocol rather than a versioned npm package with a pinned version or commit hash. This creates a supply chain risk where changes to the upstream repository could introduce malicious code into the application build without detection.

## Evidence

**Exploitation scenario**: An attacker who gains write access to the bitfinexcom/lib-js-util-base GitHub repository could push malicious code to the default branch.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
