### PR TITLE
(internal) Use orderBy util from lib-js-util-base

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,27 @@
-### Asana task:
+#### Asana task:
 ...
 
-### Description:
+#### Description:
+- [ ] ...
+
+---
+#### Details:
+
 ...
 
-### Target Release:
+#### Preview:
+...
+
+
+
+#### Target Release:
 vXX.YY
 
-### Related Pull Requests:
+---
+#### Related Pull Requests:
 ...
 
-### Type:
+#### Type:
 - [ ] fix
 - [ ] refactor
 - [ ] feature
@@ -19,7 +30,7 @@ vXX.YY
 - [ ] chore
 - [ ] other (specify)
 
-### Notes:
+#### Notes:
  - [ ] includes package-lock.json change
  - [ ] includes breaking changes
  - [ ] includes new TODO/HACK lines

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.64.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
+        "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#8ac3d64c460f9468dc885f87a33251fd9f1e640f",
         "@blueprintjs/core": "3.54.0",
         "@blueprintjs/datetime": "3.24.1",
         "@blueprintjs/icons": "3.33.0",
@@ -2112,9 +2112,9 @@
       "license": "MIT"
     },
     "node_modules/@bitfinex/lib-js-util-base": {
-      "name": "@bitfinexcom/lib-js-util-base",
-      "version": "1.10.0",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/lib-js-util-base.git#ad25616c4a0717409c573fef3a37f63e60cc9e5d",
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/lib-js-util-base.git#8ac3d64c460f9468dc885f87a33251fd9f1e640f",
+      "integrity": "sha512-8sGFODYgo9Zb8CdaUziQw86aiQG0u5KQ9JDxsY4gCjOsc1iYlRwGv98fchjojR6RlQRxeUXSnsiGZ6INdpflUg==",
       "license": "MIT"
     },
     "node_modules/@blueprintjs/colors": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "/",
   "dependencies": {
-    "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
+    "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#8ac3d64c460f9468dc885f87a33251fd9f1e640f",
     "@blueprintjs/core": "3.54.0",
     "@blueprintjs/datetime": "3.24.1",
     "@blueprintjs/icons": "3.33.0",

--- a/src/components/AccountBalance/AccountBalance.js
+++ b/src/components/AccountBalance/AccountBalance.js
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Card, Elevation } from '@blueprintjs/core'
 import classNames from 'classnames'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import {
   SectionHeader,
@@ -84,7 +83,7 @@ const AccountBalance = () => {
     () => parseChartData({
       shouldShowYear,
       timeframe: currTimeFrame,
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
     }), [currTimeFrame, entries, shouldShowYear],
   )
 

--- a/src/components/AppSummary/AppSummary.profits.js
+++ b/src/components/AppSummary/AppSummary.profits.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import NoData from 'ui/NoData'
 import Chart from 'ui/Charts/Chart'
@@ -40,7 +39,7 @@ const AccountSummaryProfits = () => {
 
   const { chartData, presentCurrencies } = useMemo(
     () => parseChartData({
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
       timeframe: timeframeConstants.DAY,
     }), [entries],
   )

--- a/src/components/AppSummary/AppSummary.value.js
+++ b/src/components/AppSummary/AppSummary.value.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import NoData from 'ui/NoData'
 import Chart from 'ui/Charts/Chart'
@@ -53,7 +52,7 @@ const AccountSummaryValue = () => {
   const { chartData, presentCurrencies } = useMemo(
     () => parseChartData({
       timeframe: currTimeFrame,
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
     }), [currTimeFrame, entries],
   )
 

--- a/src/components/AverageWinLoss/AverageWinLoss.js
+++ b/src/components/AverageWinLoss/AverageWinLoss.js
@@ -3,8 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Card, Elevation } from '@blueprintjs/core'
 import classNames from 'classnames'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import {
   SectionHeader,
@@ -57,7 +56,7 @@ const prepareChartData = (
 ) => {
   if (isVSAccBalanceData) {
     const { chartData, dataKeys } = parseVSAccBalanceChartData({
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
       shouldShowYear,
       timeframe,
       t,
@@ -66,7 +65,7 @@ const prepareChartData = (
   }
 
   const { chartData, presentCurrencies } = parseChartData({
-    data: _sortBy(entries, ['mts']),
+    data: orderBy(entries, ['mts']),
     shouldShowYear,
     timeframe,
   })

--- a/src/components/ConcentrationRisk/ConcentrationRisk.helpers.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.helpers.js
@@ -1,0 +1,40 @@
+import _keys from 'lodash/keys'
+import { orderBy } from '@bitfinex/lib-js-util-base'
+
+import { fixedFloat } from 'ui/utils'
+
+// eslint-disable-next-line import/prefer-default-export
+export const parseData = (filteredData) => {
+  let allBalance = 0
+  const summaryData = filteredData.reduce((acc, entry) => {
+    const { currency, balanceUsd } = entry
+    if (balanceUsd) {
+      acc[currency] = (acc[currency] || 0) + balanceUsd
+      allBalance += balanceUsd
+    }
+    return acc
+  }, {})
+
+  const tableData = orderBy(_keys(summaryData).map((key) => {
+    const balanceUsd = summaryData[key]
+    const percent = ((balanceUsd / allBalance) * 100)
+
+    return {
+      currency: key,
+      balanceUsd,
+      percent: fixedFloat(percent),
+    }
+  }), ['balanceUsd'], ['desc'])
+
+  const chartData = tableData
+    .filter(({ percent }) => percent > 0.1)
+    .map(({ currency, balanceUsd }) => ({
+      name: currency,
+      value: balanceUsd,
+    }))
+
+  return {
+    tableData,
+    chartData,
+  }
+}

--- a/src/components/ConcentrationRisk/ConcentrationRisk.js
+++ b/src/components/ConcentrationRisk/ConcentrationRisk.js
@@ -2,8 +2,6 @@ import React, { useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Card, Elevation } from '@blueprintjs/core'
-import _keys from 'lodash/keys'
-import _sortBy from 'lodash/sortBy'
 import { isEmpty } from '@bitfinex/lib-js-util-base'
 
 import {
@@ -18,7 +16,6 @@ import DateInput from 'ui/DateInput'
 import PieChart from 'ui/Charts/PieChart'
 import InitSyncNote from 'ui/InitSyncNote'
 import SectionSwitch from 'ui/SectionSwitch'
-import { fixedFloat } from 'ui/utils'
 import { refresh, setTimestamp } from 'state/wallets/actions'
 import { setShouldRefreshAfterSync } from 'state/sync/actions'
 import {
@@ -37,43 +34,9 @@ import { isValidTimeStamp } from 'state/query/utils'
 import useFetchLifecycle from 'hooks/useFetchLifecycle'
 
 import { getColumns } from './ConcentrationRisk.columns'
+import { parseData } from './ConcentrationRisk.helpers'
 
 const TYPE = queryConstants.MENU_CONCENTRATION_RISK
-
-const parseData = (filteredData) => {
-  let allBalance = 0
-  const summaryData = filteredData.reduce((acc, entry) => {
-    const { currency, balanceUsd } = entry
-    if (balanceUsd) {
-      acc[currency] = (acc[currency] || 0) + balanceUsd
-      allBalance += balanceUsd
-    }
-    return acc
-  }, {})
-
-  const tableData = _sortBy(_keys(summaryData).map((key) => {
-    const balanceUsd = summaryData[key]
-    const percent = ((balanceUsd / allBalance) * 100)
-
-    return {
-      currency: key,
-      balanceUsd,
-      percent: fixedFloat(percent),
-    }
-  }), 'balanceUsd').reverse()
-
-  const chartData = tableData
-    .filter(({ percent }) => percent > 0.1)
-    .map(({ currency, balanceUsd }) => ({
-      name: currency,
-      value: balanceUsd,
-    }))
-
-  return {
-    tableData: _sortBy(tableData, ['balanceUsd']).reverse(),
-    chartData,
-  }
-}
 
 const ConcentrationRisk = () => {
   const { t } = useTranslation()

--- a/src/components/ConcentrationRisk/__tests__/helpers.test.js
+++ b/src/components/ConcentrationRisk/__tests__/helpers.test.js
@@ -1,0 +1,77 @@
+import { parseData } from '../ConcentrationRisk.helpers'
+
+describe('parseData', () => {
+  it('should aggregate balances by currency', () => {
+    const { tableData } = parseData([
+      { currency: 'BTC', balanceUsd: 100 },
+      { currency: 'ETH', balanceUsd: 30 },
+      { currency: 'BTC', balanceUsd: 70 },
+    ])
+
+    expect(tableData).toEqual([
+      { currency: 'BTC', balanceUsd: 170, percent: '85.00000000' },
+      { currency: 'ETH', balanceUsd: 30, percent: '15.00000000' },
+    ])
+  })
+
+  it('should order table data by balanceUsd descending', () => {
+    const { tableData } = parseData([
+      { currency: 'ETH', balanceUsd: 50 },
+      { currency: 'BTC', balanceUsd: 300 },
+      { currency: 'USD', balanceUsd: 150 },
+      { currency: 'LTC', balanceUsd: 500 },
+    ])
+
+    expect(tableData.map(({ currency }) => currency)).toEqual(['LTC', 'BTC', 'USD', 'ETH'])
+  })
+
+  it('should keep input order for equal balances', () => {
+    const { tableData } = parseData([
+      { currency: 'AAA', balanceUsd: 100 },
+      { currency: 'BBB', balanceUsd: 100 },
+      { currency: 'CCC', balanceUsd: 100 },
+    ])
+
+    expect(tableData.map(({ currency }) => currency)).toEqual(['AAA', 'BBB', 'CCC'])
+  })
+
+  it('should skip entries with falsy balanceUsd', () => {
+    const { tableData } = parseData([
+      { currency: 'BTC', balanceUsd: 100 },
+      { currency: 'ETH', balanceUsd: 0 },
+      { currency: 'USD', balanceUsd: undefined },
+      { currency: 'LTC', balanceUsd: null },
+    ])
+
+    expect(tableData).toEqual([
+      { currency: 'BTC', balanceUsd: 100, percent: '100.00000000' },
+    ])
+  })
+
+  it('should keep only entries above 0.1 percent in chart data', () => {
+    const { chartData } = parseData([
+      { currency: 'BTC', balanceUsd: 900 },
+      { currency: 'ETH', balanceUsd: 100 },
+      { currency: 'USD', balanceUsd: 0.5 },
+    ])
+
+    expect(chartData).toEqual([
+      { name: 'BTC', value: 900 },
+      { name: 'ETH', value: 100 },
+    ])
+  })
+
+  it('should return chart data in the same order as table data', () => {
+    const { tableData, chartData } = parseData([
+      { currency: 'ETH', balanceUsd: 50 },
+      { currency: 'BTC', balanceUsd: 300 },
+      { currency: 'LTC', balanceUsd: 500 },
+    ])
+
+    expect(chartData.map(({ name }) => name)).toEqual(tableData.map(({ currency }) => currency))
+  })
+
+  it('should handle empty data', () => {
+    expect(parseData([])).toEqual({ tableData: [], chartData: [] })
+  })
+})

--- a/src/components/FeesReport/FeesReport.js
+++ b/src/components/FeesReport/FeesReport.js
@@ -2,8 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { Card, Elevation } from '@blueprintjs/core'
 import classNames from 'classnames'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import {
   SectionHeader,
@@ -116,7 +115,7 @@ class FeesReport extends PureComponent {
     } = this.props
     const paramChangerClass = classNames({ disabled: isFirstSyncing })
     const { chartData, dataKeys } = parseFeesReportChartData({
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
       shouldShowYear,
       timeframe,
       t,

--- a/src/components/LoanReport/LoanReport.js
+++ b/src/components/LoanReport/LoanReport.js
@@ -4,8 +4,7 @@ import { useRouteMatch } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { Card, Elevation } from '@blueprintjs/core'
 import classNames from 'classnames'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import {
   SectionHeader,
@@ -98,7 +97,7 @@ const LoanReport = () => {
       t,
       shouldShowYear,
       timeframe: currTimeframe,
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
     }),
     [entries, currTimeframe, shouldShowYear, t],
   )

--- a/src/components/TradedVolume/TradedVolume.js
+++ b/src/components/TradedVolume/TradedVolume.js
@@ -4,8 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useRouteMatch } from 'react-router-dom'
 import { Card, Elevation } from '@blueprintjs/core'
 import classNames from 'classnames'
-import _sortBy from 'lodash/sortBy'
-import { isEmpty } from '@bitfinex/lib-js-util-base'
+import { isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import {
   SectionHeader,
@@ -94,7 +93,7 @@ const TradedVolume = () => {
     () => parseChartData({
       timeframe,
       shouldShowYear,
-      data: _sortBy(entries, ['mts']),
+      data: orderBy(entries, ['mts']),
     }),
     [entries, timeframe, shouldShowYear],
   )

--- a/src/state/__tests__/utils.test.js
+++ b/src/state/__tests__/utils.test.js
@@ -1,0 +1,99 @@
+import queryConstants from 'state/query/constants'
+
+import { checkInit, getQueryWithoutParams } from '../utils'
+
+const { MENU_POSITIONS_AUDIT } = queryConstants
+
+const buildProps = (props = {}) => ({
+  dataReceived: true,
+  pageLoading: false,
+  isSyncRequired: false,
+  fetchData: jest.fn(),
+  setTargetIds: jest.fn(),
+  match: { params: { id: '1,2,3' } },
+  targetIds: ['1', '2', '3'],
+  ...props,
+})
+
+describe('checkInit - positions audit ids', () => {
+  it('should not refetch when the url ids match the target ids', () => {
+    const props = buildProps()
+
+    checkInit(props, MENU_POSITIONS_AUDIT)
+
+    expect(props.fetchData).not.toHaveBeenCalled()
+    expect(props.setTargetIds).not.toHaveBeenCalled()
+  })
+
+  it('should not refetch when the url ids match the target ids in a different order', () => {
+    const props = buildProps({ targetIds: ['3', '1', '2'] })
+
+    checkInit(props, MENU_POSITIONS_AUDIT)
+
+    expect(props.fetchData).not.toHaveBeenCalled()
+    expect(props.setTargetIds).not.toHaveBeenCalled()
+  })
+
+  it('should refetch when the url ids differ from the target ids', () => {
+    const props = buildProps({ targetIds: ['1', '2'] })
+
+    checkInit(props, MENU_POSITIONS_AUDIT)
+
+    expect(props.setTargetIds).toHaveBeenCalledWith(['1', '2', '3'])
+    expect(props.fetchData).toHaveBeenCalled()
+  })
+
+  it('should refetch when the target ids are empty', () => {
+    const props = buildProps({ targetIds: [] })
+
+    checkInit(props, MENU_POSITIONS_AUDIT)
+
+    expect(props.setTargetIds).toHaveBeenCalledWith(['1', '2', '3'])
+    expect(props.fetchData).toHaveBeenCalled()
+  })
+
+  it('should fetch on the initial load even when the ids match', () => {
+    const props = buildProps({ dataReceived: false })
+
+    checkInit(props, MENU_POSITIONS_AUDIT)
+
+    expect(props.fetchData).toHaveBeenCalled()
+  })
+})
+
+describe('getQueryWithoutParams', () => {
+  const setSearch = (search) => window.history.replaceState(null, '', search || '/')
+
+  afterEach(() => setSearch('/'))
+
+  // query-string stringifies keys in alphabetical order
+  it('should remove a single param', () => {
+    setSearch('?range=custom&start=1&end=2')
+
+    expect(getQueryWithoutParams('range')).toBe('?end=2&start=1')
+  })
+
+  it('should remove several params', () => {
+    setSearch('?range=custom&start=1&end=2')
+
+    expect(getQueryWithoutParams(['start', 'end'])).toBe('?range=custom')
+  })
+
+  it('should keep the query untouched when the param is absent', () => {
+    setSearch('?range=custom')
+
+    expect(getQueryWithoutParams('start')).toBe('?range=custom')
+  })
+
+  it('should return an empty string when every param is removed', () => {
+    setSearch('?range=custom')
+
+    expect(getQueryWithoutParams('range')).toBe('')
+  })
+
+  it('should return an empty string for an empty query', () => {
+    setSearch('/')
+
+    expect(getQueryWithoutParams('range')).toBe('')
+  })
+})

--- a/src/state/derivatives/reducer.js
+++ b/src/state/derivatives/reducer.js
@@ -1,6 +1,5 @@
 // https://docs.bitfinex.com/v2/reference#rest-public-status
-import _sortBy from 'lodash/sortBy'
-import { get } from '@bitfinex/lib-js-util-base'
+import { get, orderBy } from '@bitfinex/lib-js-util-base'
 
 import authTypes from 'state/auth/constants'
 import queryTypes from 'state/query/constants'
@@ -68,7 +67,7 @@ export function derivativesReducer(state = initialState, action) {
         ...state,
         dataReceived: true,
         pageLoading: false,
-        entries: _sortBy(entries, (o) => o.pair),
+        entries: orderBy(entries, ['pair']),
       }
     }
     case types.FETCH_FAIL:

--- a/src/state/filters/__tests__/utils.test.js
+++ b/src/state/filters/__tests__/utils.test.js
@@ -1,0 +1,116 @@
+import { FILTERS } from 'var/filterTypes'
+
+import { encodeFilters, getValidSortedFilters } from '../utils'
+
+const buildFilter = (column, value, type = FILTERS.CONTAINS) => ({ column, type, value })
+
+describe('getValidSortedFilters', () => {
+  it('should drop filters with a missing column, type or value', () => {
+    const filters = [
+      buildFilter('currency', 'BTC'),
+      buildFilter('', 'BTC'),
+      { column: 'amount', type: '', value: 10 },
+      { column: 'amount', type: FILTERS.EQUAL_TO, value: undefined },
+      { column: 'amount', type: FILTERS.EQUAL_TO, value: '' },
+    ]
+
+    expect(getValidSortedFilters(filters)).toEqual([buildFilter('currency', 'BTC')])
+  })
+
+  it('should keep falsy but meaningful values', () => {
+    const filters = [
+      { column: 'amount', type: FILTERS.EQUAL_TO, value: 0 },
+      { column: 'hidden', type: FILTERS.EQUAL_TO, value: false },
+    ]
+
+    expect(getValidSortedFilters(filters)).toEqual(filters)
+  })
+
+  it('should sort by column, then type, then value', () => {
+    const filters = [
+      buildFilter('currency', 'ETH', FILTERS.EQUAL_TO),
+      buildFilter('amount', 10, FILTERS.GREATER_THAN),
+      buildFilter('currency', 'BTC', FILTERS.EQUAL_TO),
+      buildFilter('currency', 'USD', FILTERS.BEGINS_WITH),
+      buildFilter('amount', 5, FILTERS.GREATER_THAN),
+    ]
+
+    expect(getValidSortedFilters(filters)).toEqual([
+      buildFilter('amount', 5, FILTERS.GREATER_THAN),
+      buildFilter('amount', 10, FILTERS.GREATER_THAN),
+      buildFilter('currency', 'USD', FILTERS.BEGINS_WITH),
+      buildFilter('currency', 'BTC', FILTERS.EQUAL_TO),
+      buildFilter('currency', 'ETH', FILTERS.EQUAL_TO),
+    ])
+  })
+
+  it('should produce the same result regardless of input order', () => {
+    const filters = [
+      buildFilter('currency', 'BTC'),
+      buildFilter('amount', 10, FILTERS.GREATER_THAN),
+      buildFilter('description', 'test', FILTERS.ENDS_WITH),
+    ]
+
+    expect(getValidSortedFilters(filters)).toEqual(getValidSortedFilters([...filters].reverse()))
+  })
+
+  it('should not mutate the source array', () => {
+    const filters = [
+      buildFilter('currency', 'BTC'),
+      buildFilter('amount', 10, FILTERS.GREATER_THAN),
+    ]
+    const snapshot = [...filters]
+
+    getValidSortedFilters(filters)
+
+    expect(filters).toEqual(snapshot)
+  })
+
+  it('should handle an empty filters list', () => {
+    expect(getValidSortedFilters([])).toEqual([])
+  })
+})
+
+describe('encodeFilters', () => {
+  it('should encode a single filter', () => {
+    expect(encodeFilters([buildFilter('currency', 'BTC')])).toBe('currency=ct,BTC')
+  })
+
+  it('should encode filters ordered by column', () => {
+    const filters = [
+      buildFilter('description', 'test', FILTERS.ENDS_WITH),
+      buildFilter('currency', 'BTC'),
+      buildFilter('amount', 10, FILTERS.GREATER_THAN),
+    ]
+
+    expect(encodeFilters(filters)).toBe('amount=gt,10&currency=ct,BTC&description=ew,test')
+  })
+
+  it('should produce the same query regardless of input order', () => {
+    const filters = [
+      buildFilter('description', 'test', FILTERS.ENDS_WITH),
+      buildFilter('currency', 'BTC'),
+      buildFilter('amount', 10, FILTERS.GREATER_THAN),
+    ]
+
+    expect(encodeFilters(filters)).toBe(encodeFilters([...filters].reverse()))
+  })
+
+  it('should uri-encode filter values', () => {
+    expect(encodeFilters([buildFilter('description', 'a b&c')])).toBe('description=ct,a%20b%26c')
+  })
+
+  it('should skip invalid filters', () => {
+    const filters = [
+      buildFilter('currency', 'BTC'),
+      buildFilter('', 'ignored'),
+      { column: 'amount', type: FILTERS.EQUAL_TO, value: '' },
+    ]
+
+    expect(encodeFilters(filters)).toBe('currency=ct,BTC')
+  })
+
+  it('should handle an empty filters list', () => {
+    expect(encodeFilters([])).toBe('')
+  })
+})

--- a/src/state/filters/utils.js
+++ b/src/state/filters/utils.js
@@ -5,14 +5,13 @@ import _omit from 'lodash/omit'
 import _uniq from 'lodash/uniq'
 import _isNaN from 'lodash/isNaN'
 import _reduce from 'lodash/reduce'
-import _sortBy from 'lodash/sortBy'
 import _filter from 'lodash/filter'
 import _countBy from 'lodash/countBy'
 import _findKey from 'lodash/findKey'
 import _toString from 'lodash/toString'
 import _toNumber from 'lodash/toNumber'
 import _toInteger from 'lodash/toInteger'
-import { get, isEmpty } from '@bitfinex/lib-js-util-base'
+import { get, isEmpty, orderBy } from '@bitfinex/lib-js-util-base'
 
 import SECTION_COLUMNS, { TRANSFORMS } from 'ui/ColumnsFilter/ColumnSelector/ColumnSelector.columns'
 import FILTER_TYPES, { FILTER_QUERY_TYPES, FILTERS, FILTER_KEYS } from 'var/filterTypes'
@@ -63,7 +62,7 @@ const getValidFilters = filters => filters.filter((filter) => {
   return column && type && value !== undefined && value !== ''
 })
 
-export const getValidSortedFilters = filters => _sortBy(getValidFilters(filters), ['column', 'type', 'value'])
+export const getValidSortedFilters = filters => orderBy(getValidFilters(filters), ['column', 'type', 'value'])
 
 export const calculateFilterQuery = (filters = [], section) => {
   if (isEmpty(filters) || !section) {
@@ -170,7 +169,7 @@ export const splitWalletFilter = (filterQuery) => {
 export const encodeFilters = (filters) => {
   const validFilters = getValidFilters(filters)
 
-  return _sortBy(validFilters, 'column').reduce((acc, filter, index) => {
+  return orderBy(validFilters, ['column']).reduce((acc, filter, index) => {
     const { column, type, value } = filter
 
     return `${acc}${index ? '&' : ''}${column}=${FILTER_QUERY_TYPES[type]},${encodeURIComponent(value)}`

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -2,8 +2,9 @@ import moment from 'moment-timezone'
 import queryString from 'query-string'
 import memoizeOne from 'memoize-one'
 import _castArray from 'lodash/castArray'
-import _sortBy from 'lodash/sortBy'
-import { get, omit, isEqual } from '@bitfinex/lib-js-util-base'
+import {
+  get, omit, isEqual, orderBy,
+} from '@bitfinex/lib-js-util-base'
 
 import { store } from 'state/store'
 import config from 'config'
@@ -244,7 +245,10 @@ export const checkInit = (props, type) => {
     case MENU_POSITIONS_AUDIT: {
       const ids = get(match, 'params.id', '').split(',')
 
-      const isIdChanged = !isEqual(_sortBy(ids), _sortBy(targetIds))
+      const isIdChanged = !isEqual(
+        orderBy(ids, [(id) => id]),
+        orderBy(targetIds, [(id) => id]),
+      )
       if (ids.length && ((!dataReceived && !pageLoading) || isIdChanged)) {
         setTargetIds(ids)
         fetchData()

--- a/src/state/weightedAverages/reducer.js
+++ b/src/state/weightedAverages/reducer.js
@@ -1,6 +1,5 @@
 import _map from 'lodash/map'
-import _sortBy from 'lodash/sortBy'
-import { isNil } from '@bitfinex/lib-js-util-base'
+import { isNil, orderBy } from '@bitfinex/lib-js-util-base'
 
 import authTypes from 'state/auth/constants'
 import queryTypes from 'state/query/constants'
@@ -71,7 +70,7 @@ export function weightedAveragesReducer(state = initialState, action) {
         dataReceived: true,
         pageLoading: false,
         nextPage,
-        entries: _sortBy(entries, (o) => o.pair),
+        entries: orderBy(entries, ['pair']),
       }
     }
     case types.FETCH_FAIL:


### PR DESCRIPTION
#### Asana tasks:
https://app.asana.com/1/29923630752984/home/task/1217111991475804
https://app.asana.com/1/29923630752984/home/task/1205580176871470

#### Description:
- [x] Uses `orderBy` all across the codebase as part of the step-by-step [migration](https://bitfinex.slack.com/archives/C024AMXFVPD/p1694500150747009) to the `lib-js-util-base` helpers





#### Target Release:
v 2.65.0

---
#### Related Pull Requests:
- [bfx-reports-framework #526](https://github.com/bitfinexcom/bfx-reports-framework/pull/526)
- [lib-js-util-base #49](https://github.com/bitfinexcom/lib-js-util-base/pull/49)
- [lib-js-util-base #51](https://github.com/bitfinexcom/lib-js-util-base/pull/51)

#### Type:
- [ ] fix
- [ ] refactor
- [ ] feature
- [ ] improvement
- [x] internal
- [ ] chore
- [ ] other (specify)

#### Notes:
 - [x] includes package-lock.json change
 - [ ] includes breaking changes
 - [ ] includes new TODO/HACK lines
 - [ ] other (specify)

